### PR TITLE
[Feature] TensorDictSequential nested keys

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -34,6 +34,7 @@ from tensordict.nn.functional_modules import (
     FunctionalModuleWithBuffers as rlFunctionalModuleWithBuffers,
 )
 from tensordict.tensordict import TensorDictBase
+from tensordict.utils import NESTED_KEY, _nested_key_type_check
 
 __all__ = [
     "TensorDictModule",
@@ -48,6 +49,16 @@ def _check_all_str(list_of_str):
         )
     if any(not isinstance(key, str) for key in list_of_str):
         raise TypeError(f"Expected a list of strings but got: {list_of_str}")
+
+
+def _check_all_nested(list_of_keys):
+    if isinstance(list_of_keys, str):
+        raise RuntimeError(
+            "Expected a list of strings, or tuples of strings but got a string: "
+            f"{list_of_keys}"
+        )
+    for key in list_of_keys:
+        _nested_key_type_check(key)
 
 
 class TensorDictModule(nn.Module):
@@ -123,8 +134,8 @@ class TensorDictModule(nn.Module):
         module: Union[
             FunctionalModule, FunctionalModuleWithBuffers, TensorDictModule, nn.Module
         ],
-        in_keys: Iterable[str],
-        out_keys: Iterable[str],
+        in_keys: Iterable[NESTED_KEY],
+        out_keys: Iterable[NESTED_KEY],
     ):
 
         super().__init__()
@@ -134,9 +145,9 @@ class TensorDictModule(nn.Module):
         if not in_keys:
             raise RuntimeError(f"in_keys were not passed to {self.__class__.__name__}")
         self.out_keys = out_keys
-        _check_all_str(self.out_keys)
+        _check_all_nested(self.out_keys)
         self.in_keys = in_keys
-        _check_all_str(self.in_keys)
+        _check_all_nested(self.in_keys)
 
         if "_" in in_keys:
             warnings.warn(
@@ -157,7 +168,7 @@ class TensorDictModule(nn.Module):
         tensordict: TensorDictBase,
         tensors: List,
         tensordict_out: Optional[TensorDictBase] = None,
-        out_keys: Optional[Iterable[str]] = None,
+        out_keys: Optional[Iterable[NESTED_KEY]] = None,
         vmap: Optional[int] = None,
     ) -> TensorDictBase:
 

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -34,7 +34,7 @@ from tensordict.nn.functional_modules import (
     FunctionalModuleWithBuffers as rlFunctionalModuleWithBuffers,
 )
 from tensordict.tensordict import TensorDictBase
