### PR TITLE
[Feature] `TensorDict.split` method

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1487,7 +1487,9 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             for idx, split_tensor in enumerate(split_tensors):
                 dictionaries[idx][key] = split_tensor
         return [
-            TensorDict(dictionaries[i], batch_sizes[i], device=self.device)
+            TensorDict(
+                dictionaries[i], batch_sizes[i], device=self.device, _run_checks=False
+            )
             for i in range(len(dictionaries))
         ]
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3151,6 +3151,11 @@ def pad_sequence_td(
         return out
 
 
+@implements_for_td(torch.split)
+def _split(td: TensorDict, split_size_or_sections: Union[int, List[int]], dim: int = 0):
+    return td.split(split_size_or_sections, dim)
+
+
 class SubTensorDict(TensorDictBase):
     """A TensorDict that only sees an index of the stored tensors.
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1443,10 +1443,12 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         batch_sizes = []
         if self.batch_dims == 0:
             raise RuntimeError("TensorDict with empty batch size is not splittable")
-        if dim >= self.batch_dims:
+        if not (-self.batch_dims <= dim < self.batch_dims):
             raise IndexError(
                 f"Dimension out of range (expected to be in range of [-{self.batch_dims}, {self.batch_dims - 1}], but got {dim})"
             )
+        if dim < 0:
+            dim += self.batch_dims
         if isinstance(split_size, int):
             rep, remainder = divmod(self.batch_size[dim], split_size)
             rep_shape = [

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1440,7 +1440,6 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             A list of TensorDict with specified size in given dimension.
 
         """
-        original_batch_size = self.batch_size
         batch_sizes = []
         if self.batch_dims == 0:
             raise RuntimeError("TensorDict with empty batch size is not splittable")
@@ -1449,31 +1448,31 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                 f"Dimension out of range (expected to be in range of [-{self.batch_dims}, {self.batch_dims - 1}], but got {dim})"
             )
         if isinstance(split_size, int):
-            rep, remainder = divmod(original_batch_size[dim], split_size)
+            rep, remainder = divmod(self.batch_size[dim], split_size)
             rep_shape = [
                 split_size if idx == dim else size
-                for (idx, size) in enumerate(original_batch_size)
+                for (idx, size) in enumerate(self.batch_size)
             ]
             batch_sizes = [rep_shape for _ in range(rep)]
             if remainder:
                 batch_sizes.append(
                     [
                         remainder if dim_idx == dim else dim_size
-                        for (dim_idx, dim_size) in enumerate(original_batch_size)
+                        for (dim_idx, dim_size) in enumerate(self.batch_size)
                     ]
                 )
         elif isinstance(split_size, list) and all(
             isinstance(element, int) for element in split_size
         ):
-            if sum(split_size) != original_batch_size[dim]:
+            if sum(split_size) != self.batch_size[dim]:
                 raise RuntimeError(
-                    f"Split method expects split_size to sum exactly to {original_batch_size[dim]} (tensor's size at dimension {dim}), but got split_size={split_size}"
+                    f"Split method expects split_size to sum exactly to {self.batch_size[dim]} (tensor's size at dimension {dim}), but got split_size={split_size}"
                 )
             for i in split_size:
                 batch_sizes.append(
                     [
                         i if dim_idx == dim else dim_size
-                        for (dim_idx, dim_size) in enumerate(original_batch_size)
+                        for (dim_idx, dim_size) in enumerate(self.batch_size)
                     ]
                 )
         else:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2971,6 +2971,16 @@ def test_split():
     assert tds[2].shape == torch.Size([3, 6])
 
 
+def test_split_torch_overload():
+    td = TensorDict({"a": torch.zeros(10)}, [10])
+
+    tds = torch.split(td, [5, 2, 3], 0)
+    assert len(tds) == 3
+    assert tds[0].shape == torch.Size([5])
+    assert tds[1].shape == torch.Size([2])
+    assert tds[2].shape == torch.Size([3])
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1643,6 +1643,59 @@ class TestTensorDicts(TestTensorDictsBase):
             )
             torch.testing.assert_close(td.get(("a", "b", "d")), tensor2)
 
