### PR TITLE
[Feature] In-place functionalisation docstrings + cleanup

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -73,53 +73,55 @@ class TensorDictModule(nn.Module):
     be specified:
 
     Examples:
-        >>> import torch, functorch
+        >>> import torch
         >>> from tensordict import TensorDict
         >>> from tensordict.nn import TensorDictModule
+        >>> from tensordict.nn.functional_modules import make_functional
         >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
         >>> module = torch.nn.GRUCell(4, 8)
-        >>> fmodule, params, buffers = functorch.make_functional_with_buffers(module)
         >>> td_fmodule = TensorDictModule(
-        ...    module=fmodule, in_keys=["input", "hidden"], out_keys=["output"]
+        ...    module=torch.nn.GRUCell(4, 8), in_keys=["input", "hidden"], out_keys=["output"]
         ... )
-        >>> td_functional = td_fmodule(td.clone(), params=params, buffers=buffers)
+        >>> params = make_functional(td_fmodule)
+        >>> td_functional = td_fmodule(td.clone(), params=params)
         >>> print(td_functional)
         TensorDict(
-            fields={input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+            fields={
                 hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 output: Tensor(torch.Size([3, 8]), dtype=torch.float32)},
-            shared=False,
             batch_size=torch.Size([3]),
-            device=cpu)
+            device=None,
+            is_shared=False)
 
     In the stateful case:
         >>> td_module = TensorDictModule(
-        ...    module=module, in_keys=["input", "hidden"], out_keys=["output"]
+        ...    module=torch.nn.GRUCell(4, 8), in_keys=["input", "hidden"], out_keys=["output"]
         ... )
         >>> td_stateful = td_module(td.clone())
         >>> print(td_stateful)
         TensorDict(
-            fields={input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+            fields={
                 hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 output: Tensor(torch.Size([3, 8]), dtype=torch.float32)},
-            shared=False,
             batch_size=torch.Size([3]),
-            device=cpu)
+            device=None,
+            is_shared=False)
 
-    One can use a vmap operator to call the functional module. In this case the tensordict is expanded to match the
-    batch size (i.e. the tensordict isn't modified in-place anymore):
-        >>> # Model ensemble using vmap
-        >>> params_repeat = tuple(param.expand(4, *param.shape).contiguous().normal_() for param in params)
-        >>> buffers_repeat = tuple(param.expand(4, *param.shape).contiguous().normal_() for param in buffers)
-        >>> td_vmap = td_fmodule(td.clone(), params=params_repeat, buffers=buffers_repeat, vmap=True)
+    One can use a vmap operator to call the functional module.
+        >>> from functorch import vmap
+        >>> params_repeat = params.expand(4)
+        >>> td_vmap = vmap(td_fmodule, (None, 0))(td.clone(), params_repeat)
         >>> print(td_vmap)
         TensorDict(
-            fields={input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+            fields={
                 hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                 output: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32)},
-            shared=False,
             batch_size=torch.Size([4, 3]),
-            device=cpu)
+            device=None,
+            is_shared=False)
 
     """
 

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
-from copy import deepcopy
 from textwrap import indent
 from typing import Any, Optional, Sequence, Tuple, Type, Union
 
@@ -210,24 +209,6 @@ class ProbabilisticTensorDictModule(TensorDictModule):
 
     def _call_module(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         return self.module(tensordict, **kwargs)
-
-    def make_functional_with_buffers(self, clone: bool = True, native: bool = False):
-        module_params = self.parameters(recurse=False)
-        if len(list(module_params)):
-            raise RuntimeError(
-                "make_functional_with_buffers cannot be called on ProbabilisticTensorDictModule"
-                "that contain parameters on the outer level."
-            )
-        if clone:
-            self_copy = deepcopy(self)
-        else:
-            self_copy = self
-
-        self_copy.module, other = self_copy.module.make_functional_with_buffers(
-            clone=True,
-            native=native,
-        )
-        return self_copy, other
 
     def get_dist(
         self,

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -108,15 +108,15 @@ class ProbabilisticTensorDictModule(TensorDictModule):
             Default is 1000
 
     Examples:
-        >>> import functorch, torch
+        >>> import torch
         >>> from tensordict import TensorDict
-        >>> from tensordict.nn import ProbabilisticTensorDictModule
+        >>> from tensordict.nn import ProbabilisticTensorDictModule, TensorDictModule
         >>> from tensordict.nn.distributions import NormalParamWrapper
+        >>> from tensordict.nn.functional_modules import make_functional
         >>> from torch.distributions import Normal
         >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
         >>> net = NormalParamWrapper(torch.nn.GRUCell(4, 8))
-        >>> fnet, params, buffers = functorch.make_functional_with_buffers(net)
-        >>> module = TensorDictModule(fnet, in_keys=["input", "hidden"], out_keys=["loc", "scale"])
+        >>> module = TensorDictModule(net, in_keys=["input", "hidden"], out_keys=["loc", "scale"])
         >>> td_module = ProbabilisticTensorDictModule(
         ...     module=module,
         ...     dist_param_keys=["loc", "scale"],
@@ -124,35 +124,36 @@ class ProbabilisticTensorDictModule(TensorDictModule):
         ...     distribution_class=Normal,
         ...     return_log_prob=True,
         ... )
-        >>> _ = td_module(td, params=params, buffers=buffers)
+        >>> params = make_functional(td_module)
+        >>> _ = td_module(td, params=params)
         >>> print(td)
         TensorDict(
             fields={
-                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
-                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 action: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                sample_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
+                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
             batch_size=torch.Size([3]),
-            device=cpu,
+            device=None,
             is_shared=False)
 
-        >>> # In the vmap case, the tensordict is again expended to match the batch:
-        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
-        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
-        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
+        >>> # we can also apply the module to the TensorDict with vmap
+        >>> from functorch import vmap
+        >>> params = params.expand(4)
+        >>> td_vmap = vmap(td_module, (None, 0))(td, params)
         >>> print(td_vmap)
         TensorDict(
             fields={
-                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
-                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                 action: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                sample_log_prob: Tensor(torch.Size([4, 3, 1]), dtype=torch.float32)},
+                hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32)},
             batch_size=torch.Size([4, 3]),
-            device=cpu,
+            device=None,
             is_shared=False)
 
     """

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import Iterable, List, Optional, Tuple, Union
 
 _has_functorch = False
