### PR TITLE
[BugFix] Merge partial sub-tensordicts with flatten ones if unflattened

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1510,13 +1510,13 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
         for key, list_of_keys in to_unflatten.items():
             tensordict = TensorDict({}, batch_size=self.batch_size, device=self.device)
+            if key in self:
+                tensordict.update(self[key])
             for (old_key, new_key) in list_of_keys:
                 value = self[old_key]
                 tensordict[new_key] = value
                 if inplace:
                     del self[old_key]
-                if key in self:
-                    tensordict.update(self[key])
             out.set(key, tensordict.unflatten_keys(separator=separator))
         return out
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1515,6 +1515,8 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                 tensordict[new_key] = value
                 if inplace:
                     del self[old_key]
+                if key in self:
+                    tensordict.update(self[key])
             out.set(key, tensordict.unflatten_keys(separator=separator))
         return out
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2479,6 +2479,12 @@ class TestMakeTensorDict:
         assert tensordict["c"].device == device
 
 
+@pytest.mark.parametrize("separator", [".", "-"])
+def test_unflatten_keys_collision(separator):
+    td = TensorDict({"a": [1, 2], f"c{separator}a": [1, 2], "c": TensorDict({"b": [1, 2]}, [])}, [])
+    ref = TensorDict({"a": [1, 2], "c": TensorDict({"a": [1, 2], "b": [1, 2]}, [])}, [])
+    assert repr(td.unflatten_keys(separator)) == repr(ref)
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2483,7 +2483,7 @@ class TestMakeTensorDict:
 def test_unflatten_keys_collision(separator):
     td = TensorDict({"a": [1, 2], f"c{separator}a": [1, 2], "c": TensorDict({"b": [1, 2]}, [])}, [])
     ref = TensorDict({"a": [1, 2], "c": TensorDict({"a": [1, 2], "b": [1, 2]}, [])}, [])
-    assert repr(td.unflatten_keys(separator)) == repr(ref)
+    assert assert_allclose_td(td.unflatten_keys(separator), ref)
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()


### PR DESCRIPTION
## Description

Merge the instantiated sub-tensordict to the unflatted sub-tensordict to avoid collision.  

## Motivation and Context

Why is this change required? What problem does it solve?
close #8 

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
