### PR TITLE
[Feature] Add metaclass for TensorClass instances

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -27,6 +27,23 @@ OPTIONAL_PATTERN = re.compile(r"Optional\[(.*?)\]")
 UNION_PATTERN = re.compile(r"Union\[(.*?)\]")
 
 
+class InvalidAttributeName(ValueError):
+    pass
+
+
+class _TensorClassMeta(type):
+    def __new__(cls, clsname, bases, attrs):
+        datacls = bases[0]
+        for attr in datacls.__dataclass_fields__:
+            if attr == "batch_size":
+                continue
+            if attr in dir(TensorDict):
+                raise InvalidAttributeName(
+                    f"Attribute name {attr} can't be used with @tensorclass"
+                )
+        return super().__new__(cls, clsname, bases, attrs)
+
+
 def tensorclass(cls: T) -> T:
     """A decorator to create :obj:`tensorclass` classes.
 
@@ -91,9 +108,8 @@ def tensorclass(cls: T) -> T:
 
     EXPECTED_KEYS = set(datacls.__dataclass_fields__.keys())
 
-    class _TensorClass(datacls):
+    class _TensorClass(datacls, metaclass=_TensorClassMeta):
         def __init__(self, *args, _tensordict=None, **kwargs):
-
             if (args or kwargs) and _tensordict is not None:
                 raise ValueError("Cannot pass both args/kwargs and _tensordict.")
 
@@ -103,7 +119,7 @@ def tensorclass(cls: T) -> T:
                         f"Keys from the tensordict ({set(_tensordict.keys())}) must correspond to the class attributes ({EXPECTED_KEYS - {'batch_size'} })."
                     )
                 input_dict = {key: None for key in _tensordict.keys()}
-                datacls.__init__(self, **input_dict, batch_size=_tensordict.batch_size)
+                super().__init__(**input_dict, batch_size=_tensordict.batch_size)
                 self.tensordict = _tensordict
             else:
 
@@ -125,14 +141,7 @@ def tensorclass(cls: T) -> T:
                     for key, value in kwargs.items()
                 }
 
-                datacls.__init__(self, *new_args, **new_kwargs)
-
-                attributes = [key for key in self.__dict__ if key != "batch_size"]
-                for attr in attributes:
-                    if attr in dir(TensorDict):
-                        raise Exception(
-                            f"Attribute name {attr} can't be used with @tensorclass"
-                        )
+                super().__init__(*new_args, **new_kwargs)
 
                 self.tensordict = TensorDict(
                     {

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -27,10 +27,6 @@ OPTIONAL_PATTERN = re.compile(r"Optional\[(.*?)\]")
 UNION_PATTERN = re.compile(r"Union\[(.*?)\]")
 
 
-class InvalidAttributeName(ValueError):
-    pass
-
-
 class _TensorClassMeta(type):
     def __new__(cls, clsname, bases, attrs):
         datacls = bases[0]
@@ -38,7 +34,7 @@ class _TensorClassMeta(type):
             if attr == "batch_size":
                 continue
             if attr in dir(TensorDict):
-                raise InvalidAttributeName(
+                raise AttributeError(
                     f"Attribute name {attr} can't be used with @tensorclass"
                 )
         return super().__new__(cls, clsname, bases, attrs)

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -10,6 +10,7 @@ import torch
 
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import tensorclass
+from tensordict.prototype.tensorclass import InvalidAttributeName
 from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
 from torch import Tensor
 
@@ -24,7 +25,6 @@ class MyData:
 
 
 def test_dataclass():
-
     data = MyData(
         X=torch.ones(3, 4, 5),
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
@@ -34,7 +34,6 @@ def test_dataclass():
 
 
 def test_type():
-
     data = MyData(
         X=torch.ones(3, 4, 5),
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
@@ -94,7 +93,6 @@ def test_banned_types():
 
 
 def test_attributes():
-
     X = torch.ones(3, 4, 5)
     y = torch.zeros(3, 4, 5, dtype=torch.bool)
     batch_size = [3, 4]
@@ -115,6 +113,19 @@ def test_attributes():
     assert data.batch_size == batch_size
     assert equality_tensordict.all()
     assert equality_tensordict.batch_size == torch.Size(batch_size)
+
+
+def test_disallowed_attributes():
+    with pytest.raises(
+        InvalidAttributeName,
+        match="Attribute name reshape can't be used with @tensorclass",
+    ):
+
+        @tensorclass
+        class MyInvalidClass:
+            x: torch.Tensor
+            y: torch.Tensor
+            reshape: torch.Tensor
 
 
 def test_indexing():

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -10,7 +10,6 @@ import torch
 
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import tensorclass
-from tensordict.prototype.tensorclass import InvalidAttributeName
 from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
 from torch import Tensor
 
@@ -117,7 +116,7 @@ def test_attributes():
 
 def test_disallowed_attributes():
     with pytest.raises(
-        InvalidAttributeName,
+        AttributeError,
         match="Attribute name reshape can't be used with @tensorclass",
     ):
 

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -8,7 +8,6 @@ import torch
 
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import tensorclass
-from tensordict.prototype.tensorclass import InvalidAttributeName
 from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
 from torch import Tensor
 
@@ -115,7 +114,7 @@ def test_attributes():
 
 def test_disallowed_attributes():
     with pytest.raises(
-        InvalidAttributeName,
+        AttributeError,
         match="Attribute name reshape can't be used with @tensorclass",
     ):
 

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -8,6 +8,7 @@ import torch
 
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import tensorclass
+from tensordict.prototype.tensorclass import InvalidAttributeName
 from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
 from torch import Tensor
 
@@ -22,7 +23,6 @@ class MyData:
 
 
 def test_dataclass():
-
     data = MyData(
         X=torch.ones(3, 4, 5),
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
@@ -32,7 +32,6 @@ def test_dataclass():
 
 
 def test_type():
-
     data = MyData(
         X=torch.ones(3, 4, 5),
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
@@ -92,7 +91,6 @@ def test_banned_types():
 
 
 def test_attributes():
-
     X = torch.ones(3, 4, 5)
     y = torch.zeros(3, 4, 5, dtype=torch.bool)
     batch_size = [3, 4]
@@ -113,6 +111,19 @@ def test_attributes():
     assert data.batch_size == batch_size
     assert equality_tensordict.all()
     assert equality_tensordict.batch_size == torch.Size(batch_size)
+
+
+def test_disallowed_attributes():
+    with pytest.raises(
+        InvalidAttributeName,
+        match="Attribute name reshape can't be used with @tensorclass",
+    ):
+
+        @tensorclass
+        class MyInvalidClass:
+            x: torch.Tensor
+            y: torch.Tensor
+            reshape: torch.Tensor
 
 
 def test_indexing():


### PR DESCRIPTION
## Description

This PR creates a new `_TensorClassMeta` metaclass, which checks the dataclass field names against reserved TensorDict attributes / methods when the class is defined, rather than when the first instance is created.

This prevents users from being able to define a class that could never be instantiated without error, and moves the error closer to the source of the problem.

cc: @roccajoseph 