### PR TITLE
[BugFix] LazyStackedTensorDict indexing along stack_dim

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4462,19 +4462,20 @@ class LazyStackedTensorDict(TensorDictBase):
                 stack_dim=new_stack_dim,
             )
         elif isinstance(item, tuple):
-            _sub_item = tuple(
-                _item for i, _item in enumerate(item) if i == self.stack_dim
-            )
-            if len(_sub_item):
-                tensordicts = self.tensordicts[_sub_item[0]]
-                if isinstance(tensordicts, TensorDictBase):
-                    return tensordicts
-            else:
-                tensordicts = self.tensordicts
             # select sub tensordicts
             _sub_item = tuple(
                 _item for i, _item in enumerate(item) if i != self.stack_dim
             )
+
+            if self.stack_dim < len(item):
+                tensordicts = self.tensordicts[item[self.stack_dim]]
+                if isinstance(tensordicts, TensorDictBase):
+                    if _sub_item:
+                        return tensordicts[_sub_item]
+                    return tensordicts
+            else:
+                tensordicts = self.tensordicts
+
             if len(_sub_item):
                 tensordicts = [td[_sub_item] for td in tensordicts]
             new_stack_dim = self.stack_dim - sum(

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -540,6 +540,29 @@ def test_stacked_td(stack_dim, device):
 
 
 @pytest.mark.parametrize("device", get_available_devices())
+@pytest.mark.parametrize("stack_dim", [0, 1])
+def test_stacked_indexing(device, stack_dim):
+    tensordicts = [
+        TensorDict(
+            {"a": torch.randn(4, 5), "b": torch.randn(4, 5)},
+            batch_size=[4, 5],
+            device=device,
+        )
+        for _ in range(3)
+    ]
+    tds = torch.stack(tensordicts, stack_dim)
+
+    item = (2, 2)
+    assert tds[item].batch_size == torch.Size([5])
+    assert (tds[item].get("a") == tds.get("a")[item]).all()
+    assert (tds[item].get("a") == tensordicts[2].get("a")[2]).all()
+
+    item = (slice(1, 2), 2)
+    assert tds[item].batch_size == torch.Size([1, 5])
+    assert (tds[item].get("a") == tds.get("a")[item]).all()
+
+
+@pytest.mark.parametrize("device", get_available_devices())
 def test_savedtensordict(device):
     vals = [torch.randn(3, 1, device=device) for _ in range(4)]
     ss_list = [


### PR DESCRIPTION
## Description

This PR fixes a bug that arose when indexing a `LazyStackedTensorDict` along its stacking dimension.

We detect whether the stacking dimension is included in the dimensions being indexed, index the list of tensordicts, and then apply the remaining indices as necessary. This seemingly was attempted in the original implementation, but there was a logic error with remaining indices not being applied after the list had been indexed.

Previous behaviour

```python
>>> import torch
>>> from tensordict import TensorDict

>>> td = TensorDict({"a": torch.rand(3, 4), "b": torch.rand(3, 4)}, [3, 4])
>>> td = torch.stack([td, td, td], 1)

>>> print(td[2, 2])
TensorDict(
    fields={
        a: Tensor(torch.Size([3, 4]), dtype=torch.float32),
        b: Tensor(torch.Size([3, 4]), dtype=torch.float32)},
    batch_size=torch.Size([3, 4]),
    device=None,
    is_shared=False)
```

New behaviour

```python
>>> print(td[2, 2])
TensorDict(
    fields={
        a: Tensor(torch.Size([4]), dtype=torch.float32),
        b: Tensor(torch.Size([4]), dtype=torch.float32)},
    batch_size=torch.Size([4]),
    device=None,
    is_shared=False)
```

