### PR TITLE
[BugFix] Accept nested dicts for update

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3447,9 +3447,11 @@ torch.Size([3, 2])
                     elif isinstance(value, (dict, TensorDictBase)):
                         target.update(value)
                         continue
-                raise ValueError(
-                    f"Tried to replace a tensordict with an incompatible object of type {type(value)}"
-                )
+                    raise ValueError(
+                        f"Tried to replace a tensordict with an incompatible object of type {type(value)}"
+                    )
+                else:
+                    self.set_(key, value)
             else:
                 self.set(key, value, inplace=inplace, **kwargs)
         return self

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2308,7 +2308,6 @@ class TensorDict(TensorDictBase):
             # since we call _nested_key_type_check above, we may assume that the key is
             # a tuple of strings
             td, subkey = _get_leaf_tensordict(self, key, _default_hook)
-            print("set:", td)
             td.set(subkey, proc_value)
 
             if _meta_val:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -586,14 +586,24 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         if input_dict_or_td is self:
             # no op
             return self
+        keys = set(self.keys(False))
         for key, value in input_dict_or_td.items():
-            if not isinstance(value, _accepted_classes):
-                raise TypeError(
-                    f"Expected value to be one of types "
-                    f"{_accepted_classes} but got {type(value)}"
-                )
-            if clone:
+            if clone and hasattr(value, clone):
                 value = value.clone()
+            if isinstance(key, tuple):
+                key, subkey = key[0], key[1:]
+            else:
+                subkey = []
+            # the key must be a string by now. Let's check if it is present
+            if key in keys:
+                target = self._get_meta(key)
+                if target.is_tensordict():
+                    target = self.get(key)
+                    if len(subkey):
+                        target.update({subkey: value})
+                    else:
+                        target.update(value)
+                    continue
             self.set(key, value, inplace=inplace, **kwargs)
         return self
 
@@ -622,11 +632,11 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             # no op
             return self
         for key, value in input_dict_or_td.items():
-            if not isinstance(value, _accepted_classes):
-                raise TypeError(
-                    f"Expected value to be one of types {_accepted_classes} "
-                    f"but got {type(value)}"
-                )
+            # if not isinstance(value, _accepted_classes):
+            #     raise TypeError(
+            #         f"Expected value to be one of types {_accepted_classes} "
+            #         f"but got {type(value)}"
+            #     )
             if clone:
                 value = value.clone()
             self.set_(key, value)
@@ -2254,6 +2264,7 @@ class TensorDict(TensorDictBase):
                 raise RuntimeError("Cannot modify locked TensorDict")
 
         _nested_key_type_check(key)
+        keys = set(self.keys(include_nested=True))
 
         if self._is_shared is None:
             try:
@@ -2267,7 +2278,7 @@ class TensorDict(TensorDictBase):
         if self._is_memmap is None:
             self._is_memmap = isinstance(value, MemmapTensor)
 
-        present = key in self.keys(include_nested=True)
+        present = key in keys
         if present and value is self.get(key):
             return self
 
@@ -2281,7 +2292,7 @@ class TensorDict(TensorDictBase):
             check_device=_run_checks,
         )  # check_tensor_shape=_run_checks
 
-        if len(key) == 1:
+        if isinstance(key, tuple) and len(key) == 1:
             key = key[0]
 
         if isinstance(key, str):
@@ -2294,6 +2305,7 @@ class TensorDict(TensorDictBase):
             # since we call _nested_key_type_check above, we may assume that the key is
             # a tuple of strings
             td, subkey = _get_leaf_tensordict(self, key, _default_hook)
+            print("set:", td)
             td.set(subkey, proc_value)
 
             if _meta_val:
@@ -3402,6 +3414,37 @@ torch.Size([3, 2])
                 return out
             return out[idx]
 
