### PR TITLE
[Bug] Fix nightly build action

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -34,7 +34,7 @@ jobs:
           - version: "3.7"
             tag: py37
           - version: "3.8"
-            tag: py39
+            tag: py38
           - version: "3.9"
             tag: py39
           - version: "3.10"
@@ -71,7 +71,7 @@ jobs:
           - version: "3.7"
             tag: py37
           - version: "3.8"
-            tag: py39
+            tag: py38
           - version: "3.9"
             tag: py39
           - version: "3.10"
@@ -141,7 +141,7 @@ jobs:
       - name: Download built wheels
         uses: actions/download-artifact@v2
         with:
-          name: tensordict-nightly-${{ matrix.python.version }}-cpu.whl
+          name: tensordict-nightly-${{ matrix.python.version }}.whl
           path: /tmp/wheels
       - name: Push TensorDict Binary to PYPI
         env:


### PR DESCRIPTION
This PR corrects a couple of typos in the nightly build workflow file and makes some modifications to `setup.py` in order to allow nightly builds and pushes to PyPI.

[I have manually run this workflow successfully](https://github.com/pytorch-labs/tensordict/actions/runs/3387628138) resulting in the nightly build of this package being [available on PyPI](https://pypi.org/project/tensordict-nightly/)