+    @pytest.mark.parametrize("performer", ["torch", "tensordict"])
+    def test_split(self, td_name, device, performer):
+        td = getattr(self, td_name)(device)
+
+        for dim in range(td.batch_dims):
+            rep, remainder = divmod(td.shape[dim], 2)
+            length = rep + remainder
+
+            # split_sizes to be [2, 2, ..., 2, 1] or [2, 2, ..., 2]
+            split_sizes = [2] * rep + [1] * remainder
+            for test_split_size in (2, split_sizes):
+
+                if performer == "torch":
+                    tds = torch.split(td, test_split_size, dim)
+                elif performer == "tensordict":
+                    tds = td.split(test_split_size, dim)
+                assert len(tds) == length
+
+                for idx, split_td in enumerate(tds):
+                    expected_split_dim_size = 1 if idx == rep else 2
+                    expected_batch_size = [
+                        expected_split_dim_size if dim_idx == dim else dim_size
+                        for (dim_idx, dim_size) in enumerate(td.batch_size)
+                    ]
+
+                    # Test each split_td has the expected batch_size
+                    assert split_td.batch_size == torch.Size(expected_batch_size)
+
+                    if td_name == "nested_td":
+                        assert isinstance(split_td["my_nested_td"], TensorDict)
+                        assert isinstance(
+                            split_td["my_nested_td"]["inner"], torch.Tensor
+                        )
+
+                    # Test each tensor (or nested_td) in split_td has the expected shape
+                    for key, item in split_td.items():
+                        expected_shape = [
+                            expected_split_dim_size if dim_idx == dim else dim_size
+                            for (dim_idx, dim_size) in enumerate(td[key].shape)
+                        ]
+                        assert item.shape == torch.Size(expected_shape)
+
+                        if key == "my_nested_td":
+                            expected_inner_tensor_size = [
+                                expected_split_dim_size if dim_idx == dim else dim_size
+                                for (dim_idx, dim_size) in enumerate(
+                                    td[key]["inner"].shape
+                                )
+                            ]
+                            assert item["inner"].shape == torch.Size(
+                                expected_inner_tensor_size
+                            )
+
 
 @pytest.mark.parametrize("device", [None, *get_available_devices()])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.uint8])
@@ -2935,50 +2988,59 @@ def test_unflatten_keys_collision(separator):
     assert assert_allclose_td(td.unflatten_keys(separator), ref)
 
 
-def test_split():
-    td = TensorDict({"a": torch.zeros(10)}, [10])
+def test_split_with_invalid_arguments():
+    td = TensorDict({"a": torch.zeros(2, 1)}, [])
+    # Test empty batch size
+    with pytest.raises(RuntimeError, match="not splittable"):
+        td.split(1, 0)
 
-    tds = td.split(5, 0)
-    assert len(tds) == 2
-    assert tds[0].shape == torch.Size([5])
-    assert tds[1].shape == torch.Size([5])
+    td = TensorDict({}, [3, 2])
 
-    tds = td.split([5, 2, 3], 0)
+    # Test invalid split_size input
+    with pytest.raises(TypeError, match="must be int or list of ints"):
+        td.split("1", 0)
+    with pytest.raises(TypeError, match="must be int or list of ints"):
+        td.split(["1", 2], 0)
+
+    # Test invalid split_size sum
+    with pytest.raises(RuntimeError, match="expects split_size to sum exactly"):
+        td.split([], 0)
+
+    with pytest.raises(RuntimeError, match="expects split_size to sum exactly"):
+        td.split([1, 1], 0)
+
+    # Test invalid dimension input
+    with pytest.raises(IndexError, match="Dimension out of range"):
+        td.split(1, 2)
+
+
+def test_split_with_empty_tensordict():
+    td = TensorDict({}, [10])
+
+    tds = td.split(4, 0)
     assert len(tds) == 3
-    assert tds[0].shape == torch.Size([5])
-    assert tds[1].shape == torch.Size([2])
-    assert tds[2].shape == torch.Size([3])
+    assert tds[0].shape == torch.Size([4])
+    assert tds[1].shape == torch.Size([4])
+    assert tds[2].shape == torch.Size([2])
 
-    td = TensorDict(
-        source={"a": torch.zeros(5, 6, 5), "b": torch.zeros(5, 6, 10, 1)},
-        batch_size=torch.Size([5, 6]),
-    )
+    tds = td.split([1, 9], 0)
 
-    tds = td.split(3, 0)
     assert len(tds) == 2
-    assert tds[0].shape == torch.Size([3, 6])
-    assert tds[1].shape == torch.Size([2, 6])
+    assert tds[0].shape == torch.Size([1])
+    assert tds[1].shape == torch.Size([9])
+
+    td = TensorDict({}, [10, 10, 3])
 
     tds = td.split(4, 1)
