### PR TITLE
[Feature] Support nested keys in exclude method

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2576,6 +2576,10 @@ def test_exclude_nested(inplace):
             ("nested", "double_nested", "t2"),
         }
 
+    # excluding "nested" should exclude all subkeys also
+    excluded2 = tensordict.exclude("nested", inplace=inplace)
+    assert set(excluded2.keys(include_nested=True)) == {"a", "b", "c"}
+
 
 def test_set_nested_keys():
     tensor = torch.randn(4, 5, 6, 7)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2542,6 +2542,8 @@ def test_exclude_nested(inplace):
         },
         batch_size=[4],
     )
+    # making a copy for inplace tests
+    tensordict2 = tensordict.clone()
 
     excluded = tensordict.exclude(
         "b", ("nested", "double_nested", "t2"), inplace=inplace
@@ -2577,7 +2579,7 @@ def test_exclude_nested(inplace):
         }
 
     # excluding "nested" should exclude all subkeys also
-    excluded2 = tensordict.exclude("nested", inplace=inplace)
+    excluded2 = tensordict2.exclude("nested", inplace=inplace)
     assert set(excluded2.keys(include_nested=True)) == {"a", "b", "c"}
 
 


### PR DESCRIPTION
## Description

**Note** This branch is currently targeting `nested-select` branch as it contains those changes also. #

This PR adds support for nested keys in `TensorDictBase.exclude()`. In the case of `LazyStackedTensorDict` we raise an exception if the keys aren't all strings until support for nested keys is added there more broadly.

## Motivation and Context

cf. #22