### PR TITLE
Use vendored infer_size_impl with older versions of torch

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -36,7 +36,11 @@ from warnings import warn
 import numpy as np
 import torch
 from torch import Tensor
-from torch.jit._shape_functions import infer_size_impl
+
+try:
+    from torch.jit._shape_functions import infer_size_impl
+except ImportError:
+    from tensordict.utils import infer_size_impl
 
 from tensordict.memmap import MemmapTensor
 from tensordict.metatensor import MetaTensor


### PR DESCRIPTION
## Description

`tensordict` currently imports from `torch.jit._shape_functions` which is causing issues on pytorch/rl#665 where one of the CI pipelines tests against older versions of PyTorch where this submodule doesn't exist.

TorchRL already handled this case by [catching the import error](https://github.com/pytorch/rl/blob/cd488b480d89d1df818bcaaadcef3e16b06434e2/torchrl/data/tensordict/tensordict.py#L39-L42) and using a vendored implementation of `infer_size_impl`.

This vendored implementation of `infer_size_impl` already exists in `tensordict.utils`, so this PR simply restores the `try`-`except` statement wrapping the import.

