### PR TITLE
[Feature] Support splitting / flattening with first-class dims

### DIFF
--- a/tensordict/metatensor.py
+++ b/tensordict/metatensor.py
@@ -26,6 +26,7 @@ from tensordict.utils import (
     _get_ordered_shape,
     _get_ordered_dims,
     _get_shape,
+    _is_first_class_dim,
 )
 
 try:
@@ -220,14 +221,10 @@ class MetaTensor:
         shape = _getitem_batch_size(self.shape, item)
         if _has_functorch_dim and (
             isinstance(self, _MetaTensorWithDims)
-            or (
-                isinstance(item, tuple)
-                and any(isinstance(i, functorch.dim.Dim) for i in item)
-            )
+            or (isinstance(item, tuple) and any(_is_first_class_dim(i) for i in item))
         ):
-            item = item if isinstance(item, tuple) else (item,)
             dims = _get_indexed_dims(
-                item,
+                item if isinstance(item, tuple) else (item,),
                 self.dims if isinstance(self, _MetaTensorWithDims) else (),
                 self.shape,
             )

--- a/tensordict/metatensor.py
+++ b/tensordict/metatensor.py
@@ -223,6 +223,19 @@ class MetaTensor:
             isinstance(self, _MetaTensorWithDims)
             or (isinstance(item, tuple) and any(_is_first_class_dim(i) for i in item))
         ):
