### PR TITLE
[BugFix] tensordict.set(nested_key, value) points to the wrong metadata dict

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3661,7 +3661,7 @@ class LazyStackedTensorDict(TensorDictBase):
     ) -> TensorDictBase:
         if isinstance(key, tuple):
             raise TypeError(
-                f"Support for setting and getting keys in LazyStackedTensorDict instances is currently limited."
+                "Support for setting and getting keys in LazyStackedTensorDict instances is currently limited."
             )
         # TODO: what should support for nested keys look like here?
         if self.is_locked:


### PR DESCRIPTION
## Description

Fixes a bug where the following code snippet tries to access the wrong meta-data dictionary

```python
from tensordict import TensorDict
td = TensorDict({'a': {'a': [1]}}, [])
print(list(td.items_meta()))
td.set(('a', 'a'), [2])
```