### PR TITLE
[Feature] TorchRec support: indexing keyedjaggedtensors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,61 @@ jobs:
       - store_test_results:
           path: test-results
 
+  unittest_linux_torchrec_gpu:
+    <<: *binary_common
+    machine:
+      image: ubuntu-2004-cuda-11.4:202110-01
+    resource_class: gpu.nvidia.medium
+    environment:
+      image_name: "pytorch/manylinux-cuda113"
+      TAR_OPTIONS: --no-same-owner
+      PYTHON_VERSION: << parameters.python_version >>
+      CU_VERSION: << parameters.cu_version >>
+
+    steps:
+      - checkout
+      - designate_upload_channel
+      - run:
+          name: Generate cache key
+          # This will refresh cache on Sundays, nightly build should generate new cache.
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+      - restore_cache:
+
+          keys:
+            - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+
+      - run:
+          name: Setup
+          command: docker run -e PYTHON_VERSION -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/setup_env.sh
+      - save_cache:
+
+          key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+
+          paths:
+            - conda
+            - env
+#      - run:
+#          # Here we create an envlist file that contains some env variables that we want the docker container to be aware of.
+#          # Normally, the CIRCLECI variable is set and available on all CI workflows: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+#          # They're available in all the other workflows (OSX and Windows).
+#          # But here, we're running the unittest_linux_gpu workflows in a docker container, where those variables aren't accessible.
+#          # So instead we dump the variables we need in env.list and we pass that file when invoking "docker run".
+#          name: export CIRCLECI env var
+#          command: echo "CIRCLECI=true" >> ./env.list
+      - run:
+          name: Install tensordict
+#          command: bash .circleci/unittest/linux_torchrec/scripts/install.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_torchrec/scripts/install.sh
+      - run:
+          name: Run tests
+          command: bash .circleci/unittest/linux_torchrec/scripts/run_test.sh
+#          command: docker run --env-file ./env.list -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/run_test.sh
+      - run:
+          name: Post Process
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/post_process.sh
+      - store_test_results:
+          path: test-results
+
   unittest_linux_stable_cpu:
     <<: *binary_common
 
@@ -604,6 +659,10 @@ workflows:
       - unittest_linux_stable_gpu:
           cu_version: cu113
           name: unittest_linux_stable_gpu_py3.9
+          python_version: '3.9'
+      - unittest_linux_torchrec_gpu:
+          cu_version: cu113
+          name: unittest_linux_torchrec_gpu_py3.9
           python_version: '3.9'
 
       - unittest_macos_cpu:

--- a/.circleci/unittest/linux_torchrec/scripts/environment.yml
+++ b/.circleci/unittest/linux_torchrec/scripts/environment.yml
@@ -1,0 +1,15 @@
+channels:
+  - pytorch
+  - defaults
+dependencies:
+  - pip
+  - protobuf
+  - pip:
+    - hypothesis
+    - future
+    - cloudpickle
+    - pytest
+    - pytest-cov
+    - pytest-mock
+    - pytest-instafail
+    - expecttest

--- a/.circleci/unittest/linux_torchrec/scripts/install.sh
+++ b/.circleci/unittest/linux_torchrec/scripts/install.sh
@@ -30,7 +30,7 @@ printf "Installing PyTorch with %s\n" "${CU_VERSION}"
 if [ "${CU_VERSION:-}" == cpu ] ; then
     pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 else
-    pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+    pip3 install --pre pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
 fi
 
 # smoke test

--- a/.circleci/unittest/linux_torchrec/scripts/install.sh
+++ b/.circleci/unittest/linux_torchrec/scripts/install.sh
@@ -30,7 +30,7 @@ printf "Installing PyTorch with %s\n" "${CU_VERSION}"
 if [ "${CU_VERSION:-}" == cpu ] ; then
     pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 else
-    pip3 install --pre pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+    pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117
 fi
 
 # smoke test

