### PR TITLE
[BugFix] Add __len__ method to tensorclass

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -257,6 +257,10 @@ def tensorclass(cls: T) -> T:
             string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
             return f"{name}(\n{string})"
 
+        def __len__(self) -> int:
+            """Returns the length of first dimension, if there is, otherwise 0."""
+            return len(self.tensordict)
+
         def to_tensordict(self) -> TensorDict:
             """Convert the tensorclass into a regular TensorDict.
 

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -167,6 +167,14 @@ def test_batch_size():
     assert myc.X.shape == torch.Size([2, 3, 4])
 
 
+def test_len():
+    myc = MyData(X=torch.rand(2, 3, 4), y=torch.rand(2, 3, 4, 5), batch_size=[2, 3])
+    assert len(myc) == 2
+
+    myc2 = MyData(X=torch.rand(2, 3, 4), y=torch.rand(2, 3, 4, 5), batch_size=[])
+    assert len(myc2) == 0
+
+
 def test_indexing():
     data = MyData(
         X=torch.ones(3, 4, 5),

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -165,6 +165,14 @@ def test_batch_size():
     assert myc.X.shape == torch.Size([2, 3, 4])
 
 
+def test_len():
+    myc = MyData(X=torch.rand(2, 3, 4), y=torch.rand(2, 3, 4, 5), batch_size=[2, 3])
+    assert len(myc) == 2
+
+    myc2 = MyData(X=torch.rand(2, 3, 4), y=torch.rand(2, 3, 4, 5), batch_size=[])
+    assert len(myc2) == 0
+
+
 def test_indexing():
     data = MyData(
         X=torch.ones(3, 4, 5),


### PR DESCRIPTION
## Description

Previously `len(my_tensorclass)` would result in an error `TypeError: object of type 'MyTensorClass' has no len()`.

This PR adds a `__len__` method to generated tensorclasses that falls back to the underlying tensordicts `__len__` method.