### PR TITLE
[Feature] Nested keys support for set_default

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -34,6 +34,7 @@ from tensordict.nn.functional_modules import (
     FunctionalModuleWithBuffers as rlFunctionalModuleWithBuffers,
 )
 from tensordict.tensordict import TensorDictBase
+from tensordict.utils import NESTED_KEY, _nested_key_type_check
 
 __all__ = [
     "TensorDictModule",
@@ -48,6 +49,16 @@ def _check_all_str(list_of_str):
         )
     if any(not isinstance(key, str) for key in list_of_str):
         raise TypeError(f"Expected a list of strings but got: {list_of_str}")
+
+
+def _check_all_nested(list_of_keys):
+    if isinstance(list_of_keys, str):
+        raise RuntimeError(
+            "Expected a list of strings, or tuples of strings but got a string: "
+            f"{list_of_keys}"
+        )
+    for key in list_of_keys:
+        _nested_key_type_check(key)
 
 
 class TensorDictModule(nn.Module):
@@ -123,8 +134,8 @@ class TensorDictModule(nn.Module):
         module: Union[
             FunctionalModule, FunctionalModuleWithBuffers, TensorDictModule, nn.Module
         ],
-        in_keys: Iterable[str],
-        out_keys: Iterable[str],
+        in_keys: Iterable[NESTED_KEY],
+        out_keys: Iterable[NESTED_KEY],
     ):
 
         super().__init__()
@@ -134,9 +145,9 @@ class TensorDictModule(nn.Module):
         if not in_keys:
             raise RuntimeError(f"in_keys were not passed to {self.__class__.__name__}")
         self.out_keys = out_keys
-        _check_all_str(self.out_keys)
+        _check_all_nested(self.out_keys)
         self.in_keys = in_keys
-        _check_all_str(self.in_keys)
+        _check_all_nested(self.in_keys)
 
         if "_" in in_keys:
             warnings.warn(
@@ -157,7 +168,7 @@ class TensorDictModule(nn.Module):
         tensordict: TensorDictBase,
         tensors: List,
         tensordict_out: Optional[TensorDictBase] = None,
-        out_keys: Optional[Iterable[str]] = None,
+        out_keys: Optional[Iterable[NESTED_KEY]] = None,
         vmap: Optional[int] = None,
     ) -> TensorDictBase:
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -24,12 +24,12 @@ from typing import (
     Iterator,
     List,
     Optional,
+    OrderedDict,
     Sequence,
     Set,
     Tuple,
     Type,
     Union,
-    OrderedDict,
 )
 from warnings import warn
 
@@ -47,8 +47,10 @@ from tensordict.metatensor import MetaTensor
 from tensordict.utils import (
     DEVICE_TYPING,
     INDEX_TYPING,
+    NESTED_KEY,
     KeyDependentDefaultDict,
     _getitem_batch_size,
+    _nested_key_type_check,
     _sub_index,
     convert_ellipsis_to_idx,
     expand_as_right,
@@ -82,8 +84,6 @@ COMPATIBLE_TYPES = Union[
 ]  # None? # leaves space for TensorDictBase
 
 _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-only or string-free indices are supported."
-
-NESTED_KEY = Union[str, Tuple[str, ...]]
 
 
 class _TensorDictKeysView:
@@ -2657,23 +2657,6 @@ class _ErrorInteceptor:
             self.exc_msg is None or self.exc_msg in str(exc_value)
         ):
             exc_value.args = (self._add_key_to_error_msg(str(exc_value)),)
