### PR TITLE
[Feature] Add leaves_only kwarg to keys / values / items methods

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2904,6 +2904,12 @@ def test_keys_view():
     assert keys == {key for key, _ in tensordict.items_meta()}
     assert keys_nested == {key for key, _ in tensordict.items_meta(include_nested=True)}
 
+    leaves = set(tensordict.keys(leaves_only=True))
+    leaves_nested = set(tensordict.keys(include_nested=True, leaves_only=True))
+
+    assert leaves == set()
+    assert leaves_nested == {("a", "b", "c")}
+
 
 def test_error_on_contains():
     td = TensorDict(


### PR DESCRIPTION
## Description

This PR adds a new `leaves_only` kwarg (default False) to the `.keys`, `.values` and `.items` methods of `TensorDict` and subclasses. When set to True, keys and values corresponding to nested tensordicts are omitted from the iteration (though their children are not).

Example

```python
import torch
from tensordict import TensorDict

td = TensorDict({"a": torch.rand(1), "b": TensorDict({"c": torch.rand(1)}, [])}, [])

assert set(td.keys(include_nested=False, leaves_only=False)) == {"a", "b"}
assert set(td.keys(include_nested=True, leaves_only=False)) == {"a", "b", ("b", "c")}
assert set(td.keys(include_nested=False, leaves_only=True)) == {"a"}
assert set(td.keys(include_nested=True, leaves_only=True)) == {"a", ("b", "c")}
```