### PR TITLE
[Feature] Refactor probabilistic module wrapper

### DIFF
--- a/tensordict/nn/prototype.py
+++ b/tensordict/nn/prototype.py
@@ -1,0 +1,304 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from textwrap import indent
+from typing import Optional, Sequence, Tuple, Type, Union
+
+import torch.nn as nn
+
+from tensordict.nn.common import _check_all_str, TensorDictModule
+from tensordict.nn.distributions import Delta, distributions_maps
+from tensordict.nn.functional_modules import repopulate_module
+from tensordict.nn.probabilistic import interaction_mode
+from tensordict.nn.sequence import TensorDictSequential
+from tensordict.tensordict import TensorDictBase
+from torch import distributions as d, Tensor
+
+__all__ = ["ProbabilisticTensorDictModule"]
+
+
+class ProbabilisticTensorDictModule(nn.Module):
+    """A probabilistic TD Module.
+
+    `ProbabilisticTensorDictModule` is a non-parametric module representing a
+    probability distribution. It reads the distribution parameters from an input
+    TensorDict using the specified `in_keys`. The output is sampled given some rule,
+    specified by the input :obj:`default_interaction_mode` argument and the
+    :obj:`interaction_mode()` global function.
+
+    :obj:`ProbabilisticTensorDictModule` can be used to construct the distribution
+    (through the :obj:`get_dist()` method) and/or sampling from this distribution
+    (through a regular :obj:`__call__()` to the module).
+
+    A :obj:`ProbabilisticTensorDictModule` instance has two main features:
+    - It reads and writes TensorDict objects
+    - It uses a real mapping R^n -> R^m to create a distribution in R^d from
+    which values can be sampled or computed.
+
+    When the :obj:`__call__` / :obj:`forward` method is called, a distribution is
+    created, and a value computed (using the 'mean', 'mode', 'median' attribute or
+    the 'rsample', 'sample' method). The sampling step is skipped if the supplied
+    TensorDict has all of the desired key-value pairs already.
+
+    By default, ProbabilisticTensorDictModule distribution class is a Delta
+    distribution, making ProbabilisticTensorDictModule a simple wrapper around
+    a deterministic mapping function.
+
+    Args:
+        in_keys (str or iterable of str or dict): key(s) that will be read from the
+            input TensorDict and used to build the distribution. Importantly, if it's an
+            iterable of string or a string, those keys must match the keywords used by
+            the distribution class of interest, e.g. :obj:`"loc"` and :obj:`"scale"` for
+            the Normal distribution and similar. If in_keys is a dictionary,, the keys
+            are the keys of the distribution and the values are the keys in the
+            tensordict that will get match to the corresponding distribution keys.
+        out_keys (str or iterable of str): keys where the sampled values will be
+            written. Importantly, if these keys are found in the input TensorDict, the
+            sampling step will be skipped.
+        default_interaction_mode (str, optional): default method to be used to retrieve
+            the output value. Should be one of: 'mode', 'median', 'mean' or 'random'
+            (in which case the value is sampled randomly from the distribution). Default
+            is 'mode'.
+            Note: When a sample is drawn, the :obj:`ProbabilisticTDModule` instance will
+            fist look for the interaction mode dictated by the `interaction_mode()`
+            global function. If this returns `None` (its default value), then the
+            `default_interaction_mode` of the `ProbabilisticTDModule` instance will be
+            used. Note that DataCollector instances will use `set_interaction_mode` to
+            `"random"` by default.
+        distribution_class (Type, optional): a torch.distributions.Distribution class to
+            be used for sampling. Default is Delta.
+        distribution_kwargs (dict, optional): kwargs to be passed to the distribution.
+        return_log_prob (bool, optional): if True, the log-probability of the
+            distribution sample will be written in the
+            tensordict with the key `'sample_log_prob'`. Default is `False`.
+        cache_dist (bool, optional): EXPERIMENTAL: if True, the parameters of the distribution (i.e. the output of the module)
+            will be written to the tensordict along with the sample. Those parameters can be used to
+            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
+            used to sample the action and the updated distribution in PPO).
+            Default is `False`.
+        n_empirical_estimate (int, optional): number of samples to compute the empirical mean when it is not available.
+            Default is 1000
+
+    Examples:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from tensordict.nn import ProbabilisticTensorDictModule, TensorDictModule
+        >>> from tensordict.nn.distributions import NormalParamWrapper
+        >>> from tensordict.nn.functional_modules import make_functional
+        >>> from torch.distributions import Normal
+        >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
+        >>> net = NormalParamWrapper(torch.nn.GRUCell(4, 8))
+        >>> module = TensorDictModule(net, in_keys=["input", "hidden"], out_keys=["loc", "scale"])
+        >>> td_module = ProbabilisticTensorDictModule(
+        ...     module=module,
+        ...     in_keys=["loc", "scale"],
+        ...     out_keys=["action"],
+        ...     distribution_class=Normal,
+        ...     return_log_prob=True,
+        ... )
+        >>> params = make_functional(td_module, funs_to_decorate=["forward", "get_dist"])
+        >>> _ = td_module(td, params=params)
+        >>> print(td)
+        TensorDict(
+            fields={
+                action: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
+            batch_size=torch.Size([3]),
+            device=None,
+            is_shared=False)
+        >>> dist, *_ = td_module.get_dist(td, params=params)
+        >>> print(dist)
+        Normal(loc: torch.Size([3, 4]), scale: torch.Size([3, 4]))
+
+        >>> # we can also apply the module to the TensorDict with vmap
+        >>> from functorch import vmap
+        >>> params = params.expand(4)
+        >>> td_vmap = vmap(td_module, (None, 0))(td, params)
+        >>> print(td_vmap)
+        TensorDict(
+            fields={
+                action: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
+                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32)},
+            batch_size=torch.Size([4, 3]),
+            device=None,
+            is_shared=False)
+
+    """
+
+    def __init__(
+        self,
+        in_keys: Union[str, Sequence[str], dict],
+        out_keys: Optional[Union[str, Sequence[str]]] = None,
+        default_interaction_mode: str = "mode",
+        distribution_class: Type = Delta,
+        distribution_kwargs: Optional[dict] = None,
+        return_log_prob: bool = False,
+        cache_dist: bool = False,
+        n_empirical_estimate: int = 1000,
+    ):
+        super().__init__()
+        if isinstance(in_keys, str):
+            in_keys = [in_keys]
+        if isinstance(out_keys, str):
+            out_keys = [out_keys]
+        elif out_keys is None:
+            out_keys = []
+        if not isinstance(in_keys, dict):
+            in_keys = {param_key: param_key for param_key in in_keys}
+
+        self.out_keys = out_keys
+        _check_all_str(self.out_keys)
+        self.in_keys = in_keys
+        _check_all_str(self.in_keys.keys())
+        _check_all_str(self.in_keys.values())
+
+        self.default_interaction_mode = default_interaction_mode
+        if isinstance(distribution_class, str):
+            distribution_class = distributions_maps.get(distribution_class.lower())
+        self.distribution_class = distribution_class
+        self.distribution_kwargs = (
+            distribution_kwargs if distribution_kwargs is not None else {}
+        )
+        self.n_empirical_estimate = n_empirical_estimate
+        self._dist = None
+        self.cache_dist = cache_dist if hasattr(distribution_class, "update") else False
+        self.return_log_prob = return_log_prob
+
+    def get_dist(self, tensordict: TensorDictBase) -> d.Distribution:
+        try:
+            dist_kwargs = {
+                dist_key: tensordict[td_key]
+                for dist_key, td_key in self.in_keys.items()
+            }
+            dist = self.distribution_class(**dist_kwargs)
+        except TypeError as err:
+            if "an unexpected keyword argument" in str(err):
+                raise TypeError(
+                    "distribution keywords and tensordict keys indicated by ProbabilisticTensorDictModule.in_keys must match."
+                    f"Got this error message: \n{indent(str(err), 4 * ' ')}\nwith in_keys={self.in_keys}"
+                )
+            elif re.search(r"missing.*required positional arguments", str(err)):
+                raise TypeError(
+                    f"TensorDict with keys {tensordict.keys()} does not match the distribution {self.distribution_class} keywords."
+                )
+            else:
+                raise err
+        return dist
+
+    def forward(
+        self,
+        tensordict: TensorDictBase,
+        tensordict_out: Optional[TensorDictBase] = None,
+    ) -> TensorDictBase:
+        if tensordict_out is None:
+            tensordict_out = tensordict
+
+        dist = self.get_dist(tensordict)
+        td_keys = set(tensordict.keys())
+        # if the tensordict contains the sampled keys we wont be sampling them again
+        # in that case ProbabilisticTensorDictModule is presumably used to return the
+        # distribution using `get_dist` or to sample log_probabilities
+        if not all(key in td_keys for key in self.out_keys):
+            out_tensors = self._dist_sample(dist, interaction_mode=interaction_mode())
+            if isinstance(out_tensors, Tensor):
+                out_tensors = (out_tensors,)
+            tensordict_out.update(
+                {key: value for key, value in zip(self.out_keys, out_tensors)}
+            )
+            if self.return_log_prob:
+                log_prob = dist.log_prob(*out_tensors)
+                tensordict_out.set("sample_log_prob", log_prob)
+        elif self.return_log_prob:
+            out_tensors = [tensordict.get(key) for key in self.out_keys]
+            log_prob = dist.log_prob(*out_tensors)
+            tensordict_out.set("sample_log_prob", log_prob)
+            # raise RuntimeError(
+            #     "ProbabilisticTensorDictModule.return_log_prob = True is incompatible with settings in which "
+            #     "the submodule is responsible for sampling. To manually gather the log-probability, call first "
+            #     "\n>>> dist, tensordict = tensordict_module.get_dist(tensordict)"
+            #     "\n>>> tensordict.set('sample_log_prob', dist.log_prob(tensordict.get(sample_key))"
+            # )
+        return tensordict_out
+
+    def _dist_sample(
+        self, dist: d.Distribution, interaction_mode: bool = None
+    ) -> Union[Tuple[Tensor], Tensor]:
+        if interaction_mode is None or interaction_mode == "":
+            interaction_mode = self.default_interaction_mode
+        if not isinstance(dist, d.Distribution):
+            raise TypeError(f"type {type(dist)} not recognised by _dist_sample")
+
+        if interaction_mode == "mode":
+            if hasattr(dist, "mode"):
+                return dist.mode
+            else:
+                raise NotImplementedError(
+                    f"method {type(dist)}.mode is not implemented"
+                )
+
+        elif interaction_mode == "median":
+            if hasattr(dist, "median"):
+                return dist.median
+            else:
+                raise NotImplementedError(
+                    f"method {type(dist)}.median is not implemented"
+                )
+
+        elif interaction_mode == "mean":
+            try:
+                return dist.mean
+            except (AttributeError, NotImplementedError):
+                if dist.has_rsample:
+                    return dist.rsample((self.n_empirical_estimate,)).mean(0)
+                else:
+                    return dist.sample((self.n_empirical_estimate,)).mean(0)
+
+        elif interaction_mode == "random":
+            if dist.has_rsample:
+                return dist.rsample()
+            else:
+                return dist.sample()
+        else:
+            raise NotImplementedError(f"unknown interaction_mode {interaction_mode}")
+
+
+class ProbabilisticTensorDictSequential(TensorDictSequential):
+    def __init__(
+        self,
+        *modules: Union[TensorDictModule, ProbabilisticTensorDictModule],
+        partial_tolerant: bool = False,
+    ) -> None:
+        if len(modules) == 0:
+            raise ValueError(
+                "ProbabilisticTensorDictSequential must consist of zero or more "
+                "TensorDictModules followed by a ProbabilisticTensorDictModule"
+            )
+        if not isinstance(modules[-1], ProbabilisticTensorDictModule):
+            raise TypeError(
+                "The final module passed to ProbabilisticTensorDictSequential must be "
+                "an instance of ProbabilisticTensorDictModule"
+            )
+        super().__init__(*modules, partial_tolerant=partial_tolerant)
+
+    def get_dist(
+        self,
+        tensordict: TensorDictBase,
+        tensordict_out: Optional[TensorDictBase] = None,
+        **kwargs,
+    ) -> d.Distribution:
+        tds = TensorDictSequential(*self.module[:-1])
+        if self.__dict__.get("_is_stateless", False):
+            tds = repopulate_module(tds, kwargs.pop("params"))
+        tensordict_out = tds(tensordict, tensordict_out, **kwargs)
+        return self.module[-1].get_dist(tensordict_out)

