### PR TITLE
[Feature] Lazystack insert / append

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4512,6 +4512,8 @@ class LazyStackedTensorDict(TensorDictBase):
         N = len(self.tensordicts)
         self._batch_size = self._compute_batch_size(batch_size, self.stack_dim, N)
         self._update_valid_keys()
+        # recreate _dict_meta to ensure shapes of stacked tensors are correct
+        self._dict_meta = KeyDependentDefaultDict(self._make_meta)
 
     def append(self, tensordict: TensorDictBase) -> None:
         """Append a TensorDict onto the stack.

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4494,7 +4494,7 @@ class LazyStackedTensorDict(TensorDictBase):
         if _batch_size != batch_size:
             raise ValueError(
                 f"Batch sizes in tensordicts differs: stack has "
-                f"batch_size={_batch_size}, new_value has batch_size={_batch_size}."
+                f"batch_size={batch_size}, new_value has batch_size={_batch_size}."
             )
 
         self.tensordicts.insert(index, tensordict)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4474,6 +4474,16 @@ class LazyStackedTensorDict(TensorDictBase):
         return td_copy.masked_fill_(mask, value)
 
     def insert(self, index: int, tensordict: TensorDictBase) -> None:
+        """Insert a TensorDict into the stack at the specified index.
+
+        Analogous to list.insert. The inserted TensorDict must have compatible
+        batch_size and device. Insertion is in-place, nothing is returned.
+
+        Args:
+            index (int): The index at which the new TensorDict should be inserted.
+            tensordict (TensorDictBase): The TensorDict to be inserted into the stack.
+
+        """
         if not isinstance(tensordict, TensorDictBase):
             raise TypeError(
                 "Expected new value to be TensorDictBase instance but got "
@@ -4504,6 +4514,15 @@ class LazyStackedTensorDict(TensorDictBase):
         self._update_valid_keys()
 
     def append(self, tensordict: TensorDictBase) -> None:
+        """Append a TensorDict onto the stack.
+
+        Analogous to list.append. The appended TensorDict must have compatible
+        batch_size and device. The append operation is in-place, nothing is returned.
+
+        Args:
+            tensordict (TensorDictBase): The TensorDict to be appended onto the stack.
+
+        """
         self.insert(len(self.tensordicts), tensordict)
 
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3219,10 +3219,16 @@ def test_lazy_stacked_insert(dim, index, device):
     td = TensorDict({"a": torch.zeros(4)}, [4], device=device)
     lstd = torch.stack([td] * 2, dim=dim)
 
-    lstd.insert(index, TensorDict({"a": torch.ones(4)}, [4], device=device))
+    lstd.insert(
+        index,
+        TensorDict({"a": torch.ones(4), "invalid": torch.rand(4)}, [4], device=device),
+    )
 
     bs = [4]
     bs.insert(dim, 3)
+
+    assert lstd.batch_size == torch.Size(bs)
+    assert set(lstd.keys()) == {"a"}
 
     t = torch.zeros(*bs, 1)
 
@@ -3252,10 +3258,15 @@ def test_lazy_stacked_append(dim, device):
     td = TensorDict({"a": torch.zeros(4)}, [4], device=device)
     lstd = torch.stack([td] * 2, dim=dim)
 
-    lstd.append(TensorDict({"a": torch.ones(4)}, [4], device=device))
+    lstd.append(
+        TensorDict({"a": torch.ones(4), "invalid": torch.rand(4)}, [4], device=device)
+    )
 
     bs = [4]
     bs.insert(dim, 3)
+
+    assert lstd.batch_size == torch.Size(bs)
+    assert set(lstd.keys()) == {"a"}
 
     t = torch.zeros(*bs, 1)
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3230,7 +3230,7 @@ def test_lazy_stacked_insert(dim, index, device):
     assert lstd.batch_size == torch.Size(bs)
     assert set(lstd.keys()) == {"a"}
 
-    t = torch.zeros(*bs, 1)
+    t = torch.zeros(*bs, 1, device=device)
 
     if dim == 0:
         t[index] = 1
@@ -3268,7 +3268,7 @@ def test_lazy_stacked_append(dim, device):
     assert lstd.batch_size == torch.Size(bs)
     assert set(lstd.keys()) == {"a"}
 
-    t = torch.zeros(*bs, 1)
+    t = torch.zeros(*bs, 1, device=device)
 
     if dim == 0:
         t[-1] = 1
@@ -3284,7 +3284,7 @@ def test_lazy_stacked_append(dim, device):
 
     if device != torch.device("cpu"):
         with pytest.raises(ValueError, match="Devices differ"):
-            lstd.append(TensorDict({"a": torch.ones(4)}, [4]), device="cpu")
+            lstd.append(TensorDict({"a": torch.ones(4)}, [4], device="cpu"))
 
     with pytest.raises(ValueError, match="Batch sizes in tensordicts differs"):
         lstd.append(TensorDict({"a": torch.ones(17)}, [17], device=device))

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3212,6 +3212,73 @@ def test_split_with_negative_dim():
     assert tds[1]["b"].shape == torch.Size([5, 3, 1])
 
 
+@pytest.mark.parametrize("dim", range(2))
+@pytest.mark.parametrize("index", range(2))
+@pytest.mark.parametrize("device", get_available_devices())
+def test_lazy_stacked_insert(dim, index, device):
+    td = TensorDict({"a": torch.zeros(4)}, [4], device=device)
+    lstd = torch.stack([td] * 2, dim=dim)
+
+    lstd.insert(index, TensorDict({"a": torch.ones(4)}, [4], device=device))
+
+    bs = [4]
+    bs.insert(dim, 3)
+
+    t = torch.zeros(*bs, 1)
+
+    if dim == 0:
+        t[index] = 1
+    else:
+        t[:, index] = 1
+
+    torch.testing.assert_close(lstd["a"], t)
+
+    with pytest.raises(
+        TypeError, match="Expected new value to be TensorDictBase instance"
+    ):
+        lstd.insert(index, torch.rand(10))
+
+    if device != torch.device("cpu"):
+        with pytest.raises(ValueError, match="Devices differ"):
+            lstd.insert(index, TensorDict({"a": torch.ones(4)}, [4], device="cpu"))
+
+    with pytest.raises(ValueError, match="Batch sizes in tensordicts differs"):
+        lstd.insert(index, TensorDict({"a": torch.ones(17)}, [17], device=device))
+
+
+@pytest.mark.parametrize("dim", range(2))
+@pytest.mark.parametrize("device", get_available_devices())
+def test_lazy_stacked_append(dim, device):
+    td = TensorDict({"a": torch.zeros(4)}, [4], device=device)
+    lstd = torch.stack([td] * 2, dim=dim)
+
+    lstd.append(TensorDict({"a": torch.ones(4)}, [4], device=device))
+
+    bs = [4]
+    bs.insert(dim, 3)
+
+    t = torch.zeros(*bs, 1)
+
+    if dim == 0:
+        t[-1] = 1
+    else:
+        t[:, -1] = 1
+
+    torch.testing.assert_close(lstd["a"], t)
+
+    with pytest.raises(
+        TypeError, match="Expected new value to be TensorDictBase instance"
+    ):
+        lstd.append(torch.rand(10))
+
+    if device != torch.device("cpu"):
+        with pytest.raises(ValueError, match="Devices differ"):
+            lstd.append(TensorDict({"a": torch.ones(4)}, [4]), device="cpu")
+
+    with pytest.raises(ValueError, match="Batch sizes in tensordicts differs"):
+        lstd.append(TensorDict({"a": torch.ones(17)}, [17], device=device))
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)


### PR DESCRIPTION
## Description

This PR adds `insert` and `append` methods to `LazyStackedTensorDict` corresponding to the analogous methods for `list`.

Under the hood `append` simply calls `insert` with `index = len(self.tensordicts)`. While `my_list.insert(len(my_list), item)` is fractionally slower than `my_list.append(item)`, this is dwarfed by the checks which I think it makes sense to share.

Example:

```python
>>> import torch
>>> from tensordict import TensorDict
>>> td = TensorDict({"a": torch.zeros(4)}, [4])
>>> lstd = torch.stack([td] * 2)
>>> lstd.insert(1, TensorDict({"a": torch.ones(4)}, [4]))
>>> lstd["a"]
tensor([[[0.],
         [0.],
         [0.],
         [0.]],

        [[1.],
         [1.],
         [1.],
         [1.]],

        [[0.],
         [0.],
         [0.],
         [0.]]])
```