### PR TITLE
[BugFix] Exclude potentially top-level packages from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ def _main(argv):
         long_description_content_type="text/markdown",
         license="BSD",
         # Package info
-        packages=find_packages(exclude=("test", "tutorials")),
+        packages=find_packages(exclude=("test", "tutorials", "packaging", "gallery")),
         cmdclass={
             "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
             "clean": clean,


### PR DESCRIPTION
## Description

`pip install -e .` can lead to the following error
```
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['gallery', 'packaging'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.
```

which is solved by this PR