--- a/tensordict/nn/prototype.py
+++ b/tensordict/nn/prototype.py
@@ -282,6 +282,26 @@ class ProbabilisticTensorDictModule(nn.Module):
 
 
 class ProbabilisticTensorDictSequential(TensorDictSequential):
+    """A sequence of TensorDictModules ending in a ProbabilistictTensorDictModule.
+
+    Similarly to :obj:`TensorDictSequential`, but enforces that the final module in the
+    sequence is an :obj:`ProbabilisticTensorDictModule` and also exposes ``get_dist``
+    method to recover the distribution object from the ``ProbabilisticTensorDictModule``
+
+    Args:
+         modules (iterable of TensorDictModules): ordered sequence of TensorDictModule
+            instances, terminating in ProbabilisticTensorDictModule, to be run
+            sequentially.
+         partial_tolerant (bool, optional): if True, the input tensordict can miss some
+            of the input keys. If so, the only module that will be executed are those
+            who can be executed given the keys that are present. Also, if the input
+            tensordict is a lazy stack of tensordicts AND if partial_tolerant is
+            :obj:`True` AND if the stack does not have the required keys, then
+            TensorDictSequential will scan through the sub-tensordicts looking for those
+            that have the required keys, if any.
+
+    """
+
     def __init__(
         self,
         *modules: Union[TensorDictModule, ProbabilisticTensorDictModule],

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -570,21 +570,21 @@ class TestTDSequence:
             tdmodule1, dummy_tdmodule, tdmodule2, prob_module
         )
 
