### PR TITLE
[Bugfix] Restore fallback for is_batchedtensor

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -70,6 +70,11 @@ try:
 except ImportError:
     _has_functorch = False
 
+    def is_batchedtensor(tensor):
+        """Placeholder for the functorch function."""
+        return False
+
+
 TD_HANDLED_FUNCTIONS: Dict = dict()
 COMPATIBLE_TYPES = Union[
     Tensor,


### PR DESCRIPTION
## Description

Currently if import of `is_batchedtensor` from functorch fails, it will fail silently but the symbol `is_batchedtensor` remains undefined. This is causing tests on pytorch/rl#665 to fail.

[TorchRL solved this issue](https://github.com/pytorch/rl/blob/cd488b480d89d1df818bcaaadcef3e16b06434e2/torchrl/data/tensordict/tensordict.py#L72-L74) by defining a dummy `is_batchedtensor` function which always returns `False`. This PR restores that.

An alternative solution could be to use the unused `_has_functorch` variable to prevent `is_batchedtensor` being reached if the import has failed. 