### PR TITLE
[BugFix] add skipif not _has_functorch

### DIFF
--- a/test/test_functorch.py
+++ b/test/test_functorch.py
@@ -114,6 +114,9 @@ def test_vmap_tdmodule_functorch(moduletype, batch_params):
         assert y.shape == torch.Size([10, 2, 3])
 
 
+@pytest.mark.skipif(
+    not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+)
 @pytest.mark.parametrize(
     "moduletype,batch_params",
     [
@@ -235,6 +238,9 @@ def test_vmap_tdsequence_functorch(moduletype, batch_params):
         assert z.shape == torch.Size([10, 2, 3])
 
 
+@pytest.mark.skipif(
+    not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+)
 @pytest.mark.parametrize(
     "moduletype,batch_params",
     [
@@ -308,6 +314,9 @@ def test_repopulate():
     assert len(new_buffers)
 
 
+@pytest.mark.skipif(
+    not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+)
 def test_nested_modules():
     class LinearWithKwargs(Linear):
         """Checks that modules with kwargs work equally well."""


### PR DESCRIPTION
Some test use functorch's vmap function. Currently, this is defined only if functorch is available. Thus, we need to skip all related tests if functorch is not available