-        assert hasattr(tdmodule.module, "__setitem__")
-        assert len(tdmodule.module) == 4
-        tdmodule.module[1] = tdmodule2
-        tdmodule.module[2] = prob_module
-        assert len(tdmodule.module) == 4
+        assert hasattr(tdmodule, "__setitem__")
+        assert len(tdmodule) == 4
+        tdmodule[1] = tdmodule2
+        tdmodule[2] = prob_module
+        assert len(tdmodule) == 4
 
-        assert hasattr(tdmodule.module, "__delitem__")
-        assert len(tdmodule.module) == 4
-        del tdmodule.module[3]
-        assert len(tdmodule.module) == 3
+        assert hasattr(tdmodule, "__delitem__")
+        assert len(tdmodule) == 4
+        del tdmodule[3]
+        assert len(tdmodule) == 3
 
-        assert hasattr(tdmodule.module, "__getitem__")
-        assert tdmodule.module[0] is tdmodule1
-        assert tdmodule.module[1] is tdmodule2
-        assert tdmodule.module[2] is prob_module
+        assert hasattr(tdmodule, "__getitem__")
+        assert tdmodule[0] is tdmodule1
+        assert tdmodule[1] is tdmodule2
+        assert tdmodule[2] is prob_module
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
         tdmodule(td)
