### PR TITLE
[Feature] Support `range` in indexing operations

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1952,12 +1952,16 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             idx = torch.tensor(idx, device=self.device)
             return self._index_tensordict(idx)
 
+        if isinstance(idx, range):
+            idx = torch.tensor(idx, device=self.device)
+            return self._index_tensordict(idx)
+
         if isinstance(idx, tuple) and any(
-            isinstance(sub_index, list) for sub_index in idx
+            isinstance(sub_index, (list, range)) for sub_index in idx
         ):
             idx = tuple(
                 torch.tensor(sub_index, device=self.device)
-                if isinstance(sub_index, list)
+                if isinstance(sub_index, (list, range))
                 else sub_index
                 for sub_index in idx
             )
@@ -3449,7 +3453,7 @@ torch.Size([3, 2])
                 f"got {type(source)}"
             )
         self._source = source
-        if not isinstance(idx, (tuple, list)):
+        if not isinstance(idx, (tuple, list, range)):
             idx = (idx,)
         else:
             idx = tuple(idx)
@@ -4404,14 +4408,14 @@ class LazyStackedTensorDict(TensorDictBase):
             isinstance(_item, str) for _item in item
         ) not in [len(item), 0]:
             raise IndexError(_STR_MIXED_INDEX_ERROR)
-        if isinstance(item, list):
+        if isinstance(item, (list, range)):
             item = torch.tensor(item, device=self.device)
         if isinstance(item, tuple) and any(
-            isinstance(sub_index, list) for sub_index in item
+            isinstance(sub_index, (list, range)) for sub_index in item
         ):
             item = tuple(
                 torch.tensor(sub_index, device=self.device)
-                if isinstance(sub_index, list)
+                if isinstance(sub_index, (list, range))
                 else sub_index
                 for sub_index in item
             )
@@ -5028,14 +5032,14 @@ class SavedTensorDict(TensorDictBase):
         return super().__reduce__(*args, **kwargs)
 
     def __getitem__(self, idx: INDEX_TYPING) -> TensorDictBase:
-        if isinstance(idx, list):
+        if isinstance(idx, (list, range)):
             idx = torch.tensor(idx, device=self.device)
         if isinstance(idx, tuple) and any(
-            isinstance(sub_index, list) for sub_index in idx
+            isinstance(sub_index, (list, range)) for sub_index in idx
         ):
             idx = tuple(
                 torch.tensor(sub_index, device=self.device)
-                if isinstance(sub_index, list)
+                if isinstance(sub_index, (list, range))
                 else sub_index
                 for sub_index in idx
             )

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1982,14 +1982,14 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     ) -> None:
         if index is Ellipsis or (isinstance(index, tuple) and Ellipsis in index):
             index = convert_ellipsis_to_idx(index, self.batch_size)
-        if isinstance(index, list):
+        if isinstance(index, (list, range)):
             index = torch.tensor(index, device=self.device)
         if isinstance(index, tuple) and any(
-            isinstance(sub_index, list) for sub_index in index
+            isinstance(sub_index, (list, range)) for sub_index in index
         ):
             index = tuple(
                 torch.tensor(sub_index, device=self.device)
-                if isinstance(sub_index, list)
+                if isinstance(sub_index, (list, range))
                 else sub_index
                 for sub_index in index
             )
@@ -4360,14 +4360,14 @@ class LazyStackedTensorDict(TensorDictBase):
         return torch.stack(tensordicts, dim=self.stack_dim)
 
     def __setitem__(self, item: INDEX_TYPING, value: TensorDictBase) -> TensorDictBase:
-        if isinstance(item, list):
+        if isinstance(item, (list, range)):
             item = torch.tensor(item, device=self.device)
         if isinstance(item, tuple) and any(
-            isinstance(sub_index, list) for sub_index in item
+            isinstance(sub_index, (list, range)) for sub_index in item
         ):
             item = tuple(
                 torch.tensor(sub_index, device=self.device)
-                if isinstance(sub_index, list)
+                if isinstance(sub_index, (list, range))
                 else sub_index
                 for sub_index in item
             )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1391,6 +1391,7 @@ class TestTensorDicts(TestTensorDictsBase):
         assert_allclose_td(td[range(2)], td[[0, 1]])
         assert_allclose_td(td[range(1), range(1)], td[[0], [0]])
         assert_allclose_td(td[:, range(2)], td[:, [0, 1]])
+        assert_allclose_td(td[..., range(1)], td[..., [0]])
 
     def test_setitem_nested_dict_value(self, td_name, device):
         torch.manual_seed(1)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1355,7 +1355,9 @@ class TestTensorDicts(TestTensorDictsBase):
         for key in td_clone.keys():
             assert (td_clone[idx].get(key) == 0).all()
 
-    @pytest.mark.parametrize("idx", [slice(1), torch.tensor([0]), torch.tensor([0, 1])])
+    @pytest.mark.parametrize(
+        "idx", [slice(1), torch.tensor([0]), torch.tensor([0, 1]), range(1), range(2)]
+    )
     def test_setitem(self, td_name, device, idx):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
@@ -1382,6 +1384,13 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         assert isinstance(td["a"], (MemmapTensor, torch.Tensor))
+
+    def test_getitem_range(self, td_name, device):
+        torch.manual_seed(1)
+        td = getattr(self, td_name)(device)
+        assert_allclose_td(td[range(2)], td[[0, 1]])
+        assert_allclose_td(td[range(1), range(1)], td[[0], [0]])
+        assert_allclose_td(td[:, range(2)], td[:, [0, 1]])
 
     def test_setitem_nested_dict_value(self, td_name, device):
         torch.manual_seed(1)


### PR DESCRIPTION
## Description

This PR adds support for `range` in indexing operations, both get and set.

E.g.

```python
>>> from tensordict import TensorDict

>>> td = TensorDict({"a": [1, 2, 3, 4, 5]}, [5])
>>> print(td[range(2)])
TensorDict(
    fields={
        a: Tensor(torch.Size([2]), dtype=torch.int64)},
    batch_size=torch.Size([2]),
    device=None,
    is_shared=False)
>>> td[range(2)] = TensorDict({"a": [0, 0]}, [2])
>>> print(td["a"])
tensor([0, 0, 3, 4, 5])
```