### PR TITLE
[Feature] TensorDictModule nested keys

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -34,6 +34,7 @@ from tensordict.nn.functional_modules import (
     FunctionalModuleWithBuffers as rlFunctionalModuleWithBuffers,
 )
 from tensordict.tensordict import TensorDictBase
+from tensordict.utils import NESTED_KEY, _nested_key_type_check
 
 __all__ = [
     "TensorDictModule",
@@ -48,6 +49,16 @@ def _check_all_str(list_of_str):
         )
     if any(not isinstance(key, str) for key in list_of_str):
         raise TypeError(f"Expected a list of strings but got: {list_of_str}")
+
+
+def _check_all_nested(list_of_keys):
+    if isinstance(list_of_keys, str):
+        raise RuntimeError(
+            "Expected a list of strings, or tuples of strings but got a string: "
+            f"{list_of_keys}"
+        )
+    for key in list_of_keys:
+        _nested_key_type_check(key)
 
 
 class TensorDictModule(nn.Module):
@@ -123,8 +134,8 @@ class TensorDictModule(nn.Module):
         module: Union[
             FunctionalModule, FunctionalModuleWithBuffers, TensorDictModule, nn.Module
         ],
-        in_keys: Iterable[str],
-        out_keys: Iterable[str],
+        in_keys: Iterable[NESTED_KEY],
+        out_keys: Iterable[NESTED_KEY],
     ):
 
         super().__init__()
@@ -134,9 +145,9 @@ class TensorDictModule(nn.Module):
         if not in_keys:
             raise RuntimeError(f"in_keys were not passed to {self.__class__.__name__}")
         self.out_keys = out_keys
-        _check_all_str(self.out_keys)
+        _check_all_nested(self.out_keys)
         self.in_keys = in_keys
-        _check_all_str(self.in_keys)
+        _check_all_nested(self.in_keys)
 
         if "_" in in_keys:
             warnings.warn(
@@ -157,7 +168,7 @@ class TensorDictModule(nn.Module):
         tensordict: TensorDictBase,
         tensors: List,
         tensordict_out: Optional[TensorDictBase] = None,
-        out_keys: Optional[Iterable[str]] = None,
+        out_keys: Optional[Iterable[NESTED_KEY]] = None,
         vmap: Optional[int] = None,
     ) -> TensorDictBase:
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -24,12 +24,12 @@ from typing import (
     Iterator,
     List,
     Optional,
+    OrderedDict,
     Sequence,
     Set,
     Tuple,
     Type,
     Union,
-    OrderedDict,
 )
 from warnings import warn
 
@@ -47,8 +47,10 @@ from tensordict.metatensor import MetaTensor
 from tensordict.utils import (
     DEVICE_TYPING,
     INDEX_TYPING,
+    NESTED_KEY,
     KeyDependentDefaultDict,
     _getitem_batch_size,
+    _nested_key_type_check,
     _sub_index,
     convert_ellipsis_to_idx,
     expand_as_right,
@@ -82,8 +84,6 @@ COMPATIBLE_TYPES = Union[
 ]  # None? # leaves space for TensorDictBase
 
 _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-only or string-free indices are supported."
-
-NESTED_KEY = Union[str, Tuple[str, ...]]
 
 
 class _TensorDictKeysView:
@@ -2657,23 +2657,6 @@ class _ErrorInteceptor:
             self.exc_msg is None or self.exc_msg in str(exc_value)
         ):
             exc_value.args = (self._add_key_to_error_msg(str(exc_value)),)
-
-
-def _nested_key_type_check(key):
-    is_tuple = isinstance(key, tuple)
-    if not (
-        isinstance(key, str)
-        or (
-            is_tuple and len(key) > 0 and all(isinstance(subkey, str) for subkey in key)
-        )
-    ):
-        key_repr = (
-            f"tuple({', '.join(str(type(i)) for i in key)})" if is_tuple else type(key)
-        )
-        raise TypeError(
-            "Expected key to be a string or non-empty tuple of strings, but found "
-            f"{key_repr}"
-        )
 
 
 def _nested_keys_to_dict(keys: Iterator[NESTED_KEY]) -> Dict[str, Any]:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -31,6 +31,8 @@ if hasattr(typing, "get_args"):
 else:
     DEVICE_TYPING_ARGS = (torch.device, str, int)
 
+NESTED_KEY = Union[str, Tuple[str, ...]]
+
 
 def _sub_index(tensor: torch.Tensor, idx: INDEX_TYPING) -> torch.Tensor:
     """Allows indexing of tensors with nested tuples.
@@ -358,3 +360,20 @@ numpy_to_torch_dtype_dict = {
 torch_to_numpy_dtype_dict = {
     value: key for key, value in numpy_to_torch_dtype_dict.items()
 }
+
+
+def _nested_key_type_check(key):
+    is_tuple = isinstance(key, tuple)
+    if not (
+        isinstance(key, str)
+        or (
+            is_tuple and len(key) > 0 and all(isinstance(subkey, str) for subkey in key)
+        )
+    ):
+        key_repr = (
+            f"tuple({', '.join(str(type(i)) for i in key)})" if is_tuple else type(key)
+        )
+        raise TypeError(
+            "Expected key to be a string or non-empty tuple of strings, but found "
+            f"{key_repr}"
+        )

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -328,9 +328,9 @@ class TestTDModule:
                 self.fc2 = nn.Linear(hidden, 1)
 
             def forward(self, x):
-                x = nn.functional.relu(self.fc1(x))
+                x = torch.relu(self.fc1(x))
                 logits = self.fc2(x)
-                return nn.functional.sigmoid(logits), logits
+                return torch.sigmoid(logits), logits
 
         module = TensorDictModule(
             Net(),


### PR DESCRIPTION
## Description

This PR adds support for nested keys to `TensorDictModule`. Much of the heavy lifting is done by existing support for nested keys in `set` and `get`. Here's a simple example:

```python
>>> import torch
>>> import torch.nn as nn

>>> class Net(nn.Module):
...     def __init__(self, input_size=100, hidden=10):
...         super().__init__()
...         self.fc1 = nn.Linear(input_size, hidden)
...         self.fc2 = nn.Linear(hidden, 1)
... 
...     def forward(self, x):
...         x = torch.relu(self.fc1(x))
...         logits = self.fc2(x)
...         return torch.sigmoid(logits), logits

>>> module = TensorDictModule(
...     Net(),
...     in_keys=[("inputs", "x")],
...     out_keys=[("outputs", "probabilities"), ("outputs", "logits")],
... )

>>> x = torch.rand(5, 100)
>>> tensordict = TensorDict({"inputs": TensorDict({"x": x}, [5])}, [5])

>>> module(tensordict)
TensorDict(
    fields={
        inputs: TensorDict(
            fields={
                x: Tensor(torch.Size([5, 100]), dtype=torch.float32)},
            batch_size=torch.Size([5]),
            device=None,
            is_shared=False),
        outputs: TensorDict(
            fields={
                logits: Tensor(torch.Size([5, 1]), dtype=torch.float32),
                probabilities: Tensor(torch.Size([5, 1]), dtype=torch.float32)},
            batch_size=torch.Size([5]),
            device=None,
            is_shared=False)},
    batch_size=torch.Size([5]),
    device=None,
    is_shared=False)
```

## Motivation and Context

cf. #22