@@ -751,24 +751,24 @@ class TestTDSequence:
 
         params = make_functional(tdmodule, funs_to_decorate=["forward", "get_dist"])
 
-        assert hasattr(tdmodule.module, "__setitem__")
-        assert len(tdmodule.module) == 4
-        tdmodule.module[1] = tdmodule2
-        tdmodule.module[2] = prob_module
+        assert hasattr(tdmodule, "__setitem__")
+        assert len(tdmodule) == 4
+        tdmodule[1] = tdmodule2
+        tdmodule[2] = prob_module
         params["module", "1"] = params["module", "2"]
         params["module", "2"] = params["module", "3"]
-        assert len(tdmodule.module) == 4
+        assert len(tdmodule) == 4
 
-        assert hasattr(tdmodule.module, "__delitem__")
-        assert len(tdmodule.module) == 4
-        del tdmodule.module[3]
+        assert hasattr(tdmodule, "__delitem__")
+        assert len(tdmodule) == 4
+        del tdmodule[3]
         del params["module", "3"]
-        assert len(tdmodule.module) == 3
+        assert len(tdmodule) == 3
 
         assert hasattr(tdmodule.module, "__getitem__")
-        assert tdmodule.module[0] is tdmodule1
-        assert tdmodule.module[1] is tdmodule2
-        assert tdmodule.module[2] is prob_module
+        assert tdmodule[0] is tdmodule1
+        assert tdmodule[1] is tdmodule2
+        assert tdmodule[2] is prob_module
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
         tdmodule(td, params=params)
@@ -914,11 +914,11 @@ class TestTDSequence:
 
         assert hasattr(tdmodule.module, "__setitem__")
         assert len(tdmodule.module) == 4
-        tdmodule.module[1] = tdmodule2
-        tdmodule.module[2] = prob_module
+        tdmodule[1] = tdmodule2
+        tdmodule[2] = prob_module
         params["module", "1"] = params["module", "2"]
         params["module", "2"] = params["module", "3"]
-        assert len(tdmodule.module) == 4
+        assert len(tdmodule) == 4
 
         assert hasattr(tdmodule.module, "__delitem__")
         assert len(tdmodule.module) == 4
@@ -927,9 +927,9 @@ class TestTDSequence:
         assert len(tdmodule.module) == 3
 
         assert hasattr(tdmodule.module, "__getitem__")
-        assert tdmodule.module[0] is tdmodule1
-        assert tdmodule.module[1] is tdmodule2
-        assert tdmodule.module[2] is prob_module
+        assert tdmodule[0] is tdmodule1
+        assert tdmodule[1] is tdmodule2
+        assert tdmodule[2] is prob_module
 
         td = TensorDict({"in": torch.randn(3, 7)}, [3])
         tdmodule(td, params=params)

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -17,6 +17,10 @@ from tensordict.nn import (
 from tensordict.nn.distributions import NormalParamWrapper
 from tensordict.nn.functional_modules import make_functional
 from tensordict.nn.probabilistic import set_interaction_mode
+from tensordict.nn.prototype import (
+    ProbabilisticTensorDictModule as ProbabilisticTensorDictModule_proto,
+    ProbabilisticTensorDictSequential,
+)
 from torch import nn
 from torch.distributions import Normal
 
@@ -80,6 +84,42 @@ class TestTDModule:
             sample_out_key=["out"],
             **kwargs,
         )