+    def update(
+        self,
+        input_dict_or_td: Union[dict, TensorDictBase],
+        clone: bool = False,
+        inplace: bool = False,
+        **kwargs,
+    ):
+        if input_dict_or_td is self:
+            # no op
+            return self
+        keys = set(self.keys(False))
+        for key, value in input_dict_or_td.items():
+            if clone and hasattr(value, clone):
+                value = value.clone()
+            if isinstance(key, tuple):
+                key, subkey = key[0], key[1:]
+            else:
+                subkey = []
+            # the key must be a string by now. Let's check if it is present
+            if key in keys:
+                target = self._get_meta(key)
+                if target.is_tensordict():
+                    target = self._source.get(key).get_sub_tensordict(self.idx)
+                    if len(subkey):
+                        target.update({subkey: value})
+                    else:
+                        target.update(value)
+                    continue
+            self.set(key, value, inplace=inplace, **kwargs)
+        return self
+
     def update_(
         self,
         input_dict: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
@@ -4165,15 +4208,32 @@ class LazyStackedTensorDict(TensorDictBase):
         if input_dict_or_td is self:
             # no op
             return self
+        keys = set(self.keys(False))
         for key, value in input_dict_or_td.items():
-            if not isinstance(value, _accepted_classes):
-                raise TypeError(
-                    f"Expected value to be one of types {_accepted_classes} "
-                    f"but got {type(value)}"
-                )
-            if clone:
+            if clone and hasattr(value, clone):
                 value = value.clone()
+            if isinstance(key, tuple):
+                key, subkey = key[0], key[1:]
+            else:
+                subkey = tuple()
+            # the key must be a string by now. Let's check if it is present
+            if key in keys:
+                target = self._get_meta(key)
+                if target.is_tensordict():
+                    if isinstance(value, dict):
+                        value_unbind = TensorDict(
+                            value, self.batch_size, _run_checks=False
+                        ).unbind(self.stack_dim)
+                    else:
+                        value_unbind = value.unbind(self.stack_dim)
+                    for t, _value in zip(self.tensordicts, value_unbind):
+                        if len(subkey):
+                            t.update({key: {subkey: _value}})
+                        else:
+                            t.update({key: _value})
+                    continue
             self.set(key, value, **kwargs)
+        self._update_valid_keys()
         return self
 
     def update_(
@@ -4369,12 +4429,30 @@ class SavedTensorDict(TensorDictBase):
             # no op
             return self
         td = self._load()
+        keys = set(td.keys(True))
         for key, value in input_dict_or_td.items():
-            if not isinstance(value, _accepted_classes):
-                raise TypeError(
-                    f"Expected value to be one of types {_accepted_classes} "
-                    f"but got {type(value)}"
-                )
+            # if not isinstance(value, _accepted_classes):
+            #     raise TypeError(
+            #         f"Expected value to be one of types {_accepted_classes} "
+            #         f"but got {type(value)}"
+            #     )
+            if clone and hasattr(value, clone):
+                value = value.clone()
+            if isinstance(key, tuple):
+                key, subkey = key[0], key[1:]
+            else:
+                subkey = []
+            # the key must be a string by now. Let's check if it is present
+            if key in keys:
+                target = self._get_meta(key)
+                if target.is_tensordict():
+                    target = self.get(key)
+                    if len(subkey):
+                        target.update({subkey: value})
+                    else:
+                        target.update(value)
+                    continue
+            td.set(key, value, inplace=False, **kwargs)
             if clone:
                 value = value.clone()
             td.set(key, value, **kwargs)
@@ -5130,7 +5208,11 @@ def _check_keys(
     return keys
 
 
-_accepted_classes = (Tensor, MemmapTensor, TensorDictBase, dict)
+_accepted_classes = (
+    Tensor,
+    MemmapTensor,
+    TensorDictBase,
+)
 
 
 def _expand_to_match_shape(parent_batch_size, tensor, self_batch_dims, self_device):

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5130,7 +5130,7 @@ def _check_keys(
     return keys
 
 
-_accepted_classes = (Tensor, MemmapTensor, TensorDictBase)
+_accepted_classes = (Tensor, MemmapTensor, TensorDictBase, dict)
 
 
 def _expand_to_match_shape(parent_batch_size, tensor, self_batch_dims, self_device):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1004,7 +1004,11 @@ class TestTensorDicts(TestTensorDictsBase):
         td.update(
             {("newnested",): {"v": torch.zeros(td.shape)}},
         )
-        keys = keys.union({("newnested", "v"),})
+        keys = keys.union(
+            {
+                ("newnested", "v"),
+            }
+        )
         assert keys == set(td.keys(True))
 
     def test_write_on_subtd(self, td_name, device):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2777,10 +2777,12 @@ class TestMakeTensorDict:
         assert tensordict["b"].device == device
         assert tensordict["c"].device == device
 
+
 def test_update_nested_dict():
     t = TensorDict({}, [2, 3])
-    t.update({'a': {'b': [[[1], [1], [1]]] * 2}})
+    t.update({"a": {"b": [[[1], [1], [1]]] * 2}})
     assert t["a", "b"].shape == torch.Size([2, 3, 1])
+
 
 @pytest.mark.parametrize("separator", [".", "-"])
 def test_unflatten_keys_collision(separator):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1001,6 +1001,11 @@ class TestTensorDicts(TestTensorDictsBase):
         )
         keys = keys.union({("newnested", "x"), ("newnested", "w")})
         assert keys == set(td.keys(True))
+        td.update(
+            {("newnested",): {"v": torch.zeros(td.shape)}},
+        )
+        keys = keys.union({("newnested", "v"),})
+        assert keys == set(td.keys(True))
 
     def test_write_on_subtd(self, td_name, device):
         td = getattr(self, td_name)(device)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -977,6 +977,31 @@ class TestTensorDicts(TestTensorDictsBase):
         assert (td_squeeze.get("a") == 1).all()
         assert (td.get("a") == 1).all()
 
+    def test_update(self, td_name, device):
+        if td_name == "saved_td":
+            pytest.skip(
+                "SavedTensorDict does not currently support iteration over nested keys."
+            )
+        td = getattr(self, td_name)(device)
+        keys = set(td.keys())
+        td.update({"x": torch.zeros(td.shape)})
+        assert set(td.keys()) == keys.union({"x"})
+        # now with nested
+        td["newnested"] = {"z": torch.zeros(td.shape)}
+        keys = set(td.keys(True))
+        assert ("newnested", "z") in keys
+        td.update({"newnested": {"y": torch.zeros(td.shape)}})
+        keys = keys.union({("newnested", "y")})
+        assert keys == set(td.keys(True))
+        td.update(
+            {
+                ("newnested", "x"): torch.zeros(td.shape),
+                ("newnested", "w"): torch.zeros(td.shape),
+            }
+        )
+        keys = keys.union({("newnested", "x"), ("newnested", "w")})
+        assert keys == set(td.keys(True))
+
     def test_write_on_subtd(self, td_name, device):
         td = getattr(self, td_name)(device)
         sub_td = td.get_sub_tensordict(0)
@@ -2779,9 +2804,13 @@ class TestMakeTensorDict:
 
 
 def test_update_nested_dict():
-    t = TensorDict({}, [2, 3])
-    t.update({"a": {"b": [[[1], [1], [1]]] * 2}})
+    t = TensorDict({"a": {"d": [[[0]] * 3] * 2}}, [2, 3])
+    assert ("a", "d") in t.keys(include_nested=True)
+    t.update({"a": {"b": [[[1]] * 3] * 2}})
+    assert ("a", "d") in t.keys(include_nested=True)
+    assert ("a", "b") in t.keys(include_nested=True)
     assert t["a", "b"].shape == torch.Size([2, 3, 1])
+    t.update({"a": {"d": [[[1]] * 3] * 2}})
 
 
 @pytest.mark.parametrize("separator", [".", "-"])

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2777,6 +2777,10 @@ class TestMakeTensorDict:
         assert tensordict["b"].device == device
         assert tensordict["c"].device == device
 
+def test_update_nested_dict():
+    t = TensorDict({}, [2, 3])
+    t.update({'a': {'b': [[[1], [1], [1]]] * 2}})
+    assert t["a", "b"].shape == torch.Size([2, 3, 1])
 
 @pytest.mark.parametrize("separator", [".", "-"])
 def test_unflatten_keys_collision(separator):


### PR DESCRIPTION
## Description

Makes sure that the following use cases are coved:
```python
tensordict.update({"a": {"b": [1]}})
tensordict.update({("a", "b"): [1]})
tensordict.update({("a", "b"): [1], ("a", "c"): [1], })
```