### PR TITLE
[Refactor] Refactor dispatch_kwargs for easier usage

### DIFF
--- a/docs/source/reference/nn.rst
+++ b/docs/source/reference/nn.rst
@@ -47,6 +47,7 @@ additional input from the tensordict as necessary. Here's an example:
 
 .. code-block::
 
+  >>> from tensordict.nn import TensorDictSequential
   >>> class Net(nn.Module):
   ...     def __init__(self, input_size=100, hidden_size=50, output_size=10):
   ...         super().__init__()
@@ -163,7 +164,7 @@ to build distributions from network outputs and get summary statistics or sample
   ... )
   >>> net = torch.nn.GRUCell(4, 8)
   >>> module = TensorDictModule(
-  ...     NormalParamWrapper(net), in_keys=["input", "hidden"], out_keys=["embed"]
+  ...     NormalParamWrapper(net), in_keys=["input", "hidden"], out_keys=["loc", "scale"]
   ... )
   >>> prob_module = ProbabilisticTensorDictModule(
   ...     in_keys=["loc", "scale"],
@@ -230,7 +231,7 @@ the structure of the model. In the following example, we show that
   >>> out = model(x, params=params)  # params is the last arg (or kwarg)
   >>> intermediate = model[0](x, params["0"])
   >>> out2 = model[1](intermediate, params["1"])
-  >>> assert torch.testing.assert_close(out, out2)
+  >>> torch.testing.assert_close(out, out2)
 
 Alternatively, parameters can also be constructed using the following methods:
 

--- a/docs/source/reference/nn.rst
+++ b/docs/source/reference/nn.rst
@@ -3,6 +3,193 @@
 tensordict.nn package
 =====================
 
+The tensordict.nn package makes it possible to flexibly use TensorDict within
+ML pipelines.
+
+Since TensorDict turns parts of one's code to a key-based structure, it is now
+possible to build complex graph structures using these keys as hooks.
+The basic building block is :obj:`TensorDictModule`, which wraps an :obj:`nn.Module`
+instance with a list of input and output keys:
+
+.. code-block::
+
+  >>> from torch.nn import Transformer
+  >>> from tensordict import TensorDict
+  >>> from tensordict.nn import TensorDictModule
+  >>> import torch
+  >>> module = TensorDictModule(Transformer(), in_keys=["feature", "target"], out_keys=["prediction"])
+  >>> data = TensorDict({"feature": torch.randn(10, 11, 512), "target": torch.randn(10, 11, 512)}, [10, 11])
+  >>> data = module(data)
+  >>> print(data)
+  TensorDict(
+      fields={
+          feature: Tensor(torch.Size([10, 11, 512]), dtype=torch.float32),
+          prediction: Tensor(torch.Size([10, 11, 512]), dtype=torch.float32),
+          target: Tensor(torch.Size([10, 11, 512]), dtype=torch.float32)},
+      batch_size=torch.Size([10, 11]),
+      device=None,
+      is_shared=False)
+
+One does not necessarily need to use :obj:`TensorDictModule`, a custom :obj:`nn.Module`
+with an ordered list of input and output keys (named :obj:`module.in_keys` and
+:obj:`module.out_keys`) will suffice.
+
+A key pain-point of multiple PyTorch users is the inability of nn.Sequential to
+handle modules with multiple inputs. Working with key-based graphs can easily
+solve that problem as each node in the sequence knows what data needs to be
+read and where to write it.
+
+For this purpose, we provide the TensorDictSequential class which passes data
+through a sequence of TensorDictModules. Each module in the sequence takes its
+input from, and writes its output to the original TensorDict, meaning it's possible
+for modules in the sequence to ignore output from their predecessors, or take
+additional input from the tensordict as necessary. Here's an example:
+
+.. code-block::
+
+  >>> class Net(nn.Module):
+  ...     def __init__(self, input_size=100, hidden_size=50, output_size=10):
+  ...         super().__init__()
+  ...         self.fc1 = nn.Linear(input_size, hidden_size)
+  ...         self.fc2 = nn.Linear(hidden_size, output_size)
+  ...
+  ...     def forward(self, x):
+  ...         x = torch.relu(self.fc1(x))
+  ...         return self.fc2(x)
+  ...
+  >>> class Masker(nn.Module):
+  ...     def forward(self, x, mask):
+  ...         return torch.softmax(x * mask, dim=1)
+  ...
+  >>> net = TensorDictModule(
+  ...     Net(), in_keys=[("input", "x")], out_keys=[("intermediate", "x")]
+  ... )
+  >>> masker = TensorDictModule(
+  ...     Masker(),
+  ...     in_keys=[("intermediate", "x"), ("input", "mask")],
+  ...     out_keys=[("output", "probabilities")],
+  ... )
+  >>> module = TensorDictSequential(net, masker)
+  >>>
+  >>> td = TensorDict(
+  ...     {
+  ...         "input": TensorDict(
+  ...             {"x": torch.rand(32, 100), "mask": torch.randint(2, size=(32, 10))},
+  ...             batch_size=[32],
+  ...         )
+  ...     },
+  ...     batch_size=[32],
+  ... )
+  >>> td = module(td)
+  >>> print(td)
+  TensorDict(
+      fields={
+          input: TensorDict(
+              fields={
+                  mask: Tensor(torch.Size([32, 10]), dtype=torch.int64),
+                  x: Tensor(torch.Size([32, 100]), dtype=torch.float32)},
+              batch_size=torch.Size([32]),
+              device=None,
+              is_shared=False),
+          intermediate: TensorDict(
+              fields={
+                  x: Tensor(torch.Size([32, 10]), dtype=torch.float32)},
+              batch_size=torch.Size([32]),
+              device=None,
+              is_shared=False),
+          output: TensorDict(
+              fields={
+                  probabilities: Tensor(torch.Size([32, 10]), dtype=torch.float32)},
+              batch_size=torch.Size([32]),
+              device=None,
+              is_shared=False)},
+      batch_size=torch.Size([32]),
+      device=None,
+      is_shared=False)
+
+We can also select sub-graphs easily throught the :obj:`TensorDictSequential.select_subsequence(in_keys, out_keys)` method:
+
+.. code-block::
+
+  >>> sub_module = module.select_subsequence(out_keys=[("intermediate", "x")])
+  >>> td = TensorDict(
+  ...     {
+  ...         "input": TensorDict(
+  ...             {"x": torch.rand(32, 100), "mask": torch.randint(2, size=(32, 10))},
+  ...             batch_size=[32],
+  ...         )
+  ...     },
+  ...     batch_size=[32],
+  ... )
+  >>> sub_module(td)
+  >>> print(td)  # the "output" has not been computed
+  TensorDict(
+      fields={
+          input: TensorDict(
+              fields={
+                  mask: Tensor(torch.Size([32, 10]), dtype=torch.int64),
+                  x: Tensor(torch.Size([32, 100]), dtype=torch.float32)},
+              batch_size=torch.Size([32]),
+              device=None,
+              is_shared=False),
+          intermediate: TensorDict(
+              fields={
+                  x: Tensor(torch.Size([32, 10]), dtype=torch.float32)},
+              batch_size=torch.Size([32]),
+              device=None,
+              is_shared=False)},
+      batch_size=torch.Size([32]),
+      device=None,
+      is_shared=False)
+
+Finally, tensordict.nn comes with a :obj:`ProbabilisticTensorDictModule` that allows
+to build distributions from network outputs and get summary statistics or samples from it
+(along with the distribution parameters):
+
+.. code-block::
+
+  >>> import torch
+  >>> from tensordict import TensorDict
+  >>> from tensordict.nn import TensorDictModule
+  >>> from tensordict.nn.distributions import NormalParamExtractor
+  >>> from tensordict.nn.functional_modules import make_functional
+  >>> from tensordict.nn.prototype import (
+  ...     ProbabilisticTensorDictModule,
+  ...     ProbabilisticTensorDictSequential,
+  ... )
+  >>> from torch.distributions import Normal
+  >>> td = TensorDict(
+  ...     {"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3]
+  ... )
+  >>> net = torch.nn.GRUCell(4, 8)
+  >>> module = TensorDictModule(
+  ...     net, in_keys=["input", "hidden"], out_keys=["embed"]
+  ... )
+  >>> extractor = TensorDictModule(
+  ...     NormalParamExtractor(), in_keys=["embed"], out_keys=["loc", "scale"]
+  ... )
+  >>> prob_module = ProbabilisticTensorDictModule(
+  ...     in_keys=["loc", "scale"],
+  ...     out_keys=["sample"],
+  ...     distribution_class=Normal,
+  ...     return_log_prob=True,
+  ... )
+  >>> td_module = ProbabilisticTensorDictSequential(module, extractor, prob_module)
+  >>> td_module(td)
+  >>> print(td)
+  TensorDict(
+      fields={
+          action: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+          hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+          input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+          loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+          sample_log_prob: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+          scale: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
+      batch_size=torch.Size([3]),
+      device=None,
+      is_shared=False)
+
+
 .. autosummary::
     :toctree: generated/
     :template: td_template_noinherit.rst
@@ -12,6 +199,17 @@ tensordict.nn package
     TensorDictSequential
     TensorDictModuleWrapper
 
+Functional
+----------
+
+.. autosummary::
+    :toctree: generated/
+    :template: rl_template_noinherit.rst
+
+    get_functional
+    make_functional
+    repopulate_module
+
 Utils
 -----
 
@@ -19,6 +217,9 @@ Utils
     :toctree: generated/
     :template: rl_template_noinherit.rst
 
+    make_tensordict
+    dispatch_kwargs
+    set_interaction_mode
     mappings
     inv_softplus
     biased_softplus

--- a/tensordict/nn/__init__.py
+++ b/tensordict/nn/__init__.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .common import *
-from .sequence import *
-from .probabilistic import *
+from .common import dispatch_kwargs, TensorDictModule, TensorDictModuleWrapper
 from .functional_modules import get_functional, make_functional, repopulate_module
+from .probabilistic import ProbabilisticTensorDictModule, set_interaction_mode
+from .sequence import TensorDictSequential

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -126,7 +126,13 @@ def dispatch_kwargs(func):
                 else:
                     expected_key = key
                 if expected_key in kwargs:
-                    tensordict_values[key] = kwargs.pop(expected_key)
+                    try:
+                        tensordict_values[key] = kwargs.pop(expected_key)
+                    except KeyError:
+                        raise KeyError(
+                            f"The key {expected_key} wasn't found in the keyword arguments "
+                            f"but is expected to execute that function."
+                        )
             tensordict = make_tensordict(tensordict_values)
             out = func(self, tensordict, *args, **kwargs)
             out = tuple(out[key] for key in self.out_keys)

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 
 import warnings
 from textwrap import indent
@@ -58,14 +59,78 @@ def _check_all_nested(list_of_keys):
 
 
 def dispatch_kwargs(func):
+    """Allows for a function expecting a TensorDict to be called using kwargs.
+
+    This method must be used within modules that have an :obj:`in_keys` and
+    :obj:`out_keys` attributes indicating what keys to be read and written
+    from the tensordict. The wrapped function should also have a :obj:`tensordict`
+    leading argument.
+
+    The resulting function will return a single tensor (if there is a single
+    element in out_keys), otherwise it will return a tuple sorted as the :obj:`out_keys`
+    of the module.
+
+    Examples:
+        >>> class MyModule(nn.Module):
+        ...     in_keys = ["a"]
+        ...     out_keys = ["b"]
+        ...
+        ...     @dispatch_kwargs
+        ...     def forward(self, tensordict):
+        ...         tensordict['b'] = tensordict['a'] + 1
+        ...         return tensordict
+        ...
+        >>> module = MyModule()
+        >>> b = module(a=torch.zeros(1, 2))
+        >>> assert (b == 1).all()
+
+    For nested keys, it is assumed that an underscore (`_`) is used to join the
+    sub-keys.
+
+    Examples:
+        >>> class MyModuleNest(nn.Module):
+        ...     in_keys = [("a", "c")]
+        ...     out_keys = ["b"]
+        ...
+        ...     @dispatch_kwargs
+        ...     def forward(self, tensordict):
+        ...         tensordict['b'] = tensordict['a', 'c'] + 1
+        ...         return tensordict
+        ...
+        >>> module = MyModuleNest()
+        >>> b, = module(a_c=torch.zeros(1, 2))
+        >>> assert (b == 1).all()
+
+
+    """
+
+    # sanity check
+    for i, key in enumerate(inspect.signature(func).parameters):
+        if i == 0:
+            # skip self
+            continue
+        if key != "tensordict":
+            raise RuntimeError(
+                "the first argument of the wrapped function must be "
+                "named 'tensordict'."
+            )
+        break
+
     @functools.wraps(func)
     def wrapper(self, tensordict=None, *args, **kwargs):
         if tensordict is None:
             tensordict_values = {}
             for key in self.in_keys:
-                if key in kwargs:
-                    tensordict_values[key] = kwargs.pop(key)
-            tensordict = make_tensordict(**tensordict_values)
+                if isinstance(key, tuple):
+                    expected_key = "_".join(key)
+                else:
+                    expected_key = key
+                if expected_key in kwargs:
+                    tensordict_values[key] = kwargs.pop(expected_key)
+            tensordict = make_tensordict(tensordict_values)
+            out = func(self, tensordict, *args, **kwargs)
+            out = tuple(out[key] for key in self.out_keys)
+            return out[0] if len(out) == 1 else out
         return func(self, tensordict, *args, **kwargs)
 
     return wrapper

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -23,7 +23,7 @@ except ImportError:
 
 import torch
 
-from tensordict.nn.common import TensorDictModule
+from tensordict.nn.common import dispatch_kwargs, TensorDictModule
 from tensordict.nn.probabilistic import ProbabilisticTensorDictModule
 from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
 from tensordict.utils import _normalize_key, NESTED_KEY
@@ -225,6 +225,7 @@ class TensorDictSequential(TensorDictModule):
             tensordict._update_valid_keys()
         return tensordict
 
+    @dispatch_kwargs
     def forward(
         self,
         tensordict: TensorDictBase,

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5607,6 +5607,7 @@ def _expand_to_match_shape(parent_batch_size, tensor, self_batch_dims, self_devi
 
 
 def make_tensordict(
+    input_dict: Optional[dict] = None,
     batch_size: Optional[Union[Sequence[int], torch.Size, int]] = None,
     device: Optional[DEVICE_TYPING] = None,
     **kwargs,  # source
@@ -5616,11 +5617,16 @@ def make_tensordict(
     If batch_size is not specified, returns the maximum batch size possible
 
     Args:
-        **kwargs (TensorDict or torch.Tensor): keyword arguments as data source.
+        input_dict (dictionary, optional): a dictionary to use as a data source
+            (nested keys compatible).
+        **kwargs (TensorDict or torch.Tensor): keyword arguments as data source
+            (incompatible with nested keys).
         batch_size (iterable of int, optional): a batch size for the tensordict.
         device (torch.device or compatible type, optional): a device for the TensorDict.
 
     """
+    if input_dict:
+        kwargs.update(input_dict)
     if batch_size is None:
         batch_size = _find_max_batch_size(kwargs)
     # _run_checks=False breaks because a tensor may have the same batch-size as the tensordict

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -412,8 +412,26 @@ class TestTDModule:
         tdm = TensorDictModule(nn.Linear(1, 1), ["a"], ["b"])
         td = TensorDict({"a": torch.zeros(1, 1)}, 1)
         tdm(td)
-        td2 = tdm(a=torch.zeros(1, 1))
-        assert (td2 == td).all()
+        out = tdm(a=torch.zeros(1, 1))
+        assert (out == td["b"]).all()
+
+    def test_dispatch_kwargs_nested(self):
+        tdm = TensorDictModule(nn.Linear(1, 1), [("a", "c")], [("b", "d")])
+        td = TensorDict({("a", "c"): torch.zeros(1, 1)}, [1])
+        tdm(td)
+        out = tdm(a_c=torch.zeros(1, 1))
+        assert (out == td["b", "d"]).all()
+
+    def test_dispatch_kwargs_multi(self):
+        tdm = TensorDictSequential(
+            TensorDictModule(nn.Linear(1, 1), [("a", "c")], [("b", "d")]),
+            TensorDictModule(nn.Linear(1, 1), [("a", "c")], ["e"]),
+        )
+        td = TensorDict({("a", "c"): torch.zeros(1, 1)}, [1])
+        tdm(td)
+        out1, out2 = tdm(a_c=torch.zeros(1, 1))
+        assert (out1 == td["b", "d"]).all()
+        assert (out2 == td["e"]).all()
 
     def test_dispatch_kwargs_module_with_additional_parameters(self):
         class MyModule(nn.Identity):


### PR DESCRIPTION
## Description

Refactors `dispatch_kwargs` for a completely `TensorDict` oblivious behviour.

Allows to call a TDModule, TDSequential or any other module decorated with `dispatch_kwargs` with a set of keyword arguments. The function will return a tuple or tensors or a single tensor, depending on the number of module outputs.

@tcbegley 