-
-
-def _nested_key_type_check(key):
-    is_tuple = isinstance(key, tuple)
-    if not (
-        isinstance(key, str)
-        or (
-            is_tuple and len(key) > 0 and all(isinstance(subkey, str) for subkey in key)
-        )
-    ):
-        key_repr = (
-            f"tuple({', '.join(str(type(i)) for i in key)})" if is_tuple else type(key)
-        )
-        raise TypeError(
-            "Expected key to be a string or non-empty tuple of strings, but found "
-            f"{key_repr}"
-        )
 
 
 def _nested_keys_to_dict(keys: Iterator[NESTED_KEY]) -> Dict[str, Any]:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2407,7 +2407,7 @@ class TensorDict(TensorDictBase):
         return self
 
     def set_at_(
-        self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
+        self, key: NESTED_KEY, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
     ) -> TensorDictBase:
         _nested_key_type_check(key)
 
@@ -2416,7 +2416,7 @@ class TensorDict(TensorDictBase):
             value = self._process_input(
                 value, check_tensor_shape=False, check_device=False
             )
-        if key not in self.keys():
+        if key not in self.keys(include_nested=isinstance(key, tuple)):
             raise KeyError(f"did not find key {key} in {self.__class__.__name__}")
         tensor_in = self.get(key)
 
@@ -3205,7 +3205,7 @@ torch.Size([3, 2])
         inplace: bool = False,
         _run_checks: bool = True,
     ) -> TensorDictBase:
-        keys = self.keys()
+        keys = self.keys(include_nested=isinstance(key, tuple))
         if self.is_locked:
             if not inplace or key not in keys:
                 raise RuntimeError("Cannot modify locked TensorDict")
@@ -3272,7 +3272,7 @@ torch.Size([3, 2])
             tensor = self._process_input(
                 tensor, check_device=False, check_tensor_shape=False
             )