+    assert len(tds) == 3
+    assert tds[0].shape == torch.Size([10, 4, 3])
+    assert tds[1].shape == torch.Size([10, 4, 3])
+    assert tds[2].shape == torch.Size([10, 2, 3])
+
+    tds = td.split([1, 9], 1)
     assert len(tds) == 2
-    assert tds[0].shape == torch.Size([5, 4])
-    assert tds[1].shape == torch.Size([5, 2])
-
-    tds = td.split([1, 1, 3], 0)
-    assert len(tds) == 3
-    assert tds[0].shape == torch.Size([1, 6])
-    assert tds[1].shape == torch.Size([1, 6])
-    assert tds[2].shape == torch.Size([3, 6])
-
-
-def test_split_torch_overload():
-    td = TensorDict({"a": torch.zeros(10)}, [10])
-
-    tds = torch.split(td, [5, 2, 3], 0)
-    assert len(tds) == 3
-    assert tds[0].shape == torch.Size([5])
-    assert tds[1].shape == torch.Size([2])
-    assert tds[2].shape == torch.Size([3])
+    assert tds[0].shape == torch.Size([10, 1, 3])
+    assert tds[1].shape == torch.Size([10, 9, 3])
 
 
 if __name__ == "__main__":

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2935,6 +2935,42 @@ def test_unflatten_keys_collision(separator):
     assert assert_allclose_td(td.unflatten_keys(separator), ref)
 
 
+def test_split():
+    td = TensorDict({"a": torch.zeros(10)}, [10])
+
+    tds = td.split(5, 0)
+    assert len(tds) == 2
+    assert tds[0].shape == torch.Size([5])
+    assert tds[1].shape == torch.Size([5])
+
+    tds = td.split([5, 2, 3], 0)
+    assert len(tds) == 3
+    assert tds[0].shape == torch.Size([5])
+    assert tds[1].shape == torch.Size([2])
+    assert tds[2].shape == torch.Size([3])
+
+    td = TensorDict(
+        source={"a": torch.zeros(5, 6, 5), "b": torch.zeros(5, 6, 10, 1)},
+        batch_size=torch.Size([5, 6]),
+    )
+
+    tds = td.split(3, 0)
+    assert len(tds) == 2
+    assert tds[0].shape == torch.Size([3, 6])
+    assert tds[1].shape == torch.Size([2, 6])
+
+    tds = td.split(4, 1)
+    assert len(tds) == 2
+    assert tds[0].shape == torch.Size([5, 4])
+    assert tds[1].shape == torch.Size([5, 2])
+
+    tds = td.split([1, 1, 3], 0)
+    assert len(tds) == 3
+    assert tds[0].shape == torch.Size([1, 6])
+    assert tds[1].shape == torch.Size([1, 6])
+    assert tds[2].shape == torch.Size([3, 6])
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3012,6 +3012,8 @@ def test_split_with_invalid_arguments():
     # Test invalid dimension input
     with pytest.raises(IndexError, match="Dimension out of range"):
         td.split(1, 2)
+    with pytest.raises(IndexError, match="Dimension out of range"):
+        td.split(1, -3)
 
 
 def test_split_with_empty_tensordict():
@@ -3041,6 +3043,19 @@ def test_split_with_empty_tensordict():
     assert len(tds) == 2
     assert tds[0].shape == torch.Size([10, 1, 3])
     assert tds[1].shape == torch.Size([10, 9, 3])
+
+
+def test_split_with_negative_dim():
+    td = TensorDict({"a": torch.zeros(5, 4, 2, 1), "b": torch.zeros(5, 4, 1)}, [5, 4])
+
+    tds = td.split([1, 3], -1)
+    assert len(tds) == 2
+    assert tds[0].shape == torch.Size([5, 1])
+    assert tds[0]["a"].shape == torch.Size([5, 1, 2, 1])
+    assert tds[0]["b"].shape == torch.Size([5, 1, 1])
+    assert tds[1].shape == torch.Size([5, 3])
+    assert tds[1]["a"].shape == torch.Size([5, 3, 2, 1])
+    assert tds[1]["b"].shape == torch.Size([5, 3, 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

- Implement `tensordict.split` method that works like [tensor.split](https://pytorch.org/docs/stable/generated/torch.split.html).
- Overload `torch.split` to support tensordict.
- Add test cases in `test_tensordict.py`

## Motivation and Context

As requested in issue #28, It would be nice to have a tensordict.split method that would work as [tensor.split](https://pytorch.org/docs/stable/generated/torch.split.html).
We would also need to overload torch.split as we do for torch.stack if possible.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.

My changes involve a new function in API, the docstring is added to the function. The auto-generated file is not included in the commit.
