### PR TITLE
[BugFix] TensorDictSequential inheritance fix

### DIFF
--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -242,7 +242,7 @@ class TensorDictSequential(TensorDictModule):
                 "No modules left after selection. Make sure that in_keys and out_keys are coherent."
             )
 
-        return TensorDictSequential(*modules)
+        return self.__class__(*modules)
 
     def _run_module(
         self,


### PR DESCRIPTION
## Description

By creating a return value using `self.__class__`, child classes inheriting from `TensorDictSequential` will return an instance of the child type rather than `TensorDictSequential` without us having to redefine `select_subsequence`.

cf. pytorch/rl#700