### PR TITLE
[BugFix] Prevent calls to get_nestedtensor when stack_dim is not 0

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -526,7 +526,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             )
         else:
             raise ValueError(
-                f"default should be None or a Tensor instance, " f"got {default}"
+                f"default should be None or a Tensor instance, got {default}"
             )
 
     @abc.abstractmethod
@@ -4225,6 +4225,14 @@ class LazyStackedTensorDict(TensorDictBase):
         key: NESTED_KEY,
         default: Union[str, COMPATIBLE_TYPES] = "_no_default_",
     ) -> COMPATIBLE_TYPES:
+        # disallow getting nested tensor if the stacking dimension is not 0
+        if self.stack_dim != 0:
+            raise RuntimeError(
+                "Because nested tensors can only be stacked along their first "
+                "dimension, LazyStackedTensorDict.get_nestedtensor can only be called "
+                "when the stack_dim is 0."
+            )
+
         # TODO: the stacking logic below works for nested keys, but the key in
         # self.valid_keys check will fail and we'll return the default instead.
         # For now we'll advise user that nested keys aren't supported, but it should be

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1257,7 +1257,7 @@ class TestTensorDicts(TestTensorDictsBase):
             assert td.view(-1).view(*new_shape) is td
             assert td.view(*new_shape) is td
 
-    @pytest.mark.parametrize("dim", [0, 1, -1])
+    @pytest.mark.parametrize("dim", [0, 1, -1, -5])
     @pytest.mark.parametrize(
         "key", ["heterogeneous-entry", ("sub", "heterogeneous-entry")]
     )
@@ -1277,8 +1277,18 @@ class TestTensorDicts(TestTensorDictsBase):
             RuntimeError, match="Found more than one unique shape in the tensors"
         ):
             td_stack[key]
-        # this will work: it is the proper way to get that entry
-        td_stack.get_nestedtensor(key)
+        if dim in (0, -5):
+            # this will work if stack_dim is 0 (or equivalently -self.batch_dims)
+            # it is the proper way to get that entry
+            td_stack.get_nestedtensor(key)
+        else:
+            # if the stack_dim is not zero, then calling get_nestedtensor is disallowed
+            with pytest.raises(
+                RuntimeError,
+                match="LazyStackedTensorDict.get_nestedtensor can only be called "
+                "when the stack_dim is 0.",
+            ):
+                td_stack.get_nestedtensor(key)
         with pytest.raises(
             RuntimeError, match="Found more than one unique shape in the tensors"
         ):


### PR DESCRIPTION
## Description

This PR prevents the user from calling `LazyStackedTensorDict.get_nestedtensor` unless `stack_dim` is `0`. 

I did wonder whether it should be allowed in the case where each item under that key had the same shape (in which case it would be possible to return the result of a call to `torch.stack`), but I figured that it would be surprising to get a regular tensor rather than a nested tensor from a call to `get_nestedtensor`. 