+            if isinstance(item, tuple):
+                for i in item:
+                    if (
+                        isinstance(i, tuple)
+                        and any(isinstance(d, functorch.dim.Dim) for d in i)
+                        and not all(isinstance(d, functorch.dim.Dim) for d in i)
+                    ):
+                        raise TypeError(
+                            "If indexing a dimension with a tuple of first-class "
+                            "dimensions, all entries of that tuple must be a "
+                            "first-class dimension"
+                        )
+
             dims = _get_indexed_dims(
                 item if isinstance(item, tuple) else (item,),
                 self.dims if isinstance(self, _MetaTensorWithDims) else (),
@@ -384,6 +397,12 @@ class _MetaTensorWithDims(MetaTensor):
         return self.dims + tuple(range(ndim))
 
     def order(self, *args) -> MetaTensor:
+        if not all(_is_first_class_dim(arg) or isinstance(arg, int) for arg in args):
+            raise TypeError(
+                "All arguments to order must either be an integer, a first-class "
+                "dimension, or a tuple of first-class dimensions"
+            )
+
         ordered_dims = _get_ordered_dims(self.dims, args)
         ordered_shape = _get_ordered_shape(self.shape, args)
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -49,6 +49,7 @@ from tensordict.utils import (
     _get_ordered_dims,
     _get_ordered_shape,
     _getitem_batch_size,
+    _is_first_class_dim,
     _is_in,
     _reslice_without_first_class_dims,
     _sub_index,
@@ -1592,10 +1593,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
         if _has_functorch_dim and (
             isinstance(self, _TensorDictWithDims)
-            or (
-                isinstance(idx, tuple)
-                and any(isinstance(item, functorch.dim.Dim) for item in idx)
-            )
+            or (isinstance(idx, tuple) and any(_is_first_class_dim(i) for i in idx))
         ):
             dims = _get_indexed_dims(
                 idx if isinstance(idx, tuple) else (idx,),
@@ -2451,6 +2449,12 @@ class _TensorDictWithDims(TensorDict):
         return self.dims + tuple(range(ndim))
 
     def order(self, *args) -> TensorDict:
+        if not all(_is_first_class_dim(arg) for arg in args):
+            raise TypeError(
+                "All arguments to order must either be a first-class dimension or a "
+                "tuple of first-class dimensions"
+            )
+
         ordered_dims = _get_ordered_dims(self.dims, args)
         ordered_batch_size = _get_ordered_shape(self.batch_size, args)
 

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -169,7 +169,7 @@ def _get_indexed_dims(
                     f"{tuple(d for d in item if not d.is_bound)}"
                 )
             elif n_unbound == 1:
-                d_size, rem = divmod(size, prod(d.size for d in item if d.is_bound))
+                d_size, rem = divmod(size, prod([d.size for d in item if d.is_bound]))
                 if rem != 0:
                     raise functorch.dim.DimensionBindError(
                         "inferred dimension does not evenly fit into larger dimension: "
@@ -180,7 +180,7 @@ def _get_indexed_dims(
                 (unbound_dim,) = tuple(d for d in item if not d.is_bound)
                 unbound_dim.size = d_size
             else:
-                size_prod = prod(d.size for d in item)
+                size_prod = prod([d.size for d in item])
                 if size_prod != size:
                     raise functorch.dim.DimensionBindError(
                         f"Dimension sizes do not match ({size} != {size_prod}) when "
@@ -224,7 +224,7 @@ def _get_ordered_shape(batch_size, args):
         if isinstance(dim, functorch.dim.Dim):
             return dim.size
         elif isinstance(dim, tuple):
-            return prod(_parse_size(d) for d in dim)
+            return prod([_parse_size(d) for d in dim])
         return batch_size[dim]
 
     # place all ordered dimensions at the front, dropping any re-ordered positional

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -127,7 +127,7 @@ def _getitem_batch_size(
                     f"The shape {shape} is incompatible with " f"the index {items}."
                 )
             continue
-        elif _has_functorch_dim and isinstance(_item, functorch.dim.Dim):
+        elif _has_functorch_dim and _is_first_class_dim(_item):
             # any first class dimensions are ommited from the new batch size
             next(iter_bs)
             continue
@@ -141,15 +141,64 @@ def _getitem_batch_size(
     return torch.Size(bs)
 
 
+def _is_first_class_dim(idx: INDEX_TYPING) -> bool:
+    # return True if idx is a first-class dimension or a tuple of first-class dimensions
+    # raise a TypeError if tuple and not all entries are first-class dimensions
+    if isinstance(idx, functorch.dim.Dim):
+        return True
+    elif isinstance(idx, tuple) and any(
+        isinstance(item, functorch.dim.Dim) for item in idx
+    ):
+        if not all(isinstance(item, functorch.dim.Dim) for item in idx):
+            raise TypeError(
+                "When indexing or ordering with a tuple of first-class dimensions, all "
+                "entries of the tuple must be a first-class dimension"
+            )
+        return True
+    return False
+
+
 def _get_indexed_dims(
-    idx: INDEX_TYPING, dims: Tuple[DIM_TYPING, ...], shape
+    idx: Tuple[INDEX_TYPING, ...], dims: Tuple[DIM_TYPING, ...], shape
 ) -> Tuple[DIM_TYPING, ...]:
-    # bind dimensions to the size of the dimensions they are indexing
+    new_dims = []
+
     for item, size in zip(idx, shape):
         if isinstance(item, functorch.dim.Dim):
+            # bind dimensions to the size of the dimensions they are indexing
             item.size = size
+            new_dims.append(item)
+        elif isinstance(item, tuple) and any(
+            isinstance(d, functorch.dim.Dim) for d in item
+        ):
+            n_unbound = sum(not d.is_bound for d in item)
+            if n_unbound > 1:
+                raise functorch.dim.DimensionBindError(
+                    f"cannot infer the sizes of {n_unbound} dimensions at once "
+                    f"{tuple(d for d in item if not d.is_bound)}"
+                )
+            elif n_unbound == 1:
+                d_size, rem = divmod(size, prod(d.size for d in item if d.is_bound))
+                if rem != 0:
+                    raise functorch.dim.DimensionBindError(
+                        "inferred dimension does not evenly fit into larger dimension: "
+                        f"{size} vs "
+                        f"{tuple(d.size if d.is_bound else '?' for d in item)}"
+                    )
 
-    dims = dims + tuple(d for d in idx if isinstance(d, functorch.dim.Dim))
+                (unbound_dim,) = tuple(d for d in item if not d.is_bound)
+                unbound_dim.size = d_size
+            else:
+                size_prod = prod(d.size for d in item)
+                if size_prod != size:
+                    raise functorch.dim.DimensionBindError(
+                        f"Dimension sizes do not match ({size} != {size_prod}) when "
+                        f"matching dimension pack {item}"
+                    )
+
+            new_dims.extend(item)
+
+    dims = dims + tuple(new_dims)
 
     # remove duplicate first-class dims. when first-class dims are reused the diagonal
     # entries are extracted and that dim only appears once in the resulting dims
@@ -163,24 +212,35 @@ def _get_indexed_dims(
     return tuple(dims_out)
 
 
-# FIXME: this is a workaround since equality comparisons with unbound
-# functorch.dim.Tensors results in a ValueError.
-def _is_in(d: DIM_TYPING, args: LEVELS_TYPING) -> bool:
-    return any(d is item for item in args)
+def _is_in(d: DIM_TYPING, args: LEVELS_TYPING, nested: bool = False) -> bool:
+    # FIXME: this is a workaround since equality comparisons with unbound
+    # functorch.dim.Tensors results in a ValueError. Same as `d in args`
+    if any(d is item for item in args):
+        return True
+    elif nested and any(isinstance(item, tuple) and _is_in(d, item) for item in args):
+        return True
+    return False
 
 
 def _get_ordered_dims(
     dims: Tuple[DIM_TYPING, ...], args: LEVELS_TYPING
 ) -> Tuple[DIM_TYPING, ...]:
-    return tuple(d for d in dims if not _is_in(d, args))
+    return tuple(d for d in dims if not _is_in(d, args, nested=True))
 
 
 def _get_ordered_shape(batch_size, args):
+    def _parse_size(dim):
+        if isinstance(dim, functorch.dim.Dim):
+            return dim.size
+        elif isinstance(dim, tuple):
+            return prod(d.size for d in dim)
+        return batch_size[dim]
+
     # place all ordered dimensions at the front, dropping any re-ordered positional
     # arguments from the existing batch_size.
     positional_args = {arg for arg in args if isinstance(arg, int)}
     return torch.Size(
-        [d.size if isinstance(d, functorch.dim.Dim) else batch_size[d] for d in args]
+        [_parse_size(d) for d in args]
         + [size for i, size in enumerate(batch_size) if i not in positional_args]
     )
 
@@ -192,18 +252,15 @@ def _reslice_without_first_class_dims(
     if not isinstance(idx, tuple):
         idx = (idx,)
 
-    idx_with = tuple(
-        item if isinstance(item, functorch.dim.Dim) else slice(None) for item in idx
-    )
+    idx_with = tuple(item if _is_first_class_dim(item) else slice(None) for item in idx)
 
     trim = 0
     for item in reversed(idx_with):
-        if isinstance(item, functorch.dim.Dim):
+        if _is_first_class_dim(item):
             break
-        else:
-            trim += 1
+        trim += 1
 
-    idx_without = tuple(item for item in idx if not isinstance(item, functorch.dim.Dim))
+    idx_without = tuple(item for item in idx if not _is_first_class_dim(item))
 
     if trim > 0:
         return idx_with[:-trim], idx_without

--- a/test/test_dim.py
+++ b/test/test_dim.py
@@ -245,6 +245,14 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.testing.assert_close(td2["a"], td_dim["a"].order(d1, (d2, d3)))
         torch.testing.assert_close(td2["a"], td["a"].reshape(4, 6, 1, -1))
 
+        # test nested in in order
+        td3 = td_dim.order((d1, d2, d3, 0))
+
+        assert td3.batch_size == torch.Size([24])
+
+        torch.testing.assert_close(td3["a"], td_dim["a"].order((d1, d2, d3, 0)))
+        torch.testing.assert_close(td3["a"], td["a"].reshape(24, -1))
+
 
 def test_dim_reuse():
     t = torch.rand(2, 3, 2)
@@ -366,12 +374,15 @@ def test_metatensor_splitting():
 def test_metatensor_flatten():
     mt = MetaTensor(4, 3, 2, 1)
 
-    d1, d2, d3 = dims(3)
-    mt_dim = mt[d1, d2, d3]
+    d1, d2 = dims(2)
+    mt_dim = mt[d1, d2]
 
-    mt2 = mt_dim.order(d1, (d2, d3))
+    mt2 = mt_dim.order((d1, d2))
 
-    assert mt2.shape == torch.Size([4, 6, 1])
+    assert mt2.shape == torch.Size([12, 2, 1])
+
+    mt3 = mt_dim.order((d1, d2, 0, 1))
+    assert mt3.shape == torch.Size([24])
 
 
 @pytest.mark.parametrize("dim", range(4))


### PR DESCRIPTION
This PR adds support for splitting / flattening TensorDict batch dimensions using first-class dimensions from functorch as raised in #14 

An example:

```python
# splitting dimensions
td = TensorDict({"a": torch.rand(6, 3, 3)}, [6, 3])
d1, d2, d3 = dims(3)
d1.size = 3
td_dim = td[(d1, d2), d3]  # split first dimension in two
td2 = td_dim.order(d1, d2, d3)
assert td2.batch_size == torch.Size([3, 2, 3])
assert td2["a"].shape == torch.Size([3, 2, 3, 3])

d1, d2 = dims(2)
td_dim = td[d1, d2]
td2 = td_dim.order((d1, d2))
assert td2.batch_size == torch.Size([18])
assert td2["a"].shape == torch.Size([18, 3])
```