### PR TITLE
[Feature] Stacking tensors of different shape

### DIFF
--- a/tensordict/metatensor.py
+++ b/tensordict/metatensor.py
@@ -96,7 +96,7 @@ class MetaTensor:
     @property
     def shape(self):
         _shape = self._shape
-        if _shape is None:
+        if _shape is None and self._tensor is not None:
             _shape = self._shape = _shape_fn(self._tensor)
         return _shape
 
@@ -114,7 +114,7 @@ class MetaTensor:
     @property
     def dtype(self):
         _dtype = self._dtype
-        if _dtype is None and not self.is_tensordict():
+        if _dtype is None and not self.is_tensordict() and self._tensor is not None:
             _dtype = self._dtype = _dtype_fn(self._tensor)
         return _dtype
 
@@ -122,7 +122,8 @@ class MetaTensor:
         _is_tensordict = self._is_tensordict
         if _is_tensordict is None:
             _is_tensordict = self._is_tensordict = (
-                not isinstance(self._tensor, torch.Tensor)
+                self._tensor is not None
+                and not isinstance(self._tensor, torch.Tensor)
                 and not self.is_memmap()
                 and not self.is_kjt()
             )
@@ -165,15 +166,20 @@ class MetaTensor:
         _is_kjt: Optional[bool] = None,
         _repr_tensordict: Optional[str] = None,
     ):
-        tensor = None
-        if len(shape) == 1 and not isinstance(shape[0], (Number,)):
+        if (
+            len(shape) == 1
+            and not isinstance(shape[0], (Number,))
+            and shape[0] is not None
+        ):
             tensor = shape[0]
             self._tensor = tensor
             return
-
-        if type(shape) is not torch.Size:
-            shape = torch.Size(shape)
-        self.shape = shape
+        elif len(shape) == 1 and shape[0] is None:
+            self.shape = None
+        else:
+            if type(shape) is not torch.Size:
+                shape = torch.Size(shape)
+            self.shape = shape
         self._device = device
         self._dtype = dtype if dtype is not None else torch.get_default_dtype()
         self._ndim = len(shape)
@@ -196,7 +202,7 @@ class MetaTensor:
             name = "MemmapTensor"
         elif self._is_kjt:
             name = "KeyedJaggedTensor"
-        elif self.is_shared() and self.device.type != "cuda":
+        elif self.is_shared() and self.device and self.device.type != "cuda":
             name = "SharedTensor"
         else:
             name = "Tensor"
@@ -207,7 +213,10 @@ class MetaTensor:
         if self.is_tensordict():
             return repr(self._tensor)
         else:
-            return f"{self.class_name}({self.shape}, dtype={self.dtype})"
+            shape = self.shape
+            if shape is None:
+                shape = "*"
+            return f"{self.class_name}({shape}, dtype={self.dtype})"
 
     def memmap_(self) -> MetaTensor:
         """Changes the storage of the MetaTensor to memmap.
@@ -242,9 +251,9 @@ class MetaTensor:
         return self
 
     def is_shared(self) -> bool:
-        if self._is_shared is None:
+        if self._is_shared is None and self._tensor is not None:
             self._is_shared = self._tensor.is_shared()
-        return self._is_shared
+        return bool(self._is_shared)
 
     def numel(self) -> int:
         if self._numel is None:
@@ -428,9 +437,17 @@ def _stack_meta(
                     f"Stacking meta tensors of different dtype is not "
                     f"allowed, got shapes {dtype} and {tensor.dtype}"
                 )
-
-    shape = list(shape)
-    shape.insert(dim, len(list_of_meta_tensors))
+    for tensor in list_of_meta_tensors:
+        if tensor.shape != shape:
+            shape = (None,)
+            break
+    else:
+        shape = list(shape)
+        shape.insert(dim, len(list_of_meta_tensors))
+    if dtype is None:
+        dtype = list_of_meta_tensors[0].dtype
+    if device is None:
+        device = list_of_meta_tensors[0].device
 
     return MetaTensor(
         *shape,

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3145,9 +3145,16 @@ def _cat(
             with _ErrorInteceptor(
                 key, "Attempted to concatenate tensors on different devices at key"
             ):
-                out.set_(
-                    key, torch.cat([td.get(key) for td in list_of_tensordicts], dim)
-                )
+                if isinstance(out, TensorDict):
+                    torch.cat(
+                        [td.get(key) for td in list_of_tensordicts],
+                        dim,
+                        out=out.get(key),
+                    )
+                else:
+                    out.set_(
+                        key, torch.cat([td.get(key) for td in list_of_tensordicts], dim)
+                    )
         return out
 
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -283,20 +283,29 @@ def test_cat_td(device):
     d = {
         "key1": torch.randn(4, 5, 6, device=device),
         "key2": torch.randn(4, 5, 10, device=device),
+        "key3": {"key4": torch.randn(4, 5, 10, device=device)},
     }
     td1 = TensorDict(batch_size=(4, 5), source=d)
     d = {
         "key1": torch.randn(4, 10, 6, device=device),
         "key2": torch.randn(4, 10, 10, device=device),
+        "key3": {"key4": torch.randn(4, 10, 10, device=device)},
     }
     td2 = TensorDict(batch_size=(4, 10), source=d)
 
     td_cat = torch.cat([td1, td2], 1)
     assert td_cat.batch_size == torch.Size([4, 15])
-    d = {"key1": torch.randn(4, 15, 6), "key2": torch.randn(4, 15, 10)}
+    d = {
+        "key1": torch.zeros(4, 15, 6, device=device),
+        "key2": torch.zeros(4, 15, 10, device=device),
+        "key3": {"key4": torch.zeros(4, 15, 10, device=device)},
+    }
     td_out = TensorDict(batch_size=(4, 15), source=d)
     torch.cat([td1, td2], 1, out=td_out)
     assert td_out.batch_size == torch.Size([4, 15])
+    assert (td_out["key1"] != 0).all()
+    assert (td_out["key2"] != 0).all()
+    assert (td_out["key3", "key4"] != 0).all()
 
 
 @pytest.mark.parametrize("device", get_available_devices())


### PR DESCRIPTION
## Description

Allows to construct LazyStackedTensorDict instances containing entries with the same key but different shape.
These entries will raise an exception when queried with `get` or functions that (indirectly) call `get`, but a proper error message will point to the solution (i.e. using `get_nestedtensor`).

Partially solves
https://github.com/pytorch/rl/issues/766

cc @matteobettini