--- a/.circleci/unittest/linux_torchrec/scripts/install.sh
+++ b/.circleci/unittest/linux_torchrec/scripts/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+unset PYTORCH_VERSION
+# For unittest, nightly PyTorch is used as the following section,
+# so no need to set PYTORCH_VERSION.
+# In fact, keeping PYTORCH_VERSION forces us to hardcode PyTorch version in config.
+
+set -e
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env
+
+if [ "${CU_VERSION:-}" == cpu ] ; then
+    version="cpu"
+    echo "Using cpu build"
+else
+    if [[ ${#CU_VERSION} -eq 4 ]]; then
+        CUDA_VERSION="${CU_VERSION:2:1}.${CU_VERSION:3:1}"
+    elif [[ ${#CU_VERSION} -eq 5 ]]; then
+        CUDA_VERSION="${CU_VERSION:2:2}.${CU_VERSION:4:1}"
+    fi
+    echo "Using CUDA $CUDA_VERSION as determined by CU_VERSION ($CU_VERSION)"
+    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+fi
+
+# submodules
+git submodule sync && git submodule update --init --recursive
+
+printf "Installing PyTorch with %s\n" "${CU_VERSION}"
+if [ "${CU_VERSION:-}" == cpu ] ; then
+    pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+else
+    pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+fi
+
+# smoke test
+python -c "import functorch"
+
+# install torchsnapshot nightly
+pip3 install torchsnapshot-nightly torchrec-nightly
+
+python -c "from torchrec import KeyedJaggedTensor"
+python -c "import torchsnapshot"
+
+printf "* Installing tensordict\n"
+pip3 install -e .

--- a/.circleci/unittest/linux_torchrec/scripts/post_process.sh
+++ b/.circleci/unittest/linux_torchrec/scripts/post_process.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env

--- a/.circleci/unittest/linux_torchrec/scripts/run-clang-format.py
+++ b/.circleci/unittest/linux_torchrec/scripts/run-clang-format.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+"""
+MIT License
+
+Copyright (c) 2017 Guillaume Papin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+A wrapper script around clang-format, suitable for linting multiple files
+and to use for continuous integration.
+
+This is an alternative API for the clang-format command line.
+It runs over multiple files and directories in parallel.
+A diff output is produced and a sensible exit code is returned.
+
+"""
+
+import argparse
+import difflib
+import fnmatch
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import traceback
+from functools import partial
+
+try:
+    from subprocess import DEVNULL  # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
+
+DEFAULT_EXTENSIONS = "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,cu"
+
+
+class ExitStatus:
+    SUCCESS = 0
+    DIFF = 1
+    TROUBLE = 2
+
+
+def list_files(files, recursive=False, extensions=None, exclude=None):
+    if extensions is None:
+        extensions = []
+    if exclude is None:
+        exclude = []
+
+    out = []
+    for file in files:
+        if recursive and os.path.isdir(file):
+            for dirpath, dnames, fnames in os.walk(file):
+                fpaths = [os.path.join(dirpath, fname) for fname in fnames]
+                for pattern in exclude:
+                    # os.walk() supports trimming down the dnames list
+                    # by modifying it in-place,
+                    # to avoid unnecessary directory listings.
+                    dnames[:] = [
+                        x
+                        for x in dnames
+                        if not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)
+                    ]
+                    fpaths = [x for x in fpaths if not fnmatch.fnmatch(x, pattern)]
+                for f in fpaths:
+                    ext = os.path.splitext(f)[1][1:]
+                    if ext in extensions:
+                        out.append(f)
+        else:
+            out.append(file)
+    return out
+
+
+def make_diff(file, original, reformatted):
+    return list(
+        difflib.unified_diff(
+            original,
+            reformatted,
+            fromfile=f"{file}\t(original)",
+            tofile=f"{file}\t(reformatted)",
+            n=3,
+        )
+    )
+
+
+class DiffError(Exception):
+    def __init__(self, message, errs=None):
+        super().__init__(message)
+        self.errs = errs or []
+
+
+class UnexpectedError(Exception):
+    def __init__(self, message, exc=None):
+        super().__init__(message)
+        self.formatted_traceback = traceback.format_exc()
+        self.exc = exc
+
+
+def run_clang_format_diff_wrapper(args, file):
+    try:
+        ret = run_clang_format_diff(args, file)
+        return ret
+    except DiffError:
+        raise
+    except Exception as e:
+        raise UnexpectedError(f"{file}: {e.__class__.__name__}: {e}", e)
+
+
+def run_clang_format_diff(args, file):
+    try:
+        with open(file, encoding="utf-8") as f:
+            original = f.readlines()
+    except OSError as exc:
+        raise DiffError(str(exc))
+    invocation = [args.clang_format_executable, file]
+
+    # Use of utf-8 to decode the process output.
+    #
+    # Hopefully, this is the correct thing to do.
+    #
+    # It's done due to the following assumptions (which may be incorrect):
+    # - clang-format will returns the bytes read from the files as-is,
+    #   without conversion, and it is already assumed that the files use utf-8.
+    # - if the diagnostics were internationalized, they would use utf-8:
+    #   > Adding Translations to Clang
+    #   >
+    #   > Not possible yet!
+    #   > Diagnostic strings should be written in UTF-8,
+    #   > the client can translate to the relevant code page if needed.
+    #   > Each translation completely replaces the format string
+    #   > for the diagnostic.
+    #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+
+    try:
+        proc = subprocess.Popen(
+            invocation,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise DiffError(
+            f"Command '{subprocess.list2cmdline(invocation)}' failed to start: {exc}"
+        )
+    proc_stdout = proc.stdout
+    proc_stderr = proc.stderr
+
+    # hopefully the stderr pipe won't get full and block the process
+    outs = list(proc_stdout.readlines())
+    errs = list(proc_stderr.readlines())
+    proc.wait()
+    if proc.returncode:
+        raise DiffError(
+            "Command '{}' returned non-zero exit status {}".format(
+                subprocess.list2cmdline(invocation), proc.returncode
+            ),
+            errs,
+        )
+    return make_diff(file, original, outs), errs
+
+
+def bold_red(s):
+    return "\x1b[1m\x1b[31m" + s + "\x1b[0m"
+
+
+def colorize(diff_lines):
+    def bold(s):
+        return "\x1b[1m" + s + "\x1b[0m"
+
+    def cyan(s):
+        return "\x1b[36m" + s + "\x1b[0m"
+
+    def green(s):
+        return "\x1b[32m" + s + "\x1b[0m"
+
+    def red(s):
+        return "\x1b[31m" + s + "\x1b[0m"
+
+    for line in diff_lines:
+        if line[:4] in ["--- ", "+++ "]:
+            yield bold(line)
+        elif line.startswith("@@ "):
+            yield cyan(line)
+        elif line.startswith("+"):
+            yield green(line)
+        elif line.startswith("-"):
+            yield red(line)
+        else:
+            yield line
+
+
+def print_diff(diff_lines, use_color):
+    if use_color:
+        diff_lines = colorize(diff_lines)
+    sys.stdout.writelines(diff_lines)
+
+
+def print_trouble(prog, message, use_colors):
+    error_text = "error:"
+    if use_colors:
+        error_text = bold_red(error_text)
+    print(f"{prog}: {error_text} {message}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--clang-format-executable",
+        metavar="EXECUTABLE",
+        help="path to the clang-format executable",
+        default="clang-format",
+    )
+    parser.add_argument(
+        "--extensions",
+        help=f"comma separated list of file extensions (default: {DEFAULT_EXTENSIONS})",
+        default=DEFAULT_EXTENSIONS,
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="run recursively over directories",
+    )
+    parser.add_argument("files", metavar="file", nargs="+")
+    parser.add_argument("-q", "--quiet", action="store_true")
+    parser.add_argument(
+        "-j",
+        metavar="N",
+        type=int,
+        default=0,
+        help="run N clang-format jobs in parallel (default number of cpus + 1)",
+    )
+    parser.add_argument(
+        "--color",
+        default="auto",
+        choices=["auto", "always", "never"],
+        help="show colored diff (default: auto)",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        metavar="PATTERN",
+        action="append",
+        default=[],
+        help="exclude paths matching the given glob-like pattern(s) from recursive search",
+    )
+
+    args = parser.parse_args()
+
+    # use default signal handling, like diff return SIGINT value on ^C
+    # https://bugs.python.org/issue14229#msg156446
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.SIGPIPE
+    except AttributeError:
+        # compatibility, SIGPIPE does not exist on Windows
+        pass
+    else:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    colored_stdout = False
+    colored_stderr = False
+    if args.color == "always":
+        colored_stdout = True
+        colored_stderr = True
+    elif args.color == "auto":
+        colored_stdout = sys.stdout.isatty()
+        colored_stderr = sys.stderr.isatty()
+
+    version_invocation = [args.clang_format_executable, "--version"]
+    try:
+        subprocess.check_call(version_invocation, stdout=DEVNULL)
+    except subprocess.CalledProcessError as e:
+        print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+    except OSError as e:
+        print_trouble(
+            parser.prog,
+            f"Command '{subprocess.list2cmdline(version_invocation)}' failed to start: {e}",
+            use_colors=colored_stderr,
+        )
+        return ExitStatus.TROUBLE
+
+    retcode = ExitStatus.SUCCESS
+    files = list_files(
+        args.files,
+        recursive=args.recursive,
+        exclude=args.exclude,
+        extensions=args.extensions.split(","),
+    )
+
+    if not files:
+        return
+
+    njobs = args.j
+    if njobs == 0:
+        njobs = multiprocessing.cpu_count() + 1
+    njobs = min(len(files), njobs)
+
+    if njobs == 1:
+        # execute directly instead of in a pool,
+        # less overhead, simpler stacktraces
+        it = (run_clang_format_diff_wrapper(args, file) for file in files)
+        pool = None
+    else:
+        pool = multiprocessing.Pool(njobs)
+        it = pool.imap_unordered(partial(run_clang_format_diff_wrapper, args), files)
+    while True:
+        try:
+            outs, errs = next(it)
+        except StopIteration:
+            break
+        except DiffError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            retcode = ExitStatus.TROUBLE
+            sys.stderr.writelines(e.errs)
+        except UnexpectedError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            sys.stderr.write(e.formatted_traceback)
+            retcode = ExitStatus.TROUBLE
+            # stop at the first unexpected error,
+            # something could be very wrong,
+            # don't process all files unnecessarily
+            if pool:
+                pool.terminate()
+            break
+        else:
+            sys.stderr.writelines(errs)
+            if outs == []:
+                continue
+            if not args.quiet:
+                print_diff(outs, use_color=colored_stdout)
+            if retcode == ExitStatus.SUCCESS:
+                retcode = ExitStatus.DIFF
+    return retcode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.circleci/unittest/linux_torchrec/scripts/run_test.sh
+++ b/.circleci/unittest/linux_torchrec/scripts/run_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env
+
+export PYTORCH_TEST_WITH_SLOW='1'
+python -m torch.utils.collect_env
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
+
+root_dir="$(git rev-parse --show-toplevel)"
+env_dir="${root_dir}/env"
+lib_dir="${env_dir}/lib"
+
+# solves ImportError: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$lib_dir
+export MKL_THREADING_LAYER=GNU
+
+pytest test/smoke_test.py -v --durations 20
+pytest --instafail -v --durations 20

--- a/.circleci/unittest/linux_torchrec/scripts/setup_env.sh
+++ b/.circleci/unittest/linux_torchrec/scripts/setup_env.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This script is for setting up environment in which unit test is ran.
+# To speed up the CI time, the resulting environment is cached.
+#
+# Do not install PyTorch and torchvision here, otherwise they also get cached.
+
+set -e
+
+this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
+root_dir="$(git rev-parse --show-toplevel)"
+conda_dir="${root_dir}/conda"
+env_dir="${root_dir}/env"
+lib_dir="${env_dir}/lib"
+
+cd "${root_dir}"
+
+case "$(uname -s)" in
+    Darwin*) os=MacOSX;;
+    *) os=Linux
+esac
+
+# 1. Install conda at ./conda
+if [ ! -d "${conda_dir}" ]; then
+    printf "* Installing conda\n"
+    wget -O miniconda.sh "http://repo.continuum.io/miniconda/Miniconda3-latest-${os}-x86_64.sh"
+    bash ./miniconda.sh -b -f -p "${conda_dir}"
+fi
+eval "$(${conda_dir}/bin/conda shell.bash hook)"
+
+# 2. Create test environment at ./env
+printf "python: ${PYTHON_VERSION}\n"
+if [ ! -d "${env_dir}" ]; then
+    printf "* Creating a test environment\n"
+    conda create --prefix "${env_dir}" -y python="$PYTHON_VERSION"
+fi
+conda activate "${env_dir}"
+
+# 3. Install Conda dependencies
+printf "* Installing dependencies (except PyTorch)\n"
+echo "  - python=${PYTHON_VERSION}" >> "${this_dir}/environment.yml"
+cat "${this_dir}/environment.yml"
+
+pip install pip --upgrade
+
+conda env update --file "${this_dir}/environment.yml" --prune

--- a/tensordict/metatensor.py
+++ b/tensordict/metatensor.py
@@ -13,8 +13,20 @@ import numpy as np
 import torch
 
 from tensordict.memmap import MemmapTensor
-from tensordict.utils import DEVICE_TYPING, INDEX_TYPING
-from tensordict.utils import _getitem_batch_size, _get_shape
+from tensordict.utils import DEVICE_TYPING, INDEX_TYPING, _shape, _is_meta, _dtype
+from tensordict.utils import _getitem_batch_size
+
+try:
+    from torchrec import KeyedJaggedTensor
+
+    _has_torchrec = True
+except ImportError as err:
+    _has_torchrec = False
+
+    class KeyedJaggedTensor:
+        pass
+
+    TORCHREC_ERR = str(err)
 
 META_HANDLED_FUNCTIONS = dict()
 
@@ -69,22 +81,25 @@ class MetaTensor:
         _is_shared: Optional[bool] = None,
         _is_memmap: Optional[bool] = None,
         _is_tensordict: Optional[bool] = None,
+        _is_kjt: Optional[bool] = None,
         _repr_tensordict: Optional[str] = None,
     ):
         if len(shape) == 1 and not isinstance(shape[0], (Number,)):
             tensor = shape[0]
-            shape = _get_shape(tensor)
+            shape = _shape(tensor)
             if _is_shared is None:
                 _is_shared = tensor.is_shared()
             if _is_memmap is None:
                 _is_memmap = isinstance(tensor, MemmapTensor)
+            if _is_kjt is None:
+                _is_kjt = isinstance(tensor, KeyedJaggedTensor)
             # FIXME: using isinstance(tensor, TensorDictBase) would likely be
             # better here, but creates circular import without more refactoring
-            device = tensor.device if not tensor.is_meta else device
+            device = tensor.device if not _is_meta(tensor) else device
             if _is_tensordict is None:
                 _is_tensordict = not _is_memmap and not isinstance(tensor, torch.Tensor)
             if not _is_tensordict:
-                dtype = tensor.dtype
+                dtype = _dtype(tensor)
             else:
                 dtype = None
                 _repr_tensordict = str(tensor)
@@ -105,12 +120,15 @@ class MetaTensor:
         self._numel = None
         self._is_shared = bool(_is_shared)
         self._is_memmap = bool(_is_memmap)
+        self._is_kjt = bool(_is_kjt)
         self._is_tensordict = bool(_is_tensordict)
         self._repr_tensordict = _repr_tensordict
         if _is_tensordict:
             name = "TensorDict"
         elif _is_memmap:
             name = "MemmapTensor"
+        elif _is_kjt:
+            name = "KeyedJaggedTensor"
         elif _is_shared and device.type != "cuda":
             name = "SharedTensor"
         else:
@@ -153,6 +171,9 @@ class MetaTensor:
 
     def is_tensordict(self) -> bool:
         return self._is_tensordict
+
+    def is_kjt(self) -> bool:
+        return self._is_kjt
 
     def numel(self) -> int:
         if self._numel is None:

--- a/tensordict/metatensor.py
+++ b/tensordict/metatensor.py
@@ -14,16 +14,13 @@ import torch
 
 from tensordict.memmap import MemmapTensor
 from tensordict.utils import (
-    _get_shape,
-    _getitem_batch_size,
     DEVICE_TYPING,
     INDEX_TYPING,
+    _getitem_batch_size,
     _shape,
     _is_meta,
     _dtype,
-    _getitem_batch_size,
 )
-from tensordict.utils import _getitem_batch_size
 
 try:
     from torchrec import KeyedJaggedTensor

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -30,6 +30,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    get_args,
 )
 from warnings import warn
 
@@ -78,12 +79,23 @@ except ImportError:
         return False
 
 
+try:
+    from torchrec import KeyedJaggedTensor
+
+    _has_torchrec = True
+except ImportError as err:
+    _has_torchrec = False
+    TORCHREC_ERR = str(err)
+
+
 TD_HANDLED_FUNCTIONS: Dict = dict()
 COMPATIBLE_TYPES = Union[
     Tensor,
     MemmapTensor,
 ]  # None? # leaves space for TensorDictBase
 
+if _has_torchrec:
+    COMPATIBLE_TYPES = Union[get_args(COMPATIBLE_TYPES) + (KeyedJaggedTensor,)]
 _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-only or string-free indices are supported."
 
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -39,6 +39,8 @@ import torch
 from torch import Tensor
 from torch.utils._pytree import tree_map
 
+from tensordict.utils import _ndimension, _shape, _is_shared, _get_item
+
 try:
     from torch.jit._shape_functions import infer_size_impl
 except ImportError:
@@ -85,6 +87,10 @@ try:
     _has_torchrec = True
 except ImportError as err:
     _has_torchrec = False
+
+    class KeyedJaggedTensor:
+        pass
+
     TORCHREC_ERR = str(err)
 
 
@@ -134,7 +140,16 @@ class _TensorDictKeysView:
 
         for key, value in items_iter:
             full_key = self._combine_keys(prefix, key)
-            if isinstance(value, TensorDictBase) and self.include_nested:
+            if (
+                isinstance(
+                    value,
+                    (
+                        TensorDictBase,
+                        KeyedJaggedTensor,
+                    ),
+                )
+                and self.include_nested
+            ):
                 subkeys = tuple(
                     self._iter_helper(
                         value,
@@ -161,6 +176,8 @@ class _TensorDictKeysView:
             return tensordict._tensordict.items()
         elif isinstance(tensordict, LazyStackedTensorDict):
             return _iter_items_lazystack(tensordict)
+        elif isinstance(tensordict, KeyedJaggedTensor):
+            return tuple((key, tensordict[key]) for key in tensordict.keys())
         elif isinstance(tensordict, _CustomOpTensorDict):
             # it's possible that a TensorDict contains a nested LazyStackedTensorDict,
             # or _CustomOpTensorDict, so as we iterate through the contents we need to
@@ -180,14 +197,23 @@ class _TensorDictKeysView:
             elif len(key) > 1:
                 if self.include_nested:
                     if key[0] in self:
-                        val = self.tensordict.get(key[0])
+                        meta_val = self.tensordict._get_meta(key[0])
                         # TODO: SavedTensorDict currently doesn't support nested memebership checks
-                        include_nested = self.include_nested and not isinstance(
-                            val, SavedTensorDict
-                        )
-                        return isinstance(val, TensorDictBase) and key[1:] in val.keys(
+                        include_nested = self.include_nested  # and not isinstance(
+                        #     val, SavedTensorDict
+                        # )
+                        _tensordict_nested = meta_val.is_tensordict() and key[
+                            1:
+                        ] in self.tensordict.get(key[0]).keys(
                             include_nested=include_nested
                         )
+                        _kjt = (
+                            meta_val.is_kjt()
+                            and len(key) == 2
+                            and key[1] in self.tensordict.get(key[0]).keys()
+                        )
+                        return _kjt or _tensordict_nested
+
                     return False
             if all(isinstance(subkey, str) for subkey in key):
                 raise TypeError(
@@ -744,7 +770,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         if check_shared:
             raise DeprecationWarning("check_shared is not authorized anymore")
 
-        if check_tensor_shape and tensor.shape[: self.batch_dims] != self.batch_size:
+        if check_tensor_shape and _shape(tensor)[: self.batch_dims] != self.batch_size:
             # if TensorDict, let's try to map it to the desired shape
             if (
                 isinstance(tensor, TensorDictBase)
@@ -756,12 +782,12 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                 raise RuntimeError(
                     f"batch dimension mismatch, got self.batch_size"
                     f"={self.batch_size} and tensor.shape[:self.batch_dims]"
-                    f"={tensor.shape[: self.batch_dims]} with tensor {tensor}"
+                    f"={_shape(tensor)[: self.batch_dims]} with tensor {tensor}"
                 )
 
         # minimum ndimension is 1
-        if tensor.ndimension() == self.ndimension() and not isinstance(
-            tensor, TensorDictBase
+        if _ndimension(tensor) == self.ndimension() and not isinstance(
+            tensor, (TensorDictBase, KeyedJaggedTensor)
         ):
             tensor = tensor.unsqueeze(-1)
 
@@ -1219,7 +1245,11 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def _check_new_batch_size(self, new_size: torch.Size):
         n = len(new_size)
         for key, meta_tensor in self.items_meta():
-            if (meta_tensor.ndimension() <= n) or (meta_tensor.shape[:n] != new_size):
+            if not meta_tensor.is_kjt():
+                c1 = meta_tensor.ndimension() <= n
+            else:
+                c1 = meta_tensor.ndimension() < n
+            if c1 or (meta_tensor.shape[:n] != new_size):
                 if meta_tensor.ndimension() == n and meta_tensor.shape == new_size:
                     raise RuntimeError(
                         "TensorDict requires tensors that have at least one more "
@@ -1730,9 +1760,9 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     def _index_tensordict(self, idx: INDEX_TYPING):
         return TensorDict(
-            source={key: item[idx] for key, item in self.items()},
+            source={key: _get_item(item, idx) for key, item in self.items()},
             _meta_source={
-                key: item[idx]
+                key: _get_item(item, idx)
                 for key, item in self.items_meta(make_unset=False)
                 if not item.is_tensordict()
             },
@@ -2142,8 +2172,8 @@ class TensorDict(TensorDictBase):
         is_shared = (
             self._is_shared
             if self._is_shared is not None
-            else proc_value.is_shared()
-            if isinstance(proc_value, (TensorDictBase, MemmapTensor))
+            else _is_shared(proc_value)
+            if isinstance(proc_value, (TensorDictBase, MemmapTensor, KeyedJaggedTensor))
             or not is_batchedtensor(proc_value)
             else False
         )
@@ -2202,10 +2232,10 @@ class TensorDict(TensorDictBase):
 
     # Checks
     def _check_is_shared(self) -> bool:
-        share_list = [value.is_shared() for key, value in self.items_meta()]
+        share_list = [_is_shared(value) for key, value in self.items_meta()]
         if any(share_list) and not all(share_list):
             shared_str = ", ".join(
-                [f"{key}: {value.is_shared()}" for key, value in self.items_meta()]
+                [f"{key}: {_is_shared(value)}" for key, value in self.items_meta()]
             )
             raise RuntimeError(
                 f"tensors must be either all shared or not, but mixed "
@@ -2238,7 +2268,9 @@ class TensorDict(TensorDictBase):
 
     def _index_tensordict(self, idx: INDEX_TYPING):
         self_copy = copy(self)
-        self_copy._tensordict = {key: item[idx] for key, item in self.items()}
+        self_copy._tensordict = {
+            key: _get_item(item, idx) for key, item in self.items()
+        }
         self_copy._dict_meta = KeyDependentDefaultDict(self_copy._make_meta)
         self_copy._batch_size = _getitem_batch_size(self_copy.batch_size, idx)
         self_copy._device = self.device
@@ -2322,7 +2354,7 @@ class TensorDict(TensorDictBase):
 
         if self._is_shared is None:
             try:
-                self._is_shared = value.is_shared()
+                self._is_shared = _is_shared(value)
             except NotImplementedError:
                 # when running functorch, a NotImplementedError may be raised
                 pass
@@ -2517,7 +2549,10 @@ class TensorDict(TensorDictBase):
         if key in self.keys(include_nested=True):
             if isinstance(key, tuple):
                 if len(key) > 1:
-                    return self.get(key[0]).get(key[1:])
+                    first_lev = self.get(key[0])
+                    if len(key) == 2 and isinstance(first_lev, KeyedJaggedTensor):
+                        return first_lev[key[1]]
+                    return first_lev.get(key[1:])
                 return self.get(key[0])
             return self._tensordict[key]
         else:
@@ -3117,8 +3152,8 @@ def pad(tensordict: TensorDictBase, pad_size: Sequence[int], value: float = 0.0)
     out = TensorDict({}, new_batch_size, device=tensordict.device, _run_checks=False)
     for key, tensor in tensordict.items():
         cur_pad = reverse_pad
-        if len(pad_size) < len(tensor.shape) * 2:
-            cur_pad = [0] * (len(tensor.shape) * 2 - len(pad_size)) + reverse_pad
+        if len(pad_size) < len(_shape(tensor)) * 2:
+            cur_pad = [0] * (len(_shape(tensor)) * 2 - len(pad_size)) + reverse_pad
 
         if isinstance(tensor, TensorDictBase):
             padded = pad(tensor, pad_size, value)
@@ -3322,7 +3357,7 @@ torch.Size([3, 2])
         else:
             tensor_expand = torch.zeros(
                 *parent.batch_size,
-                *tensor.shape[self.batch_dims :],
+                *_shape(tensor)[self.batch_dims :],
                 dtype=tensor.dtype,
                 device=self.device,
             )
@@ -3361,10 +3396,10 @@ torch.Size([3, 2])
                 raise KeyError(f"key {key} not found in {self.keys()}")
             if (
                 not isinstance(tensor, dict)
-                and tensor.shape[: self.batch_dims] != self.batch_size
+                and _shape(tensor)[: self.batch_dims] != self.batch_size
             ):
                 raise RuntimeError(
-                    f"tensor.shape={tensor.shape[:self.batch_dims]} and "
+                    f"tensor.shape={_shape(tensor)[:self.batch_dims]} and "
                     f"self.batch_size={self.batch_size} mismatch"
                 )
 
@@ -3867,10 +3902,10 @@ class LazyStackedTensorDict(TensorDictBase):
         if isinstance(tensor, TensorDictBase):
             if tensor.batch_size[: self.batch_dims] != self.batch_size:
                 tensor.batch_size = self.clone(recurse=False).batch_size
-        if self.batch_size != tensor.shape[: self.batch_dims]:
+        if self.batch_size != _shape(tensor)[: self.batch_dims]:
             raise RuntimeError(
                 "Setting tensor to tensordict failed because the shapes "
-                f"mismatch: got tensor.shape = {tensor.shape} and "
+                f"mismatch: got tensor.shape = {_shape(tensor)} and "
                 f"tensordict.batch_size={self.batch_size}"
             )
 
@@ -3897,10 +3932,10 @@ class LazyStackedTensorDict(TensorDictBase):
             if isinstance(tensor, TensorDictBase):
                 if tensor.batch_size[: self.batch_dims] != self.batch_size:
                     tensor.batch_size = self.clone(recurse=False).batch_size
-            if self.batch_size != tensor.shape[: self.batch_dims]:
+            if self.batch_size != _shape(tensor)[: self.batch_dims]:
                 raise RuntimeError(
                     "Setting tensor to tensordict failed because the shapes "
-                    f"mismatch: got tensor.shape = {tensor.shape} and "
+                    f"mismatch: got tensor.shape = {_shape(tensor)} and "
                     f"tensordict.batch_size={self.batch_size}"
                 )
             if key not in self.valid_keys:
@@ -3964,7 +3999,7 @@ class LazyStackedTensorDict(TensorDictBase):
             return self._default_get(key, default)
 
         tensors = [td.get(key, default=default) for td in self.tensordicts]
-        shapes = set(tensor.shape for tensor in tensors)
+        shapes = set(_shape(tensor) for tensor in tensors)
         if len(shapes) != 1:
             raise RuntimeError(
                 f"found more than one unique shape in the tensors to be "
@@ -5162,7 +5197,7 @@ class _ViewedTensorDict(_CustomOpTensorDict):
 
     def _update_inv_op_kwargs(self, tensor: Tensor) -> Dict:
         size = list(self.inv_op_kwargs.get("size"))
-        size += list(tensor.shape[self.batch_dims :])
+        size += list(_shape(tensor)[self.batch_dims :])
         new_dim = torch.Size(size)
         new_dict = deepcopy(self.inv_op_kwargs)
         new_dict.update({"size": new_dim})
@@ -5244,7 +5279,7 @@ class _PermutedTensorDict(_CustomOpTensorDict):
 
     def _update_inv_op_kwargs(self, tensor: Tensor) -> Dict[str, Any]:
         new_dims = self.add_missing_dims(
-            self._source.batch_dims + len(tensor.shape[self.batch_dims :]),
+            self._source.batch_dims + len(_shape(tensor)[self.batch_dims :]),
             self.custom_op_kwargs["dims"],
         )
         kwargs = deepcopy(self.custom_op_kwargs)
@@ -5316,13 +5351,15 @@ _accepted_classes = (
     MemmapTensor,
     TensorDictBase,
 )
+if _has_torchrec:
+    _accepted_classes = _accepted_classes + (KeyedJaggedTensor,)
 
 
 def _expand_to_match_shape(parent_batch_size, tensor, self_batch_dims, self_device):
     if hasattr(tensor, "dtype"):
         return torch.zeros(
             *parent_batch_size,
-            *tensor.shape[self_batch_dims:],
+            *_shape(tensor)[self_batch_dims:],
             dtype=tensor.dtype,
             device=self_device,
         )
@@ -5330,39 +5367,10 @@ def _expand_to_match_shape(parent_batch_size, tensor, self_batch_dims, self_devi
         # tensordict
         out = TensorDict(
             {},
-            [*parent_batch_size, *tensor.shape[self_batch_dims:]],
+            [*parent_batch_size, *_shape(tensor)[self_batch_dims:]],
             device=self_device,
         )
         return out
-
-
-# seems like we can do without registering in pytree -- which requires us to create a new TensorDict,
-# an operation that does not come for free
-
-# def _flatten_tensordict(tensordict):
-#     return tensordict, tuple()
-#     # keys, values = list(zip(*tensordict.items()))
-#     # # represent values as batched tensors
-#     # vmap_level = 0
-#     # in_dim
-#     # values = [_add_batch_dim(value, in_dim, vmap_level)
-#     # return list(values), (list(keys), tensordict.device, tensordict.batch_size)
-#
-# def _unflatten_tensordict(values, context):
-#     return values
-#     # values = [_unwrap_value(value) for value in values]
-#     # keys, device, batch_size = context
-#     # print(values[0].shape)
-#     # return TensorDict(
-#     #     {key: value for key, value in zip(keys, values)},
-#     #     [],
-#     #     # [*new_batch_sizes[0], *batch_size],
-#     #     # new_batch_sizes[0],
-#     #     device=device
-#     # )
-#
-#
-# _register_pytree_node(TensorDict, _flatten_tensordict, _unflatten_tensordict)
 
 
 def make_tensordict(

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -233,11 +233,6 @@ def infer_size_impl(shape: List[int], numel: int) -> List[int]:
     return out
 
 
-def _get_shape(value):
-    # we call it "legacy code"
-    return value.shape
-
-
 def _unwrap_value(value):
     # batch_dims = value.ndimension()
     if not isinstance(value, torch.Tensor):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -550,9 +550,7 @@ def _ndimension(tensor: torch.Tensor):
     elif isinstance(tensor, KeyedJaggedTensor):
         return 1
     else:
-        raise NotImplementedError(
-            f"_ndimension not implemented for inputs of type {type(tensor)}"
-        )
+        return tensor.ndimension()
 
 
 def _shape(tensor: torch.Tensor):
@@ -561,9 +559,7 @@ def _shape(tensor: torch.Tensor):
     elif isinstance(tensor, KeyedJaggedTensor):
         return torch.Size([len(tensor.lengths()) // len(tensor.keys())])
     else:
-        raise NotImplementedError(
-            f"_shape not implemented for inputs of type {type(tensor)}"
-        )
+        return tensor.shape
 
 
 def _is_shared(tensor: torch.Tensor):
@@ -572,9 +568,7 @@ def _is_shared(tensor: torch.Tensor):
     elif isinstance(tensor, KeyedJaggedTensor):
         return False
     else:
-        raise NotImplementedError(
-            f"_is_shared not implemented for inputs of type {type(tensor)}"
-        )
+        return tensor.is_shared()
 
 
 def _is_meta(tensor: torch.Tensor):
@@ -583,9 +577,7 @@ def _is_meta(tensor: torch.Tensor):
     elif isinstance(tensor, KeyedJaggedTensor):
         return False
     else:
-        raise NotImplementedError(
-            f"_is_meta not implemented for inputs of type {type(tensor)}"
-        )
+        return tensor.is_meta
 
 
 def _dtype(tensor: torch.Tensor):
@@ -594,9 +586,7 @@ def _dtype(tensor: torch.Tensor):
     elif isinstance(tensor, KeyedJaggedTensor):
         return tensor._values.dtype
     else:
-        raise NotImplementedError(
-            f"_dtype not implemented for inputs of type {type(tensor)}"
-        )
+        return tensor.dtype
 
 
 def _get_item(tensor: torch.Tensor, index):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -536,12 +536,15 @@ def setitem_keyedjaggedtensor(
     tensor_weights[new_index_to_keep] = weights_to_keep
     tensor_weights[new_index_new_elts] = new_weights
 
-    return KeyedJaggedTensor(
+    kjt = KeyedJaggedTensor(
         values=tensor,
         keys=source_keys,
         weights=tensor_weights,
         lengths=_lengths_out,
     )
+    for k, item in kjt.__dict__.items():
+        source.__dict__[k] = item
+    return source
 
 
 def _ndimension(tensor: torch.Tensor):
@@ -596,3 +599,24 @@ def _get_item(tensor: torch.Tensor, index):
         return index_keyedjaggedtensor(tensor, index)
     else:
         return tensor[index]
+
+
+def _set_item(tensor: torch.Tensor, value, index):
+    if isinstance(tensor, torch.Tensor):
+        tensor[index] = value
+        return tensor
+    elif isinstance(tensor, KeyedJaggedTensor):
+        tensor = setitem_keyedjaggedtensor(tensor, index, value)
+        return tensor
+    else:
+        tensor[index] = value
+        return tensor
+
+
+def _requires_grad(tensor: torch.Tensor):
+    if isinstance(tensor, torch.Tensor):
+        return tensor.requires_grad
+    elif isinstance(tensor, KeyedJaggedTensor):
+        return tensor._values.requires_grad
+    else:
+        return tensor.requires_grad

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -393,8 +393,8 @@ def _normalize_key(key: NESTED_KEY) -> NESTED_KEY:
 
 
 def index_keyedjaggedtensor(
-    kjt: "torchrec.KeyedJaggedTensor", index: torch.Tensor
-):  # noqa
+    kjt: "torchrec.KeyedJaggedTensor", index: torch.Tensor  # noqa
+):
     """Indexes a KeyedJaggedTensor along the batch dimension.
 
     Args:

--- a/test/test_torchrec.py
+++ b/test/test_torchrec.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+
+import pytest
+import torch
+from tensordict.utils import index_keyedjaggedtensor
+from torchrec import KeyedJaggedTensor
+
+
+@pytest.mark.parametrize("index", [[0, 2], 2, torch.tensor([0, 2]), range(0, 3, 2)])
+def test_kjt_indexing(index):
+    values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0])
+    weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5, 1.0, 1.0, 1.0])
+    keys = ["index_0", "index_1", "index_2"]
+    offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8, 9, 10, 11])
+
+    jag_tensor = KeyedJaggedTensor(
+        values=values,
+        keys=keys,
+        offsets=offsets,
+        weights=weights,
+    )
+    j0 = jag_tensor["index_0"]
+    j1 = jag_tensor["index_1"]
+    j2 = jag_tensor["index_2"]
+    ikjt = index_keyedjaggedtensor(jag_tensor, index)
+    assert (
+        ikjt["index_0"].to_padded_dense(),
+        j0.to_padded_dense() == j0.to_padded_dense()[:, index],
+    ).all()
+    assert (
+        ikjt["index_1"].to_padded_dense(),
+        j1.to_padded_dense() == j1.to_padded_dense()[:, index],
+    ).all()
+    assert (
+        ikjt["index_2"].to_padded_dense(),
+        j2.to_padded_dense() == j2.to_padded_dense()[:, index],
+    ).all()
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_torchrec.py
+++ b/test/test_torchrec.py
@@ -8,9 +8,17 @@ import argparse
 import pytest
 import torch
 from tensordict.utils import index_keyedjaggedtensor
-from torchrec import KeyedJaggedTensor
+
+try:
+    from torchrec import KeyedJaggedTensor
+
+    _has_torchrec = True
+except ImportError as err:
+    _has_torchrec = False
+    # TORCHREC_ERR = str(err)
 
 
+@pytest.mark.skipif(not _has_torchrec, reason="torchrec not found.")
 @pytest.mark.parametrize("index", [[0, 2], 2, torch.tensor([0, 2]), range(0, 3, 2)])
 def test_kjt_indexing(index):
     values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0])

--- a/test/test_torchrec.py
+++ b/test/test_torchrec.py
@@ -37,7 +37,7 @@ def _get_kjt():
 @pytest.mark.skipif(not _has_torchrec, reason="torchrec not found.")
 class TestKJT:
     @pytest.mark.parametrize("index", [[0, 2], torch.tensor([0, 2]), range(0, 3, 2)])
-    def test_kjt_indexing(index):
+    def test_kjt_indexing(self, index):
         jag_tensor = _get_kjt()
         j0 = jag_tensor["index_0"]
         j1 = jag_tensor["index_1"]

--- a/test/test_torchrec.py
+++ b/test/test_torchrec.py
@@ -7,6 +7,7 @@ import argparse
 
 import pytest
 import torch
+from tensordict import TensorDict
 from tensordict.utils import index_keyedjaggedtensor
 
 try:
@@ -18,9 +19,7 @@ except ImportError as err:
     # TORCHREC_ERR = str(err)
 
 
-@pytest.mark.skipif(not _has_torchrec, reason="torchrec not found.")
-@pytest.mark.parametrize("index", [[0, 2], 2, torch.tensor([0, 2]), range(0, 3, 2)])
-def test_kjt_indexing(index):
+def _get_kjt():
     values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0])
     weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5, 1.0, 1.0, 1.0])
     keys = ["index_0", "index_1", "index_2"]
@@ -32,19 +31,70 @@ def test_kjt_indexing(index):
         offsets=offsets,
         weights=weights,
     )
-    j0 = jag_tensor["index_0"]
-    j1 = jag_tensor["index_1"]
-    j2 = jag_tensor["index_2"]
-    ikjt = index_keyedjaggedtensor(jag_tensor, index)
-    assert (
-        ikjt["index_0"].to_padded_dense() == j0.to_padded_dense()[:, index]
-    ).all()
-    assert (
-        ikjt["index_1"].to_padded_dense() == j1.to_padded_dense()[:, index]
-    ).all()
-    assert (
-        ikjt["index_2"].to_padded_dense() == j2.to_padded_dense()[:, index]
-    ).all()
+    return jag_tensor
+
+
+@pytest.mark.skipif(not _has_torchrec, reason="torchrec not found.")
+class TestKJT:
+    @pytest.mark.parametrize("index", [[0, 2], torch.tensor([0, 2]), range(0, 3, 2)])
+    def test_kjt_indexing(index):
+        jag_tensor = _get_kjt()
+        j0 = jag_tensor["index_0"]
+        j1 = jag_tensor["index_1"]
+        j2 = jag_tensor["index_2"]
+        ikjt = index_keyedjaggedtensor(jag_tensor, index)
+        assert (
+            ikjt["index_0"].to_padded_dense() == j0.to_padded_dense()[:, index]
+        ).all()
+        assert (
+            ikjt["index_1"].to_padded_dense() == j1.to_padded_dense()[:, index]
+        ).all()
+        assert (
+            ikjt["index_2"].to_padded_dense() == j2.to_padded_dense()[:, index]
+        ).all()
+
+    def test_td_build(self):
+        jag_tensor = _get_kjt()
+        _ = TensorDict({}, [])
+        _ = TensorDict({"b": jag_tensor}, [])
+        _ = TensorDict({"b": jag_tensor}, [3])
+
+    def test_td_rep(self):
+        jag_tensor = _get_kjt()
+        td = TensorDict({"b": jag_tensor}, [])
+        assert (
+            str(td)
+            == """TensorDict(
+    fields={
+        b: KeyedJaggedTensor(torch.Size([3]), dtype=torch.float32)},
+    batch_size=torch.Size([]),
+    device=None,
+    is_shared=False)"""
+        )
+
+    def test_td_index(self):
+        jag_tensor = _get_kjt()
+        td = TensorDict({"b": jag_tensor}, [3])
+        subtd = td[:2]
+        assert subtd.shape == torch.Size([2])
+        assert subtd["b", "index_0"].to_padded_dense() == torch.tensor(
+            [[1.0, 2.0], [0.0, 0.0]]
+        )
+        subtd = td[[0, 2]]
+        assert subtd.shape == torch.Size([2])
+        assert subtd["b", "index_0"].to_padded_dense() == torch.tensor(
+            [[1.0, 2.0], [3.0, 0.0]]
+        )
+
+    def test_td_change_batch_size(self):
+        jag_tensor = _get_kjt()
+        td = TensorDict({"b": jag_tensor}, [])
+        td.batch_size = [3]
+        with pytest.raises(
+            RuntimeError,
+            match="the tensor b has shape torch.Size([3]) which is incompatible with the new shape torch.Size([4])",
+        ):
+            td.batch_size = [4]
 
 
 if __name__ == "__main__":

--- a/test/test_torchrec.py
+++ b/test/test_torchrec.py
@@ -37,16 +37,13 @@ def test_kjt_indexing(index):
     j2 = jag_tensor["index_2"]
     ikjt = index_keyedjaggedtensor(jag_tensor, index)
     assert (
-        ikjt["index_0"].to_padded_dense(),
-        j0.to_padded_dense() == j0.to_padded_dense()[:, index],
+        ikjt["index_0"].to_padded_dense() == j0.to_padded_dense()[:, index]
     ).all()
     assert (
-        ikjt["index_1"].to_padded_dense(),
-        j1.to_padded_dense() == j1.to_padded_dense()[:, index],
+        ikjt["index_1"].to_padded_dense() == j1.to_padded_dense()[:, index]
     ).all()
     assert (
-        ikjt["index_2"].to_padded_dense(),
-        j2.to_padded_dense() == j2.to_padded_dense()[:, index],
+        ikjt["index_2"].to_padded_dense() == j2.to_padded_dense()[:, index]
     ).all()
 
 


### PR DESCRIPTION
## Description

KeyedJaggedTensor support.

Allows for indexing KJTs along the batch dimension, allowing them to be part of a TensorDict.

```python
>>> values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0])
>>> weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5, 1.0, 1.0, 1.0])
>>> keys = ["index_0", "index_1", "index_2"]
>>> offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8, 9, 10, 11])
>>> jag_tensor = KeyedJaggedTensor(
...    values=values,
...    keys=keys,
...    offsets=offsets,
...    weights=weights,
... )
>>> td = TensorDict({"b": jag_tensor}, [3])
>>> subtd = td[:2]
>>> assert subtd.shape == torch.Size([2])
>>> assert (
...     subtd["b", "index_0"].to_padded_dense()
...         == torch.tensor([[1.0, 2.0], [0.0, 0.0]])
...     ).all()
```
The `__getitem__` and `__setitem__` equivalents are coded (resp `index_keyedjaggedtensor` and `setitem_keyedjaggedtensor`).

Indexing the key of the KJT can also be achieved as nested TDs are indexed:
```
jt = td["b", "index_0"]
```