### PR TITLE
[BugFix] Default version to None if not found

### DIFF
--- a/tensordict/__init__.py
+++ b/tensordict/__init__.py
@@ -12,7 +12,11 @@ from .tensordict import (
     LazyStackedTensorDict,
     SavedTensorDict,
 )
-from .version import __version__
+
+try:
+    from .version import __version__
+except ImportError:
+    __version__ = None
 
 __all__ = [
     "LazyStackedTensorDict",


### PR DESCRIPTION
## Description

For internal usage we need the `__version__` attribute to be possibly None when the library is not installed using pip install.