### PR TITLE
[BugFix] patched nn.Module deserialization

### DIFF
--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -203,12 +203,14 @@ def extract_weights_and_buffers(model: nn.Module, funs_to_decorate=None, recurse
 
     if not model.__dict__.get("_functionalized", False):
         for fun_to_decorate in funs_to_decorate:
-            if hasattr(model, fun_to_decorate):
+            try:
                 setattr(
                     model,
                     fun_to_decorate,
                     types.MethodType(_make_decorator(model, fun_to_decorate), model),
                 )
+            except AttributeError:
+                continue
     model.__dict__["_functionalized"] = True
     model.__dict__["_is_stateless"] = True
     return TensorDict(tensordict, [], _run_checks=False)
@@ -277,9 +279,10 @@ def get_functional(module, funs_to_decorate=None):
 
 def _make_decorator(module, fun_name):
     fun = getattr(module, fun_name)
-
     # we need to update the signature so that params can be the last positional arg
     oldsig = inspect.signature(fun)
+    if "_forward_unimplemented" in fun.__name__:
+        raise AttributeError("_forward_unimplemented not supported")
     # search if a VAR_POSITIONAL or VAR_KEYWORD is present
     # if yes insert step parameter before it, else insert it in last position
     params = list(oldsig.parameters.values())


### PR DESCRIPTION
## Description

Fixes a bug where nn.Module with no forward method fail to be serialized/deserialized if they have been functionalized.
For the record, the error reads:
```
AttributeError: 'ModuleList' object has no attribute '_forward_unimplemented'
```
This is due to the fact that an nn.Module.forward is defined as
```
def _forward_unimplemented(self, *args):
    etc.

class nn.Module():
    forward = _forward_unimplemented
```
We expect this bug to occur every time a forward method is written outside of the module and assigned subsequently.
The current patch only fixes the `_forward_unimplemented`-related error.

cc @tcbegley 