### PR TITLE
[BugFix] Stack dimension indexing

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4475,7 +4475,16 @@ class LazyStackedTensorDict(TensorDictBase):
             )
 
             if self.stack_dim < len(item):
-                tensordicts = self.tensordicts[item[self.stack_dim]]
+                idx = item[self.stack_dim]
+                if isinstance(idx, (Number, slice)):
+                    tensordicts = self.tensordicts[idx]
+                elif isinstance(idx, torch.Tensor):
+                    tensordicts = [self.tensordicts[i] for i in idx]
+                else:
+                    raise TypeError(
+                        "Invalid index used for stack dimension. Expected number, "
+                        f"slice, or tensor-like. Got {type(idx)}"
+                    )
                 if isinstance(tensordicts, TensorDictBase):
                     if _sub_item:
                         return tensordicts[_sub_item]

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1427,6 +1427,15 @@ class TestTensorDicts(TestTensorDictsBase):
         assert_allclose_td(td[:, range(2)], td[:, [0, 1]])
         assert_allclose_td(td[..., range(1)], td[..., [0]])
 
+        if td_name in ("stacked_td", "nested_stacked_td"):
+            # this is a bit contrived, but want to check that if we pass something
+            # weird as the index to the stacking dimension we'll get the error
+            idx = (slice(None),) * td.stack_dim + ({1, 2, 3},)
+            with pytest.raises(
+                TypeError, match="Invalid index used for stack dimension."
+            ):
+                td[idx]
+
     def test_setitem_nested_dict_value(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)


### PR DESCRIPTION
## Description

This PR fixes the failing tests on main arising from the merging of #139 and #140.

#140 introduced a new test class `nested_stacked_td` with stack dimension `1` to `TestTensorDictsBase` which surfaced issues with stack dimension indexing in `LazyStackedTensorDict`. In brief, whatever was used to index the stack dimension was simply used to index the underlying list at `self.tensordicts`. Thus while numbers and slices worked fine, you would get an error if you tried to index the stack dimension with a list, tensor, or `range` object.

With these changes, things should now work as expected.