### PR TITLE
Support propagation of in-place modifications to masked tensordict 

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3436,6 +3436,16 @@ def test_shared_inheritance():
     assert td0.is_shared()
 
 
+def test_in_place_set_to_masked_tensordict():
+    # Related to https://github.com/pytorch/rl/issues/298
+    td = TensorDict({"a": torch.randn(3, 4, 2), "b": torch.randn(3, 4)}, [3, 4])
+
+    mask = torch.tensor([True, False, True])
+    x = torch.randn(2, 4, 2)
+    td[mask]["a"] = x
+    torch.testing.assert_allclose(td[mask]["a"], x)
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)


### PR DESCRIPTION
## Description

This is an attempt to solve this issue: https://github.com/pytorch/rl/issues/298

My goal is not to change the behaviour of __getitem__ but just __setitem__. I have added a new test that matches the example of the issue.

I just have a problem with the `test_nested_td_index` test:

```
test/test_tensordict.py:1640 (TestTensorDicts.test_nested_td_index[device0-idx_td])
Traceback (most recent call last):
  File "/Users/waris/Projects/tensordict/test/test_tensordict.py", line 1669, in test_nested_td_index
    td["sub_td", "sub_sub_td"] = other_sub_sub_td
  File "/Users/waris/Projects/tensordict/tensordict/tensordict.py", line 1984, in __setitem__
    source.__setitem__(index, value)
  File "/Users/waris/Projects/tensordict/tensordict/tensordict.py", line 2012, in __setitem__
    self.set(index, value, inplace=isinstance(self, SubTensorDict))
  File "/Users/waris/Projects/tensordict/tensordict/tensordict.py", line 3512, in set
    return self.set_(key, tensor)
  File "/Users/waris/Projects/tensordict/tensordict/tensordict.py", line 3588, in set_
    self._source.set_at_(key, tensor, self.idx)
  File "/Users/waris/Projects/tensordict/tensordict/tensordict.py", line 2699, in set_at_
    _set_item(tensor_in, value, idx)
  File "/Users/waris/Projects/tensordict/tensordict/utils.py", line 640, in _set_item
    tensor[index] = value
  File "/Users/waris/Projects/tensordict/tensordict/tensordict.py", line 2028, in __setitem__
    raise RuntimeError(
RuntimeError: indexed destination TensorDict batch size is torch.Size([4, 3, 2, 1]) (batch_size = torch.Size([2, 4, 3, 2, 1]), index=(1,)), which differs from the source batch size torch.Size([4, 3, 2, 1, 2, 2])
```


I'm trying to figure out what the problem might be. Please let me know if this PR seems relevant :)


## Motivation and Context

It will close https://github.com/pytorch/rl/issues/298

- [X] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [X] I have updated the documentation accordingly.