+
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        with set_interaction_mode(interaction_mode):
+            tensordict_module(td)
+        assert td.shape == torch.Size([3])
+        assert td.get("out").shape == torch.Size([3, 4])
+
+    @pytest.mark.parametrize("out_keys", [["loc", "scale"], ["loc_1", "scale_1"]])
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("interaction_mode", ["mode", "random", None])
+    def test_stateful_probabilistic_proto(self, lazy, interaction_mode, out_keys):
+        torch.manual_seed(0)
+        param_multiplier = 2
+        if lazy:
+            net = nn.LazyLinear(4 * param_multiplier)
+        else:
+            net = nn.Linear(3, 4 * param_multiplier)
+
+        in_keys = ["in"]
+        net = TensorDictModule(
+            module=NormalParamWrapper(net), in_keys=in_keys, out_keys=out_keys
+        )
+
+        kwargs = {"distribution_class": Normal}
+        if out_keys == ["loc", "scale"]:
+            dist_in_keys = ["loc", "scale"]
+        elif out_keys == ["loc_1", "scale_1"]:
+            dist_in_keys = {"loc": "loc_1", "scale": "scale_1"}
+        else:
+            raise NotImplementedError
+
+        prob_module = ProbabilisticTensorDictModule_proto(
+            in_keys=dist_in_keys, out_keys=["out"], **kwargs
+        )
+
+        tensordict_module = ProbabilisticTensorDictSequential(net, prob_module)
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
         with set_interaction_mode(interaction_mode):
@@ -177,6 +217,32 @@ class TestTDModule:
     @pytest.mark.skipif(
         not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
     )
+    def test_functional_probabilistic_proto(self):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        tdnet = TensorDictModule(
+            module=NormalParamWrapper(nn.Linear(3, 4 * param_multiplier)),
+            in_keys=["in"],
+            out_keys=["loc", "scale"],
+        )
+
+        kwargs = {"distribution_class": Normal}
+        prob_module = ProbabilisticTensorDictModule_proto(
+            in_keys=["loc", "scale"], out_keys=["out"], **kwargs
+        )
+
+        tensordict_module = ProbabilisticTensorDictSequential(tdnet, prob_module)
+        params = make_functional(tensordict_module)
+
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        tensordict_module(td, params=params)
+        assert td.shape == torch.Size([3])
+        assert td.get("out").shape == torch.Size([3, 4])
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
     def test_functional_with_buffer(self):
         torch.manual_seed(0)
         param_multiplier = 1
@@ -210,6 +276,32 @@ class TestTDModule:
             sample_out_key=["out"],
             **kwargs,
         )
+
+        td = TensorDict({"in": torch.randn(3, 32 * param_multiplier)}, [3])
+        tdmodule(td, params=params)
+        assert td.shape == torch.Size([3])
+        assert td.get("out").shape == torch.Size([3, 32])
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
+    def test_functional_with_buffer_probabilistic_proto(self):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        tdnet = TensorDictModule(
+            module=NormalParamWrapper(nn.BatchNorm1d(32 * param_multiplier)),
+            in_keys=["in"],
+            out_keys=["loc", "scale"],
+        )
+
+        kwargs = {"distribution_class": Normal}
+        prob_module = ProbabilisticTensorDictModule_proto(
+            in_keys=["loc", "scale"], out_keys=["out"], **kwargs
+        )
+
+        tdmodule = ProbabilisticTensorDictSequential(tdnet, prob_module)
+        params = make_functional(tdmodule)
 
         td = TensorDict({"in": torch.randn(3, 32 * param_multiplier)}, [3])
         tdmodule(td, params=params)
@@ -263,6 +355,41 @@ class TestTDModule:
             sample_out_key=["out"],
             **kwargs,
         )
+        params = make_functional(tdmodule)
+
+        # vmap = True
+        params = params.expand(10)
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        td_out = vmap(tdmodule, (None, 0))(td, params)
+        assert td_out is not td
+        assert td_out.shape == torch.Size([10, 3])
+        assert td_out.get("out").shape == torch.Size([10, 3, 4])
+
+        # vmap = (0, 0)
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        td_repeat = td.expand(10, *td.batch_size)
+        td_out = vmap(tdmodule, (0, 0))(td_repeat, params)
+        assert td_out is not td_repeat
+        assert td_out.shape == torch.Size([10, 3])
+        assert td_out.get("out").shape == torch.Size([10, 3, 4])
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
+    def test_vmap_probabilistic_proto(self):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        net = NormalParamWrapper(nn.Linear(3, 4 * param_multiplier))
+
+        tdnet = TensorDictModule(module=net, in_keys=["in"], out_keys=["loc", "scale"])
+
+        kwargs = {"distribution_class": Normal}
+        prob_module = ProbabilisticTensorDictModule_proto(
+            in_keys=["loc", "scale"], out_keys=["out"], **kwargs
+        )
+
+        tdmodule = ProbabilisticTensorDictSequential(tdnet, prob_module)
         params = make_functional(tdmodule)
 
         # vmap = True