-            if key not in self.keys():
+            if key not in self.keys(include_nested=isinstance(key, tuple)):
                 raise KeyError(f"key {key} not found in {self.keys()}")
             if (
                 not isinstance(tensor, dict)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -170,7 +170,7 @@ class _TensorDictKeysView:
                         val = self.tensordict.get(key[0])
                         # TODO: SavedTensorDict currently doesn't support nested memebership checks
                         include_nested = self.include_nested and not isinstance(
-                            val, (SavedTensorDict,)
+                            val, SavedTensorDict
                         )
                         return isinstance(val, TensorDictBase) and key[1:] in val.keys(
                             include_nested=include_nested
@@ -3274,9 +3274,8 @@ torch.Size([3, 2])
         return self
 
     def keys(self, include_nested: bool = False) -> _TensorDictKeysView:
-        # TODO: temporary hack while SavedTensorDict and LazyStackedTensorDict don't
-        # support nested iteration
-        if isinstance(self._source, (LazyStackedTensorDict, SavedTensorDict)):
+        # TODO: temporary hack while SavedTensorDict doesn't support nested iteration
+        if isinstance(self._source, SavedTensorDict):
             include_nested = False
         return self._source.keys(include_nested=include_nested)
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1885,26 +1885,25 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         self._is_locked = value
 
     def set_default(
-        self, key: NESTED_KEY, item: COMPATIBLE_TYPES, inplace: bool = False, **kwargs
+        self, key: NESTED_KEY, default: COMPATIBLE_TYPES, **kwargs
     ) -> COMPATIBLE_TYPES:
-        """Returns the value of the key if the key is in the tensordict. If not, insert key with a value of item and returns item.
+        """Insert key with a value of default if key is not in the dictionary.
+
+        Return the value for key if key is in the dictionary, else default.
 
         Args:
-            key (str): name of the item
-            item (torch.Tensor): value to be stored in the tensordict
-            inplace (bool, optional): if True and if a key matches an existing
-                key in the tensordict, then the update will occur in-place
-                for that key-value pair. Default is :obj:`False`.
+            key (str): the name of the value.
+            default (torch.Tensor): value to be stored in the tensordict if the key is
+                not already present.
 
         Returns:
-            the value of the key or item if the key is not in the tensordict
+            The value of key in the tensordict. Will be default if the key was not
+            previously set.
 
         """
-        if key in self.keys(include_nested=isinstance(key, tuple)):
-            return self.get(key)
-        else:
-            self.set(key, item, inplace=inplace, **kwargs)
-            return item
+        if key not in self.keys(include_nested=isinstance(key, tuple)):
+            self.set(key, default, **kwargs)
+        return self.get(key)
 
     def lock(self):
         self.is_locked = True
@@ -4374,25 +4373,25 @@ class SavedTensorDict(TensorDictBase):
         return self
 
     def set_default(
-        self, key: NESTED_KEY, item: COMPATIBLE_TYPES, inplace: bool = False, **kwargs
+        self, key: NESTED_KEY, default: COMPATIBLE_TYPES, **kwargs
     ) -> COMPATIBLE_TYPES:
-        """Returns the value of the key if the key is in the tensordict. If not, insert
-        key with a value of item and returns item.
+        """Insert key with a value of default if key is not in the dictionary.
+
+        Return the value for key if key is in the dictionary, else default.
 
         Args:
-            key (str): name of the item
-            item (torch.Tensor): value to be stored in the tensordict
-            inplace (bool, optional): if True and if a key matches an existing
-                key in the tensordict, then the update will occur in-place
-                for that key-value pair. Default is :obj:`False`.
+            key (str): the name of the value.
+            default (torch.Tensor): value to be stored in the tensordict if the key is
+                not already present.
 
         Returns:
-            the value of the key or item if the key is not in the tensordict
+            The value of key in the tensordict. Will be default if the key was not
+            previously set.
 
         """
         if isinstance(key, tuple):
             raise TypeError("SavedTensorDict does not currently support nested keys.")
-        return super().set_default(key=key, item=item, inplace=inplace, **kwargs)
+        return super().set_default(key=key, default=default, **kwargs)
 
     def expand(self, *shape, inplace: bool = False) -> TensorDictBase:
         if len(shape) == 1 and isinstance(shape[0], Sequence):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -31,6 +31,8 @@ if hasattr(typing, "get_args"):
 else:
     DEVICE_TYPING_ARGS = (torch.device, str, int)
 
+NESTED_KEY = Union[str, Tuple[str, ...]]
+
 
 def _sub_index(tensor: torch.Tensor, idx: INDEX_TYPING) -> torch.Tensor:
     """Allows indexing of tensors with nested tuples.
@@ -358,3 +360,20 @@ numpy_to_torch_dtype_dict = {
 torch_to_numpy_dtype_dict = {
     value: key for key, value in numpy_to_torch_dtype_dict.items()
 }
+
+
+def _nested_key_type_check(key):
+    is_tuple = isinstance(key, tuple)
+    if not (
+        isinstance(key, str)
+        or (
+            is_tuple and len(key) > 0 and all(isinstance(subkey, str) for subkey in key)
+        )
+    ):
+        key_repr = (
+            f"tuple({', '.join(str(type(i)) for i in key)})" if is_tuple else type(key)
+        )
+        raise TypeError(
+            "Expected key to be a string or non-empty tuple of strings, but found "
+            f"{key_repr}"
+        )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -17,7 +17,7 @@ from tensordict import (
     SavedTensorDict,
     TensorDict,
 )
-from tensordict.tensordict import TensorDictBase, SubTensorDict
+from tensordict.tensordict import TensorDictBase
 from tensordict.tensordict import _stack as stack_td
 from tensordict.tensordict import assert_allclose_td, make_tensordict, pad
 from tensordict.utils import _getitem_batch_size, convert_ellipsis_to_idx
@@ -1526,10 +1526,12 @@ class TestTensorDicts(TestTensorDictsBase):
 
         td = getattr(self, td_name)(device)
 
-        tensor = torch.randn(4, 3, 2, 1, 5)
-        tensor2 = torch.ones(4, 3, 2, 1, 5)
-        sub_sub_tensordict = TensorDict({"c": tensor}, [4, 3, 2, 1])
-        sub_tensordict = TensorDict({"b": sub_sub_tensordict}, [4, 3, 2, 1])
+        tensor = torch.randn(4, 3, 2, 1, 5, device=device)
+        tensor2 = torch.ones(4, 3, 2, 1, 5, device=device)
+        sub_sub_tensordict = TensorDict({"c": tensor}, [4, 3, 2, 1], device=device)
+        sub_tensordict = TensorDict(
+            {"b": sub_sub_tensordict}, [4, 3, 2, 1], device=device
+        )
 
         if td_name == "sub_td":
             td = td._source.set(
@@ -1537,7 +1539,8 @@ class TestTensorDicts(TestTensorDictsBase):
             ).get_sub_tensordict(1)
         elif td_name == "sub_td2":
             td = td._source.set(
-                "a", sub_tensordict.expand(2, *sub_tensordict.shape).permute(1, 0, 2, 3, 4)
+                "a",
+                sub_tensordict.expand(2, *sub_tensordict.shape).permute(1, 0, 2, 3, 4),
             ).get_sub_tensordict((slice(None), 1))
         else:
             td.set("a", sub_tensordict)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2488,6 +2488,21 @@ def test_setitem_nested():
     assert (tensordict["a", "b", "c"] == 1).all()
 
 
+def test_setdefault_nested():
+    tensor = torch.randn(4, 5, 6, 7)
+    tensor2 = torch.ones(4, 5, 6, 7)
+    sub_sub_tensordict = TensorDict({"c": tensor}, [4, 5, 6])
+    sub_tensordict = TensorDict({"b": sub_sub_tensordict}, [4, 5])
+    tensordict = TensorDict({"a": sub_tensordict}, [4])
+
+    # if key exists we return the existing value
+    assert tensordict.set_default(("a", "b", "c"), tensor2) is tensor
+
+    assert tensordict.set_default(("a", "b", "d"), tensor2) is tensor2
+    assert (tensordict["a", "b", "d"] == 1).all()
+    assert tensordict.get(("a", "b", "d")) is tensor2
+
+
 @pytest.mark.parametrize("inplace", [True, False])
 def test_select_nested(inplace):
     tensor_1 = torch.rand(4, 5, 6, 7)

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -320,6 +320,33 @@ class TestTDModule:
         assert td_out.shape == torch.Size([10, 3])
         assert td_out.get("out").shape == torch.Size([10, 3, 4])
 
+    def test_nested_keys(self):
+        class Net(nn.Module):
+            def __init__(self, input_size=100, hidden=10):
+                super().__init__()
+                self.fc1 = nn.Linear(input_size, hidden)
+                self.fc2 = nn.Linear(hidden, 1)
+
+            def forward(self, x):
+                x = torch.relu(self.fc1(x))
+                logits = self.fc2(x)
+                return torch.sigmoid(logits), logits
+
+        module = TensorDictModule(
+            Net(),
+            in_keys=[("inputs", "x")],
+            out_keys=[("outputs", "probabilities"), ("outputs", "logits")],
+        )
+
+        x = torch.rand(5, 100)
+        tensordict = TensorDict({"inputs": TensorDict({"x": x}, [5])}, [5])
+
+        tensordict = module(tensordict)
+
+        assert tensordict["inputs", "x"] is x
+        assert ("outputs", "probabilities") in tensordict.keys(include_nested=True)
+        assert ("outputs", "logits") in tensordict.keys(include_nested=True)
+
 
 class TestTDSequence:
     def test_key_exclusion(self):


### PR DESCRIPTION
## Description

Add support for nested keys to `.set_default` method.

Note that currently given a `LazyStackedTensorDict`, `set_default` will work if passed an existing key, but will fail when falling back to `set` which raises an error. Would it be better to raise an error earlier and disallow use of nested keys in `set_default` entirely?

## Context

cf. #22 