### PR TITLE
[Feature] Tensorclass device

### DIFF
--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -8,6 +8,8 @@ from typing import Any, Optional, Union
 import pytest
 import torch
 
+from _utils_internal import get_available_devices
+
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import tensorclass
 from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
@@ -21,6 +23,19 @@ class MyData:
 
     def stuff(self):
         return self.X + self.y
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_device(device):
+    data = MyData(
+        X=torch.ones(3, 4, 5),
+        y=torch.zeros(3, 4, 5, dtype=torch.bool),
+        batch_size=[3, 4],
+        device=device,
+    )
+    assert data.device == device
+    assert data.X.device == device
+    assert data.y.device == device
 
 
 def test_dataclass():

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -25,19 +25,6 @@ class MyData:
         return self.X + self.y
 
 
-@pytest.mark.parametrize("device", get_available_devices())
-def test_device(device):
-    data = MyData(
-        X=torch.ones(3, 4, 5),
-        y=torch.zeros(3, 4, 5, dtype=torch.bool),
-        batch_size=[3, 4],
-        device=device,
-    )
-    assert data.device == device
-    assert data.X.device == device
-    assert data.y.device == device
-
-
 def test_dataclass():
     data = MyData(
         X=torch.ones(3, 4, 5),
@@ -54,6 +41,19 @@ def test_type():
         batch_size=[3, 4],
     )
     assert isinstance(data, MyData)
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_device(device):
+    data = MyData(
+        X=torch.ones(3, 4, 5),
+        y=torch.zeros(3, 4, 5, dtype=torch.bool),
+        batch_size=[3, 4],
+        device=device,
+    )
+    assert data.device == device
+    assert data.X.device == device
+    assert data.y.device == device
 
 
 def test_banned_types():

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -6,6 +6,8 @@ from typing import Any, Optional, Union
 import pytest
 import torch
 
+from _utils_internal import get_available_devices
+
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import tensorclass
 from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
@@ -37,6 +39,21 @@ def test_type():
         batch_size=[3, 4],
     )
     assert isinstance(data, MyData)
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_device(device):
+    data = MyData(
+        X=torch.ones(3, 4, 5),
+        y=torch.zeros(3, 4, 5, dtype=torch.bool),
+        batch_size=[3, 4],
+        device=device,
+    )
+    assert data.device == device
+    assert data.X.device == device
+    assert data.y.device == device
+
+
 
 
 def test_banned_types():

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -54,8 +54,6 @@ def test_device(device):
     assert data.y.device == device
 
 
-
-
 def test_banned_types():
     @tensorclass
     class MyAnyClass:


### PR DESCRIPTION
## Description

This PR allows the user to specify `device` when instantiating a TensorClass (`@tensorclass` decorated dataclass).