@@ -413,6 +540,60 @@ class TestTDSequence:
         dist, *_ = tdmodule.get_dist(td)
         assert dist.rsample().shape[: td.ndimension()] == td.shape
 
+    @pytest.mark.parametrize("lazy", [True, False])
+    def test_stateful_probabilistic_proto(self, lazy):
+        torch.manual_seed(0)
+        param_multiplier = 2
+        if lazy:
+            net1 = nn.LazyLinear(4)
+            dummy_net = nn.LazyLinear(4)
+            net2 = nn.LazyLinear(4 * param_multiplier)
+        else:
+            net1 = nn.Linear(3, 4)
+            dummy_net = nn.Linear(4, 4)
+            net2 = nn.Linear(4, 4 * param_multiplier)
+        net2 = NormalParamWrapper(net2)
+
+        kwargs = {"distribution_class": Normal}
+        tdmodule1 = TensorDictModule(net1, in_keys=["in"], out_keys=["hidden"])
+        dummy_tdmodule = TensorDictModule(
+            dummy_net, in_keys=["hidden"], out_keys=["hidden"]
+        )
+        tdmodule2 = TensorDictModule(
+            net2, in_keys=["hidden"], out_keys=["loc", "scale"]
+        )
+
+        prob_module = ProbabilisticTensorDictModule_proto(
+            in_keys=["loc", "scale"], out_keys=["out"], **kwargs
+        )
+        tdmodule = ProbabilisticTensorDictSequential(
+            tdmodule1, dummy_tdmodule, tdmodule2, prob_module
+        )
+
+        assert hasattr(tdmodule.module, "__setitem__")
+        assert len(tdmodule.module) == 4
+        tdmodule.module[1] = tdmodule2
+        tdmodule.module[2] = prob_module
+        assert len(tdmodule.module) == 4
+
+        assert hasattr(tdmodule.module, "__delitem__")
+        assert len(tdmodule.module) == 4
+        del tdmodule.module[3]
+        assert len(tdmodule.module) == 3
+
+        assert hasattr(tdmodule.module, "__getitem__")
+        assert tdmodule.module[0] is tdmodule1
+        assert tdmodule.module[1] is tdmodule2
+        assert tdmodule.module[2] is prob_module
+
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        tdmodule(td)
+        assert td.shape == torch.Size([3])
+        assert td.get("out").shape == torch.Size([3, 4])
+
+        dist = tdmodule.get_dist(td)
+        assert dist.rsample().shape[: td.ndimension()] == td.shape
+
     @pytest.mark.skipif(
         not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
     )
@@ -541,6 +722,65 @@ class TestTDSequence:
     @pytest.mark.skipif(
         not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
     )
+    def test_functional_probabilistic_proto(self):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        net1 = nn.Linear(3, 4)
+        dummy_net = nn.Linear(4, 4)
+        net2 = nn.Linear(4, 4 * param_multiplier)
+        net2 = NormalParamWrapper(net2)
+
+        tdmodule1 = TensorDictModule(net1, in_keys=["in"], out_keys=["hidden"])
+        dummy_tdmodule = TensorDictModule(
+            dummy_net, in_keys=["hidden"], out_keys=["hidden"]
+        )
+        tdmodule2 = TensorDictModule(
+            net2, in_keys=["hidden"], out_keys=["loc", "scale"]
+        )
+
+        kwargs = {"distribution_class": Normal}
+        prob_module = ProbabilisticTensorDictModule_proto(
+            out_keys=["out"],
+            in_keys=["loc", "scale"],
+            **kwargs,
+        )
+        tdmodule = ProbabilisticTensorDictSequential(
+            tdmodule1, dummy_tdmodule, tdmodule2, prob_module
+        )
+
+        params = make_functional(tdmodule, funs_to_decorate=["forward", "get_dist"])
+
+        assert hasattr(tdmodule.module, "__setitem__")
+        assert len(tdmodule.module) == 4
+        tdmodule.module[1] = tdmodule2
+        tdmodule.module[2] = prob_module
+        params["module", "1"] = params["module", "2"]
+        params["module", "2"] = params["module", "3"]
+        assert len(tdmodule.module) == 4
+
+        assert hasattr(tdmodule.module, "__delitem__")
+        assert len(tdmodule.module) == 4
+        del tdmodule.module[3]
+        del params["module", "3"]
+        assert len(tdmodule.module) == 3
+
+        assert hasattr(tdmodule.module, "__getitem__")
+        assert tdmodule.module[0] is tdmodule1
+        assert tdmodule.module[1] is tdmodule2
+        assert tdmodule.module[2] is prob_module
+
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        tdmodule(td, params=params)
+        assert td.shape == torch.Size([3])
+        assert td.get("out").shape == torch.Size([3, 4])
+
+        dist = tdmodule.get_dist(td, params=params)
+        assert dist.rsample().shape[: td.ndimension()] == td.shape
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
     def test_functional_with_buffer(self):
         torch.manual_seed(0)
         param_multiplier = 1
