### PR TITLE
[Draft] Coding trees with TensorDict

### DIFF
--- a/tensordict/prototype/__init__.py
+++ b/tensordict/prototype/__init__.py
@@ -1,6 +1,4 @@
 from .tensorclass import is_tensorclass, tensorclass
+from .tree import make_tree
 
-__all__ = [
-    "is_tensorclass",
-    "tensorclass",
-]
+__all__ = ["is_tensorclass", "make_tree", "tensorclass"]

--- a/tensordict/prototype/tree.py
+++ b/tensordict/prototype/tree.py
@@ -10,34 +10,6 @@ from tensordict.tensordict import (
 )
 from tensordict.utils import _is_shared
 
-_has_functorch = False
-try:
-    try:
-        from functorch._C import is_batchedtensor
-    except ImportError:
-        from torch._C._functorch import is_batchedtensor
-
-    _has_functorch = True
-except ImportError:
-    _has_functorch = False
-
-    def is_batchedtensor(tensor):
-        """Placeholder for the functorch function."""
-        return False
-
-
-try:
-    from torchrec import KeyedJaggedTensor
-
-    _has_torchrec = True
-except ImportError as err:
-    _has_torchrec = False
-
-    class KeyedJaggedTensor:
-        pass
-
-    TORCHREC_ERR = str(err)
-
 KEY_ERR = (
     "All nodes must have the same leaf keys as the root node. The leaf keys on the "
     "root node are {leaf_keys}, but you are trying to set the key(s) {key}."

--- a/tensordict/prototype/tree.py
+++ b/tensordict/prototype/tree.py
@@ -1,0 +1,203 @@
+import heapq
+
+import torch
+from tensordict.memmap import MemmapTensor
+from tensordict.metatensor import MetaTensor
+from tensordict.tensordict import (
+    _TensorDictKeysView, SubTensorDict, TensorDict, TensorDictBase
+)
+from tensordict.utils import _is_shared
+
+_has_functorch = False
+try:
+    try:
+        from functorch._C import is_batchedtensor
+    except ImportError:
+        from torch._C._functorch import is_batchedtensor
+
+    _has_functorch = True
+except ImportError:
+    _has_functorch = False
+
+    def is_batchedtensor(tensor):
+        """Placeholder for the functorch function."""
+        return False
+
+try:
+    from torchrec import KeyedJaggedTensor
+
+    _has_torchrec = True
+except ImportError as err:
+    _has_torchrec = False
+
+    class KeyedJaggedTensor:
+        pass
+
+    TORCHREC_ERR = str(err)
+
+
+class _TensorDictNodeKeysView(_TensorDictKeysView):
+    # a custom keys view class for tensordict nodes which merges keys
+    # from the tensordict and keys corresponding to the children
+    def _keys(self):
+        return (*self.tensordict._source.keys(), *self.tensordict._children)
+
+    def _items(self, tensordict=None):
+        if tensordict is None:
+            tensordict = self.tensordict
+        if isinstance(tensordict, _TensorDictNode):
+            return (*tensordict._source.items(), *tensordict._children.items())
+        return super()._items(tensordict)
+
+
+class _TensorDictNode(SubTensorDict):
+    # a basic node class that inherits from SubTensorDict and implements simple
+    # get and set operations, as well as `keys` and `_make_meta` to make sure
+    # that __repr__ displays the right thing
+    def __init__(self, source, idx):
+        super().__init__(source, idx)
+        self._children = {}
+
+    def keys(self, include_nested=False, leaves_only=False):
+        return _TensorDictNodeKeysView(self, include_nested, leaves_only)
+
+    def _make_meta(self, key):
+        if key in self._children:
+            # entries of self._children are always nodes, so we can simplify slightly
+            # compared to the logic in other implementations of _make_meta
+            out = self._children[key]
+            is_memmap = (
+                self._is_memmap
+                if self._is_memmap is not None
+                else False
+            )
+            is_shared = (
+                self._is_shared
+                if self._is_shared is not None
+                else _is_shared(out)
+            )
+            return MetaTensor(
+                out,
+                device=out.device,
+                _is_memmap=is_memmap,
+                _is_shared=is_shared,
+                _is_tensordict=True,
+            )
+        return super()._make_meta(key)
+
+    def __setitem__(self, key, item):
+        key = key[0] if isinstance(key, tuple) and len(key) == 1 else key
+        if isinstance(key, tuple) or isinstance(item, TensorDictBase):
+            if isinstance(key, tuple):
+                key, subkey = key[0], key[1:]
+            else:
+                subkey = ()
+            if key in self._children:
+                node = self._children[key]
+            else:
+                node = self._source.add_node()
+                self._children[key] = node
+            if subkey:
+                node[subkey] = item
+            elif isinstance(item, TensorDictBase):
+                node.update(item)
+        else:
+            super().__setitem__(key, item)
+
+    def __getitem__(self, key):
+        if isinstance(key, tuple):
+            key, subkey = key[0], key[1:]
+        else:
+            subkey = ()
+        if key in self._children:
+            if subkey:
+                return self._children[key][subkey]
+            return self._children[key]
+        if subkey:
+            raise KeyError("key not valid")
+        return super().__getitem__(key)
+
+    def __delitem__(self, key):
+        if isinstance(key, tuple):
+            prekey, key = key[:-1], key[-1]
+        else:
+            prekey = ()
+
+        if prekey:
+            del self[prekey][key]
+        else:
+            if key in self._children:
+                for idx in self._children[key]._child_indices():
+                    self._source.remove_node(idx)
+                del self._children[key]
+            else:
+                super().__delitem__(key)
+
+    def _child_indices(self):
+        yield self.idx[0]
+        for child in self._children.values():
+            if isinstance(child, _TensorDictNode):
+                yield from child._child_indices()
+
+    def apply_(self, fn):
+        indices = list(self._child_indices())
+        for k in self._source.keys():
+            self._source[k][indices] = fn(self._source[k][indices])
+
+    def get_multiple_items(self, *keys):
+        keys = [(key,) if isinstance(key, str) else key for key in keys]
+        key = keys[0][-1]
+        assert set(k[-1] for k in keys) == {key}
+        indices = [self[k[:-1]].idx[0] if k[:-1] else self.idx[0] for k in keys]
+        return self._source[key][indices]
+
+
+class _TensorDictTreeSource(TensorDict):
+    # a simple source class that keeps track of available indices
+    # and can add / remove nodes
+    def __init__(
+        self,
+        source,
+        batch_size=None,
+        device=None,
+        *,
+        _n_nodes=1000,
+        _meta_source=None,
+        _run_checks=None,
+        _is_shared=None,
+        _is_memmap=None,
+    ):
+        super().__init__(
+            source,
+            batch_size,
+            device=device,
+            _meta_source=_meta_source,
+            _run_checks=_run_checks,
+            _is_shared=_is_shared,
+            _is_memmap=_is_memmap,
+        )
+        self._n_nodes = _n_nodes
+        self._available_indices = list(range(self._n_nodes))
+        heapq.heapify(self._available_indices)
+        self._node_indices = set()
+
+    def numel(self):
+        return len(self._node_indices)
+
+    @property
+    def cursor(self):
+        return self._available_indices[0]
+
+    def add_node(self):
+        idx = heapq.heappop(self._available_indices)
+        self._node_indices.add(idx)
+        return _TensorDictNode(self, idx)
+
+    def remove_node(self, idx):
+        heapq.heappush(self._available_indices, idx)
+        self._node_indices.remove(idx)
+
+
+def make_tree(batch_size, n_nodes=1_000):
+    source = _TensorDictTreeSource({}, torch.Size([n_nodes, *batch_size]))
+    return source.add_node()

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -123,3 +123,25 @@ def test_apply():
     root.apply_(torch.abs)
 
     assert (root["a"] == 2).all()
+
+
+def test_key_checks():
+    td = TensorDict({"a": torch.ones(2, 3, 4)}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+
+    with pytest.raises(
+        KeyError, match="All nodes must have the same leaf keys as the root node."
+    ):
+        root["left"] = TensorDict({"b": torch.rand(2, 3, 4)}, [2, 3])
+
+    with pytest.raises(
+        KeyError, match="All nodes must have the same leaf keys as the root node."
+    ):
+        root["left"] = torch.rand(2, 3, 4)
+
+    with pytest.raises(
+        KeyError, match="All nodes must have the same leaf keys as the root node."
+    ):
+        root["left"] = TensorDict(
+            {"a": torch.rand(2, 3, 4), "b": torch.rand(2, 3, 4)}, [2, 3]
+        )

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -1,0 +1,125 @@
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.prototype import make_tree
+from tensordict.prototype.tree import _TensorDictNode
+
+
+@pytest.mark.parametrize("n_nodes", [10, 20, 100])
+def test_create_root(n_nodes):
+    a = torch.rand(2, 3, 4)
+    td = TensorDict({"a": a}, [2, 3])
+    root = make_tree(td, n_nodes=n_nodes)
+
+    torch.testing.assert_close(a, root["a"])
+    assert root.source.batch_size == torch.Size([n_nodes, 2, 3])
+    torch.testing.assert_close(a, root.source["a"][0])
+    assert root.source.numel() == 1
+    assert root.source.cursor == 1
+    assert root.source._node_indices == {0}
+
+
+def test_tree_from_nested_tensordict():
+    left_left = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+    left_right = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+    left = TensorDict(
+        {"a": torch.rand(2, 3, 4), "left": left_left, "right": left_right}, [2, 3]
+    )
+    right = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+    td = TensorDict({"a": torch.rand(2, 3, 4), "left": left, "right": right}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+    source = root.source
+
+    assert source.numel() == 5
+    assert set(root.keys(include_nested=True, leaves_only=True)) == {
+        "a",
+        ("left", "a"),
+        ("left", "left", "a"),
+        ("left", "right", "a"),
+        ("right", "a"),
+    }
+    torch.testing.assert_close(root["left", "right", "a"], left_right["a"])
+
+
+def test_add_nested_value():
+    a = torch.rand(2, 3, 4)
+    td = TensorDict({"a": a}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+
+    root["left"] = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+
+    assert root.source.numel() == 2
+    assert isinstance(root["left"], _TensorDictNode)
+    assert (root["left", "a"] == root["left"]["a"]).all()
+    torch.testing.assert_close(root["left", "a"], root.source["a"][root["left"].idx])
+
+
+def test_add_tensordict():
+    a = torch.rand(2, 3, 4)
+    td = TensorDict({"a": a}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+
+    left = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+    root["left"] = TensorDict({"a": torch.rand(2, 3, 4), "left": left}, [2, 3])
+    source = root.source
+
+    assert source.numel() == 3
+    torch.testing.assert_close(left["a"], root["left", "left", "a"])
+
+
+def test_delete_nodes():
+    td = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+
+    # collect the indicies of each node in the left branch
+    indices = set()
+    for key in ["left", ("left", "left"), ("left", "right")]:
+        root[key] = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+        indices.add(root[key].idx[0])
+
+    assert root.source.numel() == 4
+    del root["left"]
+    assert root.source.numel() == 1
+    # none of the left branch indices should be in the tree anymore
+    assert len(root.source._node_indices & indices) == 0
+
+    with pytest.raises(KeyError):
+        root["left"]
+
+
+def test_get_multiple_items():
+    td = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+
+    keys = [
+        ("left",),
+        ("left", "left"),
+        ("left", "right"),
+        ("right",),
+        ("right", "right"),
+    ]
+    for key in keys:
+        root[key] = TensorDict({"a": torch.rand(2, 3, 4)}, [2, 3])
+
+    keys = [k + ("a",) for k in keys]
+
+    assert root.source.numel() == 6
+    assert (
+        root.get_multiple_items(*keys) == torch.stack([root[k] for k in keys])
+    ).all()
+    # get_multiple_items is relative
+    left_keys = [k for k in keys if k[0] == "left"]
+    left = root["left"]
+    assert (
+        root.get_multiple_items(*left_keys)
+        == left.get_multiple_items(*(k[1:] for k in left_keys))
+    ).all()
+
+
+def test_apply():
+    td = TensorDict({"a": -2 * torch.ones(2, 3, 4)}, [2, 3])
+    root = make_tree(td, n_nodes=10)
+
+    root.apply_(torch.abs)
+
+    assert (root["a"] == 2).all()

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -126,7 +126,7 @@ def test_apply():
 
 
 def test_key_checks():
-    td = TensorDict({"a": torch.ones(2, 3, 4)}, [2, 3])
+    td = TensorDict({"a": torch.ones(2, 3, 4), "b": torch.zeros(2, 3, 4)}, [2, 3])
     root = make_tree(td, n_nodes=10)
 
     with pytest.raises(
@@ -143,5 +143,10 @@ def test_key_checks():
         KeyError, match="All nodes must have the same leaf keys as the root node."
     ):
         root["left"] = TensorDict(
-            {"a": torch.rand(2, 3, 4), "b": torch.rand(2, 3, 4)}, [2, 3]
+            {
+                "a": torch.rand(2, 3, 4),
+                "b": torch.rand(2, 3, 4),
+                "c": torch.rand(2, 3, 4),
+            },
+            [2, 3],
         )


### PR DESCRIPTION
## Description

This PR contains a draft implementation of support for trees using `TensorDict`.

We allow the user to create a tree structure where each node in the tree is a tensordict with the same keys. The entire contents of the tree are backed by a single source tensordict with pre-allocated memory. As nodes are added to the tree the data in the node is stored in the source. The primary advantage of this setup is that collecting the data from multiple nodes requires us to simply index the source which can be done very efficiently compared to a naive alternative which would require us to iterate over the nodes we want and stack the results.

The interface is very preliminary and up for debate. The tests should give an idea of usage, here's a very basic example.

```python
>>> import torch
>>> from tensordict import TensorDict
>>> from tensordict.prototype import make_tree

>>> # create the root node from a tensordict
>>> # preallocate memory for 100 nodes in the source
>>> root = make_tree(TensorDict({"data": torch.rand(2, 3, 4)}, [2, 3]), n_nodes=100)

>>> # adding a new tensordict as a child creates a new node in the tree
>>> root["left"] = TensorDict({"data": torch.rand(2, 3, 4)}, [2, 3])

>>> # we can now gather the data for the two nodes in the tree
>>> root.get_multiple_items("data", ("left", "data"))
tensor(...)  # shape torch.Size([2, 2, 3, 4])

>>> # alternatively we can create a tree from a nested tensordict
>>> root = make_tree(
...     TensorDict(
...         {"data": torch.ones(2, 3, 4), "left": TensorDict({"data": torch.zeros(2, 3, 4)}, [2, 3])},
...         [2, 3]
...     ),
...     n_nodes=100,
... )
>>> root.get_multiple_items("data", ("left", "data"))
```