### PR TITLE
[Feature] Add TensorDictKeysView

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1520,7 +1520,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def unflatten_keys(
         self, separator: str = ",", inplace: bool = False
     ) -> TensorDictBase:
-        to_unflatten = defaultdict(lambda: list())
+        to_unflatten = defaultdict(list)
         for key in self.keys():
             if separator in key[1:-1]:
                 split_key = key.split(separator)
@@ -1541,7 +1541,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
         for key, list_of_keys in to_unflatten.items():
             tensordict = TensorDict({}, batch_size=self.batch_size, device=self.device)
-            if key in self:
+            if key in self.keys():
                 tensordict.update(self[key])
             for (old_key, new_key) in list_of_keys:
                 value = self[old_key]

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -21,7 +21,6 @@ from typing import (
     Dict,
     Generator,
     Iterator,
-    KeysView,
     List,
     Optional,
     Sequence,
@@ -87,6 +86,38 @@ COMPATIBLE_TYPES = Union[
 ]  # None? # leaves space for TensorDictBase
 
 _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-only or string-free indices are supported."
+
+
+class _TensorDictKeysView:
+    """
+    Wrapper class that enables richer behaviour of `key in tensordict.keys()`
+    """
+
+    def __init__(self, tensordict):
+        self.tensordict = tensordict
+
+    def __iter__(self):
+        return iter(self.tensordict._tensordict.keys())
+
+    def __len__(self):
+        return len(self.tensordict._tensordict.keys())
+
+    def __contains__(self, key):
+        if isinstance(key, str):
+            return key in self.tensordict._tensordict.keys()
+        elif isinstance(key, tuple):
+            if len(key) == 1:
+                return key[0] in self
+            elif len(key) > 1:
+                return (
+                    key[0] in self
+                    and isinstance(self.tensordict[key[0]], TensorDictBase)
+                    and key[1:] in self.tensordict[key[0]].keys()
+                )
+        raise TypeError(
+            "TensorDict keys are always strings. Membership checks are only supported "
+            "for strings or non-empty tuples of strings (for nested TensorDicts)"
+        )
 
 
 class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
@@ -671,7 +702,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             return self._dict_meta.values()
 
     @abc.abstractmethod
-    def keys(self) -> KeysView:
+    def keys(self) -> _TensorDictKeysView:
         """Returns a generator of tensordict keys."""
         raise NotImplementedError(f"{self.__class__.__name__}")
 
@@ -1523,6 +1554,19 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def __len__(self) -> int:
         """Returns the length of first dimension, if there is, otherwise 0."""
         return self.shape[0] if self.batch_dims else 0
+
+    def __contains__(self, key):
+        # by default a Mapping will implement __contains__ by calling __getitem__ and
+        # returning False if a KeyError is raised, True otherwise. TensorDict has a
+        # complex __getitem__ method since we support more than just retrieval of values
+        # by key, and so this can be quite inefficient, particularly if values are
+        # evaluated lazily on access. Hence we don't support use of __contains__ and
+        # direct the user to use TensorDict.keys() instead
+        raise NotImplementedError(
+            "TensorDict does not support membership checks with the `in` keyword. If "
+            "you want to check if a particular key is in your TensorDict, please use "
+            "`key in tensordict.keys()` instead."
+        )
 
     def __getitem__(self, idx: INDEX_TYPING) -> TensorDictBase:
         """Indexes all tensors according to the provided index.
@@ -2410,8 +2454,8 @@ class TensorDict(TensorDictBase):
             _is_shared=self._is_shared,
         )
 
-    def keys(self) -> KeysView:
-        return self._tensordict.keys()
+    def keys(self) -> _TensorDictKeysView:
+        return _TensorDictKeysView(self)
 
 
 class _TensorDictWithDims(TensorDict):
@@ -2508,7 +2552,7 @@ class _TensorDictWithDims(TensorDict):
             return False
 
         for key in self.keys():
-            if key not in tensordict:
+            if key not in tensordict.keys():
                 return False
 
             self_value = self[key]
@@ -3153,7 +3197,7 @@ torch.Size([3, 2])
             self._dict_meta[key].requires_grad = tensor.requires_grad
         return self
 
-    def keys(self) -> KeysView:
+    def keys(self) -> _TensorDictKeysView:
         return self._source.keys()
 
     def set_(
@@ -3834,6 +3878,11 @@ class LazyStackedTensorDict(TensorDictBase):
                     td[item] = sub_td
             return self
         return super().__setitem__(item, value)
+
+    def __contains__(self, item) -> bool:
+        if isinstance(item, TensorDictBase):
+            return any(item is td for td in self.tensordicts)
+        super().__contains__(item)
 
     def __getitem__(self, item: INDEX_TYPING) -> TensorDictBase:
         if _has_functorch_dim and (
@@ -4615,7 +4664,7 @@ class _CustomOpTensorDict(TensorDictBase):
             f"\n\top={self.custom_op}({custom_op_kwargs_str}))"
         )
 
-    def keys(self) -> KeysView:
+    def keys(self) -> _TensorDictKeysView:
         return self._source.keys()
 
     def select(self, *keys: str, inplace: bool = False) -> _CustomOpTensorDict:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2530,9 +2530,12 @@ class TestMakeTensorDict:
 
 @pytest.mark.parametrize("separator", [".", "-"])
 def test_unflatten_keys_collision(separator):
-    td = TensorDict({"a": [1, 2], f"c{separator}a": [1, 2], "c": TensorDict({"b": [1, 2]}, [])}, [])
+    td = TensorDict(
+        {"a": [1, 2], f"c{separator}a": [1, 2], "c": TensorDict({"b": [1, 2]}, [])}, []
+    )
     ref = TensorDict({"a": [1, 2], "c": TensorDict({"a": [1, 2], "b": [1, 2]}, [])}, [])
     assert assert_allclose_td(td.unflatten_keys(separator), ref)
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2381,6 +2381,55 @@ def test_setitem_nested():
     assert (tensordict["a", "b", "c"] == 1).all()
 
 
+def test_keys_view():
+    tensor = torch.randn(4, 5, 6, 7)
+    sub_sub_tensordict = TensorDict({"c": tensor}, [4, 5, 6])
+    sub_tensordict = TensorDict({}, [4, 5])
+    tensordict = TensorDict({}, [4])
+
+    sub_tensordict["b"] = sub_sub_tensordict
+    tensordict["a"] = sub_tensordict
+
+    assert "a" in tensordict.keys()
+    assert ("a",) in tensordict.keys()
+    assert ("a", "b", "c") in tensordict.keys()
+    assert ("a", "c", "b") not in tensordict.keys()
+    assert "random_string" not in tensordict.keys()
+
+    with pytest.raises(TypeError, match="TensorDict keys are always strings."):
+        42 in tensordict.keys()
+
+    with pytest.raises(TypeError, match="TensorDict keys are always strings."):
+        ("a", 42) in tensordict.keys()
+
+
+def test_error_on_contains():
+    td = TensorDict(
+        {"a": TensorDict({"b": torch.rand(1, 2)}, [1, 2]), "c": torch.rand(1)}, [1]
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="TensorDict does not support membership checks with the `in` keyword",
+    ):
+        "random_string" in td
+
+
+def test_lazy_stacked_contains():
+    td = TensorDict(
+        {"a": TensorDict({"b": torch.rand(1, 2)}, [1, 2]), "c": torch.rand(1)}, [1]
+    )
+    lstd = torch.stack([td, td, td])
+
+    assert td in lstd
+    assert td.clone() not in lstd
+
+    with pytest.raises(
+        NotImplementedError,
+        match="TensorDict does not support membership checks with the `in` keyword",
+    ):
+        "random_string" in lstd
+
+
 @pytest.mark.parametrize("method", ["share_memory", "memmap"])
 def test_memory_lock(method):
     torch.manual_seed(1)


### PR DESCRIPTION
This PR adds a new object `_TensorDictKeysView` which is returned when accessing `tensordict.keys()` and holds a reference to the original tensordict. This allows us to modify the behaviour of `key in tensordict.keys()` and use tuples for nested key lookups. For example

```python
import torch
from tensordict import TensorDict

td = TensorDict(
    {"a": TensorDict({"b": torch.rand(1, 2)}, [1, 2]), "c": torch.rand(1)}, 
    [1],
)

assert "a" in td.keys()
assert ("a",) in td.keys()
assert ("a", "b") in td.keys()
assert ("a", "c") not in td.keys()
```

This PR also disallows checks like `item in tensordict` except in the case of `tensordict in lazy_stacked_tensordict` where it will check if the tensordict is one of the tensordicts that will be lazily stacked when items are accessed.