@@ -640,6 +880,69 @@ class TestTDSequence:
     @pytest.mark.skipif(
         not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
     )
+    def test_functional_with_buffer_probabilistic_proto(self):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        net1 = nn.Sequential(nn.Linear(7, 7), nn.BatchNorm1d(7))
+        dummy_net = nn.Sequential(nn.Linear(7, 7), nn.BatchNorm1d(7))
+        net2 = nn.Sequential(
+            nn.Linear(7, 7 * param_multiplier), nn.BatchNorm1d(7 * param_multiplier)
+        )
+        net2 = NormalParamWrapper(net2)
+
+        tdmodule1 = TensorDictModule(net1, in_keys=["in"], out_keys=["hidden"])
+        dummy_tdmodule = TensorDictModule(
+            dummy_net, in_keys=["hidden"], out_keys=["hidden"]
+        )
+        tdmodule2 = TensorDictModule(
+            net2, in_keys=["hidden"], out_keys=["loc", "scale"]
+        )
+
+        kwargs = {"distribution_class": Normal}
+        prob_module = ProbabilisticTensorDictModule_proto(
+            in_keys=["loc", "scale"],
+            out_keys=["out"],
+            **kwargs,
+        )
+
+        tdmodule = ProbabilisticTensorDictSequential(
+            tdmodule1, dummy_tdmodule, tdmodule2, prob_module
+        )
+
+        params = make_functional(tdmodule, ["forward", "get_dist"])
+
+        assert hasattr(tdmodule.module, "__setitem__")
+        assert len(tdmodule.module) == 4
+        tdmodule.module[1] = tdmodule2
+        tdmodule.module[2] = prob_module
+        params["module", "1"] = params["module", "2"]
+        params["module", "2"] = params["module", "3"]
+        assert len(tdmodule.module) == 4
+
+        assert hasattr(tdmodule.module, "__delitem__")
+        assert len(tdmodule.module) == 4
+        del tdmodule.module[3]
+        del params["module", "3"]
+        assert len(tdmodule.module) == 3
+
+        assert hasattr(tdmodule.module, "__getitem__")
+        assert tdmodule.module[0] is tdmodule1
+        assert tdmodule.module[1] is tdmodule2
+        assert tdmodule.module[2] is prob_module
+
+        td = TensorDict({"in": torch.randn(3, 7)}, [3])
+        tdmodule(td, params=params)
+
+        dist = tdmodule.get_dist(td, params=params)
+        assert dist.rsample().shape[: td.ndimension()] == td.shape
+
+        assert td.shape == torch.Size([3])
+        assert td.get("out").shape == torch.Size([3, 7])
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
     def test_vmap(self):
         torch.manual_seed(0)
         param_multiplier = 1
@@ -708,6 +1011,51 @@ class TestTDSequence:
             net2, sample_out_key=["out"], dist_in_keys=["loc", "scale"], **kwargs
         )
         tdmodule = TensorDictSequential(tdmodule1, tdmodule2)
+
+        params = make_functional(tdmodule)
+
+        # vmap = True
+        params = params.expand(10)
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        td_out = vmap(tdmodule, (None, 0))(td, params)
+        assert td_out is not td
+        assert td_out.shape == torch.Size([10, 3])
+        assert td_out.get("out").shape == torch.Size([10, 3, 4])
+
+        # vmap = (0, 0)
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+        td_repeat = td.expand(10, *td.batch_size)
+        td_out = vmap(tdmodule, (0, 0))(td_repeat, params)
+        assert td_out is not td_repeat
+        assert td_out.shape == torch.Size([10, 3])
+        assert td_out.get("out").shape == torch.Size([10, 3, 4])
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
+    def test_vmap_probabilistic_proto(self):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        net1 = nn.Linear(3, 4)
+
+        net2 = nn.Linear(4, 4 * param_multiplier)
+        net2 = NormalParamWrapper(net2)
+
+        kwargs = {"distribution_class": Normal}
+        tdmodule1 = TensorDictModule(net1, in_keys=["in"], out_keys=["hidden"])
+        tdmodule2 = TensorDictModule(
+            net2, in_keys=["hidden"], out_keys=["loc", "scale"]
+        )
+        tdmodule = ProbabilisticTensorDictSequential(
+            tdmodule1,
+            tdmodule2,
+            ProbabilisticTensorDictModule_proto(
+                out_keys=["out"],
+                in_keys=["loc", "scale"],
+                **kwargs,
+            ),
+        )
 
         params = make_functional(tdmodule)
 