@@ -28,11 +28,7 @@ from tensordict.nn.common import TensorDictModule
 from tensordict.nn.probabilistic import (
     ProbabilisticTensorDictModule,
 )
-from tensordict.tensordict import (
-    LazyStackedTensorDict,
-    TensorDict,
-    TensorDictBase,
-)
+from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
 from tensordict.utils import NESTED_KEY, _normalize_key
 
 __all__ = ["TensorDictSequential"]
@@ -358,68 +354,6 @@ class TensorDictSequential(TensorDictModule):
 
     def __delitem__(self, index: Union[int, slice]) -> None:
         self.module.__delitem__(idx=index)
-
-    def make_functional_with_buffers(self, clone: bool = True, native: bool = False):
-        """Transforms a stateful module in a functional module and returns its parameters and buffers.
-
-        Unlike functorch.make_functional_with_buffers, this method supports lazy modules.
-
-        Args:
-            clone (bool, optional): if True, a clone of the module is created before it is returned.
-                This is useful as it prevents the original module to be scraped off of its
-                parameters and buffers.
-                Defaults to True
-            native (bool, optional): if True, TorchRL's functional modules will be used.
-                Defaults to True
-
-        Returns:
-            A tuple of parameter and buffer tuples
-
-        Examples:
-            >>> from tensordict import TensorDict
-            >>> lazy_module1 = nn.LazyLinear(4)
-            >>> lazy_module2 = nn.LazyLinear(3)
-            >>> td_module1 = TensorDictModule(module=lazy_module1, in_keys=["some_input"], out_keys=["hidden"])
-            >>> td_module2 = TensorDictModule(module=lazy_module2, in_keys=["hidden"], out_keys=["some_output"])
-            >>> td_module = TensorDictSequential(td_module1, td_module2)
-            >>> # initialize lazy layers
-            >>> td_module(TensorDict({"some_input": torch.randn(18)}, batch_size=[]))
-            >>> _, (params, buffers) = td_module.make_functional_with_buffers()
-            >>> print(params[0].shape)
-            torch.Size([4, 18])
-            >>> print(td_module(
-            ...    TensorDict({'some_input': torch.randn(18)}, batch_size=[]),
-            ...    params=params,
-            ...    buffers=buffers))
-            TensorDict(
-                fields={
-                    some_input: Tensor(torch.Size([18]), dtype=torch.float32),
-                    hidden: Tensor(torch.Size([4]), dtype=torch.float32),
-                    some_output: Tensor(torch.Size([3]), dtype=torch.float32)},
-                batch_size=torch.Size([]),
-                device=cpu,
-                is_shared=False)
-
-        """
-        if clone:
-            self_copy = deepcopy(self)
-            self_copy.module = copy(self_copy.module)
-        else:
-            self_copy = self
-        params = [] if not native else TensorDict({}, [])
-        buffers = [] if not native else TensorDict({}, [])
-        for i, module in enumerate(self.module):
-            self_copy.module[i], (
-                _params,
-                _buffers,
-            ) = module.make_functional_with_buffers(clone=True, native=native)
-            if native or not _has_functorch:
-                params[str(i)] = _params
-                buffers[str(i)] = _buffers
-            else:
-                params.extend(_params)
-                buffers.extend(_buffers)
-        return self_copy, (params, buffers)
 
     def get_dist(
         self,

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -57,61 +57,62 @@ class TensorDictSequential(TensorDictModule):
 
     TensorDictSequence supports functional, modular and vmap coding:
     Examples:
-        >>> import torch, functorch
+        >>> import torch
         >>> from tensordict import TensorDict
-        >>> from tensordict.nn import ProbabilisticTensorDictModule, TensorDictSequential
+        >>> from tensordict.nn import (
+        ...     ProbabilisticTensorDictModule,
+        ...     TensorDictModule,
+        ...     TensorDictSequential,
+        ... )
         >>> from tensordict.nn.distributions import NormalParamWrapper
+        >>> from tensordict.nn.functional_modules import make_functional
         >>> from torch.distributions import Normal
         >>> td = TensorDict({"input": torch.randn(3, 4)}, [3,])
         >>> net1 = NormalParamWrapper(torch.nn.Linear(4, 8))
-        >>> fnet1, params1, buffers1 = functorch.make_functional_with_buffers(net1)
-        >>> fmodule1 = TensorDictModule(fnet1, in_keys=["input"], out_keys=["loc", "scale"])
+        >>> module1 = TensorDictModule(net1, in_keys=["input"], out_keys=["loc", "scale"])
         >>> td_module1 = ProbabilisticTensorDictModule(
-        ...    module=fmodule1,
+        ...    module=module1,
         ...    dist_param_keys=["loc", "scale"],
         ...    out_key_sample=["hidden"],
         ...    distribution_class=Normal,
         ...    return_log_prob=True,
         ...    )
         >>> module2 = torch.nn.Linear(4, 8)
-        >>> fmodule2, params2, buffers2 = functorch.make_functional_with_buffers(module2)
         >>> td_module2 = TensorDictModule(
-        ...    module=fmodule2, in_keys=["hidden"], out_keys=["output"]
+        ...    module=module2, in_keys=["hidden"], out_keys=["output"]
         ... )
         >>> td_module = TensorDictSequential(td_module1, td_module2)
-        >>> params = params1 + params2
-        >>> buffers = buffers1 + buffers2
-        >>> _ = td_module(td, params=params, buffers=buffers)
+        >>> params = make_functional(td_module)
+        >>> _ = td_module(td, params=params)
         >>> print(td)
         TensorDict(
             fields={
+                hidden: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                sample_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32),
-                output: Tensor(torch.Size([3, 8]), dtype=torch.float32)},
+                output: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
             batch_size=torch.Size([3]),
-            device=cpu,
+            device=None,
             is_shared=False)
 
     In the vmap case:
-        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
-        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
-        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
+        >>> from functorch import vmap
+        >>> params = params.expand(4)
+        >>> td_vmap = vmap(td_module, (None, 0))(td, params)
         >>> print(td_vmap)
         TensorDict(
             fields={
+                hidden: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                 input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                 loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
-                sample_log_prob: Tensor(torch.Size([4, 3, 1]), dtype=torch.float32),
-                output: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32)},
+                output: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32)},
             batch_size=torch.Size([4, 3]),
-            device=cpu,
+            device=None,
             is_shared=False)
-
 
     """
 


### PR DESCRIPTION
## Description

This PR updates examples in docstrings for the new in-place functionalisation API and also deprecates the `make_functional_with_buffers` methods on probabilistic and sequential tensordict modules (these would break anyway since they call the `make_functional_with_buffers` method of the underlying modules which has already been deprecated.