-from tensordict.utils import NESTED_KEY, _nested_key_type_check
+from tensordict.utils import NESTED_KEY, _nested_key_type_check, _normalize_key
 
 __all__ = [
     "TensorDictModule",
@@ -144,10 +144,10 @@ class TensorDictModule(nn.Module):
             raise RuntimeError(f"out_keys were not passed to {self.__class__.__name__}")
         if not in_keys:
             raise RuntimeError(f"in_keys were not passed to {self.__class__.__name__}")
-        self.out_keys = out_keys
-        _check_all_nested(self.out_keys)
-        self.in_keys = in_keys
-        _check_all_nested(self.in_keys)
+        _check_all_nested(out_keys)
+        self.out_keys = [_normalize_key(key) for key in out_keys]
+        _check_all_nested(in_keys)
+        self.in_keys = [_normalize_key(key) for key in in_keys]
 
         if "_" in in_keys:
             warnings.warn(

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -24,12 +24,12 @@ from typing import (
     Iterator,
     List,
     Optional,
+    OrderedDict,
     Sequence,
     Set,
     Tuple,
     Type,
     Union,
-    OrderedDict,
 )
 from warnings import warn
 
@@ -47,8 +47,10 @@ from tensordict.metatensor import MetaTensor
 from tensordict.utils import (
     DEVICE_TYPING,
     INDEX_TYPING,
+    NESTED_KEY,
     KeyDependentDefaultDict,
     _getitem_batch_size,
+    _nested_key_type_check,
     _sub_index,
     convert_ellipsis_to_idx,
     expand_as_right,
@@ -82,8 +84,6 @@ COMPATIBLE_TYPES = Union[
 ]  # None? # leaves space for TensorDictBase
 
 _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-only or string-free indices are supported."
-
-NESTED_KEY = Union[str, Tuple[str, ...]]
 
 
 class _TensorDictKeysView:
@@ -2657,23 +2657,6 @@ class _ErrorInteceptor:
             self.exc_msg is None or self.exc_msg in str(exc_value)
         ):
             exc_value.args = (self._add_key_to_error_msg(str(exc_value)),)
-
-
-def _nested_key_type_check(key):
-    is_tuple = isinstance(key, tuple)
-    if not (
-        isinstance(key, str)
-        or (
-            is_tuple and len(key) > 0 and all(isinstance(subkey, str) for subkey in key)
-        )
-    ):
-        key_repr = (
-            f"tuple({', '.join(str(type(i)) for i in key)})" if is_tuple else type(key)
-        )
-        raise TypeError(
-            "Expected key to be a string or non-empty tuple of strings, but found "
-            f"{key_repr}"
-        )
 
 
 def _nested_keys_to_dict(keys: Iterator[NESTED_KEY]) -> Dict[str, Any]:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -170,7 +170,7 @@ class _TensorDictKeysView:
                         val = self.tensordict.get(key[0])
                         # TODO: SavedTensorDict currently doesn't support nested memebership checks
                         include_nested = self.include_nested and not isinstance(
-                            val, (SavedTensorDict,)
+                            val, SavedTensorDict
                         )
                         return isinstance(val, TensorDictBase) and key[1:] in val.keys(
                             include_nested=include_nested
@@ -3274,9 +3274,8 @@ torch.Size([3, 2])
         return self
 
     def keys(self, include_nested: bool = False) -> _TensorDictKeysView:
-        # TODO: temporary hack while SavedTensorDict and LazyStackedTensorDict don't
-        # support nested iteration
-        if isinstance(self._source, (LazyStackedTensorDict, SavedTensorDict)):
+        # TODO: temporary hack while SavedTensorDict doesn't support nested iteration
+        if isinstance(self._source, SavedTensorDict):
             include_nested = False
         return self._source.keys(include_nested=include_nested)
 

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -31,6 +31,8 @@ if hasattr(typing, "get_args"):
 else:
     DEVICE_TYPING_ARGS = (torch.device, str, int)
 
+NESTED_KEY = Union[str, Tuple[str, ...]]
+
 
 def _sub_index(tensor: torch.Tensor, idx: INDEX_TYPING) -> torch.Tensor:
     """Allows indexing of tensors with nested tuples.
@@ -358,3 +360,20 @@ numpy_to_torch_dtype_dict = {
 torch_to_numpy_dtype_dict = {
     value: key for key, value in numpy_to_torch_dtype_dict.items()
 }
+
+
+def _nested_key_type_check(key):
+    is_tuple = isinstance(key, tuple)
+    if not (
+        isinstance(key, str)
+        or (
+            is_tuple and len(key) > 0 and all(isinstance(subkey, str) for subkey in key)
+        )
+    ):
+        key_repr = (
+            f"tuple({', '.join(str(type(i)) for i in key)})" if is_tuple else type(key)
+        )
+        raise TypeError(
+            "Expected key to be a string or non-empty tuple of strings, but found "
+            f"{key_repr}"
+        )

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -377,3 +377,8 @@ def _nested_key_type_check(key):
             "Expected key to be a string or non-empty tuple of strings, but found "
             f"{key_repr}"
         )
+
+
+def _normalize_key(key: NESTED_KEY) -> NESTED_KEY:
+    # normalises tuples of length one to their string contents
+    return key if not isinstance(key, tuple) or len(key) > 1 else key[0]

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2488,6 +2488,21 @@ def test_setitem_nested():
     assert (tensordict["a", "b", "c"] == 1).all()
 
 
+def test_setdefault_nested():
+    tensor = torch.randn(4, 5, 6, 7)
+    tensor2 = torch.ones(4, 5, 6, 7)
+    sub_sub_tensordict = TensorDict({"c": tensor}, [4, 5, 6])
+    sub_tensordict = TensorDict({"b": sub_sub_tensordict}, [4, 5])
+    tensordict = TensorDict({"a": sub_tensordict}, [4])
+
+    # if key exists we return the existing value
+    assert tensordict.set_default(("a", "b", "c"), tensor2) is tensor
+
+    assert tensordict.set_default(("a", "b", "d"), tensor2) is tensor2
+    assert (tensordict["a", "b", "d"] == 1).all()
+    assert tensordict.get(("a", "b", "d")) is tensor2
+
+
 @pytest.mark.parametrize("inplace", [True, False])
 def test_select_nested(inplace):
     tensor_1 = torch.rand(4, 5, 6, 7)

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -328,9 +328,9 @@ class TestTDModule:
                 self.fc2 = nn.Linear(hidden, 1)
 
             def forward(self, x):
-                x = nn.functional.relu(self.fc1(x))
+                x = torch.relu(self.fc1(x))
                 logits = self.fc2(x)
-                return nn.functional.sigmoid(logits), logits
+                return torch.sigmoid(logits), logits
 
         module = TensorDictModule(
             Net(),


### PR DESCRIPTION
## Description

*Note*: this branches off `tensordictmodule-nested-keys` and so #48 should be merged first

This PR adds support for nested keys to `TensorDictSequential`. A simple example:

```python
>>> import torch
>>> import torch.nn as nn
>>> from tensordict import TensorDict
>>> from tensordict.nn import TensorDictModule, TensorDictSequential


>>> class Net(nn.Module):
...     def __init__(self, input_size=100, hidden_size=50, output_size=10):
...         super().__init__()
...         self.fc1 = nn.Linear(input_size, hidden_size)
...         self.fc2 = nn.Linear(hidden_size, output_size)
... 
...     def forward(self, x):
...         x = torch.relu(self.fc1(x))
...         return self.fc2(x)


>>> class Masker(nn.Module):
...     def forward(self, x, mask):
...         return torch.softmax(x * mask, dim=1)


>>> net = TensorDictModule(
...     Net(), in_keys=[("input", "x")], out_keys=[("intermediate", "x")]
... )
>>> masker = TensorDictModule(
...     Masker(),
...     in_keys=[("intermediate", "x"), ("input", "mask")],
...     out_keys=[("output", "probabilities")],
... )
>>> module = TensorDictSequential(net, masker)

>>> tensordict = TensorDict(
...     {
...         "input": TensorDict(
...             {
...                 "x": torch.rand(32, 100),
...                 "mask": torch.randint(low=0, high=2, size=(32, 10), dtype=torch.uint8),
...             },
...             batch_size=[32],
...         )
...     },
...     batch_size=[32],
... )

TensorDict(
    fields={
        input: TensorDict(
            fields={
                mask: Tensor(torch.Size([32, 10]), dtype=torch.uint8),
                x: Tensor(torch.Size([32, 100]), dtype=torch.float32)},
            batch_size=torch.Size([32]),
            device=None,
            is_shared=False),
        intermediate: TensorDict(
            fields={
                x: Tensor(torch.Size([32, 10]), dtype=torch.float32)},
            batch_size=torch.Size([32]),
            device=None,
            is_shared=False),
        output: TensorDict(
            fields={
                probabilities: Tensor(torch.Size([32, 10]), dtype=torch.float32)},
            batch_size=torch.Size([32]),
            device=None,
            is_shared=False)},
    batch_size=torch.Size([32]),
    device=None,
    is_shared=False)
```

## Context

cf. #22