@@ -833,6 +1181,80 @@ class TestTDSequence:
             assert "out" in td.keys()
             assert "b" in td.keys()
 
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
+    @pytest.mark.parametrize("stack", [True, False])
+    @pytest.mark.parametrize("functional", [True, False])
+    def test_sequential_partial_proto(self, stack, functional):
+        torch.manual_seed(0)
+        param_multiplier = 2
+
+        net1 = nn.Linear(3, 4)
+
+        net2 = nn.Linear(4, 4 * param_multiplier)
+        net2 = NormalParamWrapper(net2)
+        net2 = TensorDictModule(net2, in_keys=["b"], out_keys=["loc", "scale"])
+
+        net3 = nn.Linear(4, 4 * param_multiplier)
+        net3 = NormalParamWrapper(net3)
+        net3 = TensorDictModule(net3, in_keys=["c"], out_keys=["loc", "scale"])
+
+        kwargs = {"distribution_class": Normal}
+
+        tdmodule1 = TensorDictModule(net1, in_keys=["a"], out_keys=["hidden"])
+        tdmodule2 = ProbabilisticTensorDictSequential(
+            net2,
+            ProbabilisticTensorDictModule_proto(
+                out_keys=["out"], in_keys=["loc", "scale"], **kwargs
+            ),
+        )
+        tdmodule3 = ProbabilisticTensorDictSequential(
+            net3,
+            ProbabilisticTensorDictModule_proto(
+                out_keys=["out"], in_keys=["loc", "scale"], **kwargs
+            ),
+        )
+        tdmodule = TensorDictSequential(
+            tdmodule1, tdmodule2, tdmodule3, partial_tolerant=True
+        )
+
+        if functional:
+            params = make_functional(tdmodule)
+        else:
+            params = None
+
+        if stack:
+            td = torch.stack(
+                [
+                    TensorDict({"a": torch.randn(3), "b": torch.randn(4)}, []),
+                    TensorDict({"a": torch.randn(3), "c": torch.randn(4)}, []),
+                ],
+                0,
+            )
+            if functional:
+                tdmodule(td, params=params)
+            else:
+                tdmodule(td)
+            assert "loc" in td.keys()
+            assert "scale" in td.keys()
+            assert "out" in td.keys()
+            assert td["out"].shape[0] == 2
+            assert td["loc"].shape[0] == 2
+            assert td["scale"].shape[0] == 2
+            assert "b" not in td.keys()
+            assert "b" in td[0].keys()
+        else:
+            td = TensorDict({"a": torch.randn(3), "b": torch.randn(4)}, [])
+            if functional:
+                tdmodule(td, params=params)
+            else:
+                tdmodule(td)
+            assert "loc" in td.keys()
+            assert "scale" in td.keys()
+            assert "out" in td.keys()
+            assert "b" in td.keys()
+
     def test_subsequence_weight_update(self):
         td_module_1 = TensorDictModule(
             nn.Linear(3, 2), in_keys=["in"], out_keys=["hidden"]
@@ -854,6 +1276,18 @@ class TestTDSequence:
 
         assert not torch.allclose(copy, sub_seq_1[0].module.weight)
         assert torch.allclose(td_module[0].module.weight, sub_seq_1[0].module.weight)
+
+
+def test_probabilistic_sequential_type_checks():
+    td_module_1 = TensorDictModule(nn.Linear(3, 2), in_keys=["in"], out_keys=["hidden"])
+    td_module_2 = TensorDictModule(
+        nn.Linear(2, 4), in_keys=["hidden"], out_keys=["out"]
+    )
+    with pytest.raises(
+        TypeError,
+        match="The final module passed to ProbabilisticTensorDictSequential",
+    ):
+        ProbabilisticTensorDictSequential(td_module_1, td_module_2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR makes changes to `ProbabilisticTensorDictModule` and adds a new class `ProbabilisticTensorDictSequential`.

`ProbabilisticTensorDictModule` is now a pretty lightweight class which reads distribution parameters from a tensordict. A foward pass writes a sample to the output tensordict, whereas `get_dist` method can be used to recover the distribution object.

`ProbabilisticTensorDictSequential` is much like `TensorDictSequential`, but the final module in the sequence must always be a `ProbabilisticTensorDictModule`. We then additionally expose the `get_dist` method which allows the user to perform a forward pass of the sequence to get distribution parameters, and then return the resulting distribution.