### PR TITLE
[Feature] Add NormalParamSplitter

### DIFF
--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -12,7 +12,7 @@ import torch
 from tensordict.nn.utils import mappings
 from torch import distributions as D, nn
 
-__all__ = ["NormalParamWrapper", "Delta"]
+__all__ = ["NormalParamWrapper", "NormalParamSplitter", "Delta"]
 
 # speeds up distribution construction
 D.Distribution.set_default_validate_args(False)
@@ -66,6 +66,54 @@ class NormalParamWrapper(nn.Module):
         if not isinstance(net_output, torch.Tensor):
             net_output, *others = net_output
         loc, scale = net_output.chunk(2, -1)
+        scale = mappings(self.scale_mapping)(scale).clamp_min(self.scale_lb)
+        return (loc, scale, *others)
+
+
+class NormalParamSplitter(nn.Module):
+    """A non-parametric nn.Module that splits its input into loc and scale parameters.
+
+    The scale parameters are mapped onto positive values using the specified ``scale_mapping``.
+
+    Args:
+        scale_mapping (str, optional): positive mapping function to be used with the std.
+            default = "biased_softplus_1.0" (i.e. softplus map with bias such that fn(0.0) = 1.0)
+            choices: "softplus", "exp", "relu", "biased_softplus_1";
+        scale_lb (Number, optional): The minimum value that the variance can take. Default is 1e-4.
+
+    Examples:
+        >>> import torch
+        >>> from tensordict.nn.distributions import NormalParamSplitter
+        >>> from torch import nn
+        >>> module = nn.Linear(3, 4)
+        >>> normal_params = NormalParamSplitter()
+        >>> tensor = torch.randn(3)
+        >>> loc, scale = normal_params(module(tensor))
+        >>> print(loc.shape, scale.shape)
+        torch.Size([2]) torch.Size([2])
+        >>> assert (scale > 0).all()
+        >>> # with modules that return more than one tensor
+        >>> module = nn.LSTM(3, 4)
+        >>> tensor = torch.randn(4, 2, 3)
+        >>> loc, scale, others = normal_params(*module(tensor))
+        >>> print(loc.shape, scale.shape)
+        torch.Size([4, 2, 2]) torch.Size([4, 2, 2])
+        >>> assert (scale > 0).all()
+
+    """
+
+    def __init__(
+        self,
+        scale_mapping: str = "biased_softplus_1.0",
+        scale_lb: Number = 1e-4,
+    ) -> None:
+        super().__init__()
+        self.scale_mapping = scale_mapping
+        self.scale_lb = scale_lb
+
+    def forward(self, *tensors: torch.Tensor) -> Tuple[torch.Tensor]:
+        tensor, *others = tensors
+        loc, scale = tensor.chunk(2, -1)
         scale = mappings(self.scale_mapping)(scale).clamp_min(self.scale_lb)
         return (loc, scale, *others)
 

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -121,15 +121,18 @@ class ProbabilisticTensorDictModule(nn.Module):
         ...     ProbabilisticTensorDictSequential,
         ...     TensorDictModule,
         ... )
-        >>> from tensordict.nn.distributions import NormalParamWrapper
+        >>> from tensordict.nn.distributions import NormalParamSplitter
         >>> from tensordict.nn.functional_modules import make_functional
         >>> from torch.distributions import Normal
         >>> td = TensorDict(
         ...     {"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3]
         ... )
-        >>> net = NormalParamWrapper(torch.nn.GRUCell(4, 8))
+        >>> net = torch.nn.GRUCell(4, 8)
         >>> module = TensorDictModule(
-        ...     net, in_keys=["input", "hidden"], out_keys=["loc", "scale"]
+        ...     net, in_keys=["input", "hidden"], out_keys=["params"]
+        ... )
+        >>> normal_params = TensorDictModule(
+        ...     NormalParamSplitter(), in_keys=["params"], out_keys=["loc", "scale"]
         ... )
         >>> prob_module = ProbabilisticTensorDictModule(
         ...     in_keys=["loc", "scale"],
@@ -137,7 +140,9 @@ class ProbabilisticTensorDictModule(nn.Module):
         ...     distribution_class=Normal,
         ...     return_log_prob=True,
         ... )
-        >>> td_module = ProbabilisticTensorDictSequential(module, prob_module)
+        >>> td_module = ProbabilisticTensorDictSequential(
+        ...     module, normal_params, prob_module
+        ... )
         >>> params = make_functional(td_module, funs_to_decorate=["forward", "get_dist"])
         >>> _ = td_module(td, params=params)
         >>> print(td)
@@ -147,6 +152,7 @@ class ProbabilisticTensorDictModule(nn.Module):
                 hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
                 input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                params: Tensor(torch.Size([3, 8]), dtype=torch.float32),
                 sample_log_prob: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                 scale: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
             batch_size=torch.Size([3]),
@@ -166,6 +172,7 @@ class ProbabilisticTensorDictModule(nn.Module):
                 hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
                 input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                 loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                params: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
                 sample_log_prob: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                 scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32)},
             batch_size=torch.Size([4, 3]),


### PR DESCRIPTION
## Description

This PR adds a new module `NormalParamSplitter` which behaves much like `NormalParamWrapper`, but is intended to be used as a component in a sequence rather than a wrapper around another module.

I haven't yet deprecated the `NormalParamWrapper` so as not to break TorchRL.

This is branching off `deprecate-old-probabilistic-module` as the changes there are quite substantially relevant to these changes, so this shouldn't be merged before #109 