### PR TITLE
[Feature] Support nested keys in select method

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2530,8 +2530,9 @@ class TensorDict(TensorDictBase):
         return self
 
     def select(self, *keys: NESTED_KEY, inplace: bool = False) -> TensorDictBase:
+        existing_keys = self.keys(include_nested=True)
         for key in keys:
-            if key not in self.keys(include_nested=True):
+            if key not in existing_keys:
                 raise KeyError(f"Key {key} was not found.")
 
         nested_keys = defaultdict(list)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2529,18 +2529,43 @@ class TensorDict(TensorDictBase):
             return self.clone()
         return self
 
-    def select(self, *keys: str, inplace: bool = False) -> TensorDictBase:
-        d = {key: value for (key, value) in self.items() if key in keys}
-        d_meta = {
-            key: value
-            for (key, value) in self.items_meta(make_unset=False)
-            if key in keys
-        }
+    def select(self, *keys: NESTED_KEY, inplace: bool = False) -> TensorDictBase:
+        for key in keys:
+            if key not in self.keys(include_nested=True):
+                raise KeyError(f"Key {key} was not found.")
+
+        nested_keys = defaultdict(list)
+        for key in keys:
+            _nested_key_type_check(key)
+            if isinstance(key, str):
+                # ensure key is in the top level of the dict
+                nested_keys[key]
+            elif len(key) == 1:
+                nested_keys[key[0]]
+            else:
+                nested_keys[key[0]].append(key[1:])
+
+        d = {}
+        d_meta = {}
+
+        for key, subkeys in nested_keys.items():
+            value = self.get(key)
+            if len(subkeys) > 0 and isinstance(value, TensorDictBase):
+                value = value.select(*subkeys, inplace=inplace)
+                d_meta[key] = MetaTensor(value)
+            elif key in self._dict_meta:
+                d_meta[key] = self._dict_meta[key]
+
+            d[key] = value
+
         if inplace:
             self._tensordict = d
             for key in list(self._dict_meta.keys()):
-                if key not in keys:
+                if key not in nested_keys:
                     del self._dict_meta[key]
+                elif len(nested_keys[key]) > 0:
+                    # meta value needs to be updated as not all keys present in children
+                    self._dict_meta[key] = d_meta[key]
             return self
         return TensorDict(
             device=self.device,
@@ -3855,6 +3880,14 @@ class LazyStackedTensorDict(TensorDictBase):
         self._valid_keys = sorted(valid_keys)
 
     def select(self, *keys: str, inplace: bool = False) -> LazyStackedTensorDict:
+        # TODO: Add support for nested keys.
+        for key in keys:
+            if not isinstance(key, str):
+                raise TypeError(
+                    "All keys passed to LazyStackedTensorDict.select must be strings. "
+                    f"Found {key} of type {type(key)}. Note that LazyStackedTensorDict "
+                    "does not yet support nested keys."
+                )
         # the following implementation keeps the hidden keys in the tensordicts
         excluded_keys = set(self.valid_keys) - set(keys)
         tensordicts = [


### PR DESCRIPTION
## Description

This PR adds support for nested keys in `TensorDict.select`.

Example:

```python
>>> import torch
>>> from tensordict import TensorDict

>>> td = TensorDict({"nested": TensorDict({"a": torch.rand(1), "b": torch.rand(1)}, [])}, [])
>>> td.select(("nested", "b"))

TensorDict(
    fields={
        nested: TensorDict(
            fields={
                b: Tensor(torch.Size([1]), dtype=torch.float32)},
            batch_size=torch.Size([]),
            device=None,
            is_shared=False)},
    batch_size=torch.Size([]),
    device=None,
    is_shared=False)
```

## Motivation and Context

cf. #22 