### PR TITLE
[BugFix] Create TensorClass by modifying decorated class in-place

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -28,29 +28,10 @@ OPTIONAL_PATTERN = re.compile(r"Optional\[(.*?)\]")
 UNION_PATTERN = re.compile(r"Union\[(.*?)\]")
 
 
-class _TensorClassMeta(type):
-    def __new__(cls, clsname, bases, attrs, cls_repr=None):
-        datacls = bases[0]
-        attrs["_cls_repr"] = cls_repr
-        for attr in datacls.__dataclass_fields__:
-            if attr == "batch_size":
-                continue
-            if attr in dir(TensorDict):
-                raise AttributeError(
-                    f"Attribute name {attr} can't be used with @tensorclass"
-                )
-        return super().__new__(cls, datacls.__name__, bases, attrs)
-
-    def __repr__(self):
-        if self._cls_repr is not None:
-            return self._cls_repr
-        return super().__repr__()
-
-
 def is_tensorclass(obj):
     """Returns True if obj is either a tensorclass or an instance of a tensorclass"""
     cls = obj if isinstance(obj, type) else type(obj)
-    return dataclasses.is_dataclass(cls) and isinstance(cls, _TensorClassMeta)
+    return dataclasses.is_dataclass(cls) and cls.__name__ in CLASSES_DICT
 
 
 def tensorclass(cls: T) -> T:
@@ -106,267 +87,306 @@ def tensorclass(cls: T) -> T:
 
 
     """
-    TD_HANDLED_FUNCTIONS: Dict = {}
-
-    name = cls.__name__
-    # by capturing the representation of the original class, the representation of the
-    # generated class can be made the same, including preserving information about
-    # where the original class was defined
-    cls_repr = repr(cls)
-    datacls = dataclass(cls)
-
-    EXPECTED_KEYS = set(datacls.__dataclass_fields__)
-
-    class _TensorClass(datacls, metaclass=_TensorClassMeta, cls_repr=cls_repr):
-        def __init__(self, *args, _tensordict=None, **kwargs):
-            if (args or kwargs) and _tensordict is not None:
-                raise ValueError("Cannot pass both args/kwargs and _tensordict.")
-
-            if _tensordict is not None:
-                if not all(key in EXPECTED_KEYS for key in _tensordict.keys()):
-                    raise ValueError(
-                        f"Keys from the tensordict ({set(_tensordict.keys())}) must correspond to the class attributes ({EXPECTED_KEYS})."
-                    )
-                input_dict = {key: None for key in _tensordict.keys()}
-                super().__init__(**input_dict)
-                self.tensordict = _tensordict
-            else:
-                device = kwargs.pop("device", None)
-                if "batch_size" not in kwargs:
-                    raise TypeError("Missing keyword argument batch_size")
-                batch_size = kwargs.pop("batch_size")
-
-                for value, key in zip(args, self.__dataclass_fields__):
-                    if key in kwargs:
-                        raise ValueError(f"The key {key} is already set in kwargs")
-                    kwargs[key] = value
-                args = []
-                kwargs = self._set_default_values(kwargs)
-                new_args = [None for _ in args]
-                new_kwargs = {key: None for key in kwargs}
-
-                super().__init__(*new_args, **new_kwargs)
-
-                self.tensordict = TensorDict(
-                    {
-                        key: _get_typed_value(value)
-                        for key, value in kwargs.items()
-                        if key not in ("batch_size",)
-                    },
-                    batch_size=batch_size,
-                    device=device,
-                )
-
-        @classmethod
-        def _build_from_tensordict(cls, tensordict):
-            return cls(_tensordict=tensordict)
-
-        def _set_default_values(self, kwargs):
-            for key in self.__dataclass_fields__:
-                default = self.__dataclass_fields__[key].default
-                default_factory = self.__dataclass_fields__[key].default_factory
-                if not isinstance(default_factory, dataclasses._MISSING_TYPE):
-                    default = default_factory
-                if default is not None:
-                    kwargs.setdefault(key, default)
-            return kwargs
-
-        @classmethod
-        def __torch_function__(
-            cls,
-            func: Callable,
-            types,
-            args: Tuple = (),
-            kwargs: Optional[dict] = None,
-        ) -> Callable:
-            if kwargs is None:
-                kwargs = {}
-            if func not in TD_HANDLED_FUNCTIONS or not all(
-                issubclass(t, (Tensor, cls)) for t in types
-            ):
-                return NotImplemented
-            return TD_HANDLED_FUNCTIONS[func](*args, **kwargs)
-
-        def __getattribute__(self, item):
-            if (
-                not item.startswith("__")
-                and "tensordict" in self.__dict__
-                and item in self.__dict__["tensordict"].keys()
-            ):
-                out = self.__dict__["tensordict"][item]
-                expected_type = datacls.__dataclass_fields__[item].type
-                out = _get_typed_output(out, expected_type)
-                return out
-            return super().__getattribute__(item)
-
-        def __setattr__(self, key, value):
-            if "tensordict" not in self.__dict__ or key in ("batch_size", "device"):
-                return super().__setattr__(key, value)
-            if key not in EXPECTED_KEYS:
-                raise AttributeError(
-                    f"Cannot set the attribute '{key}', expected attributes are {EXPECTED_KEYS}."
-                )
-            if type(value) in CLASSES_DICT.values():
-                value = value.__dict__["tensordict"]
-            self.__dict__["tensordict"][key] = value
-            assert self.__dict__["tensordict"][key] is value
-
-        def __getattr__(self, attr):
-            res = getattr(self.tensordict, attr)
-            if not callable(res):
-                return res
-            func = res
-
-            def wrapped_func(*args, **kwargs):
-                res = func(*args, **kwargs)
-                if isinstance(res, TensorDictBase):
-                    new = _TensorClass(_tensordict=res)
-                    return new
-                else:
-                    return res
-
-            return wrapped_func
-
-        def __getitem__(self, item):
-            if isinstance(item, str) or (
-                isinstance(item, tuple)
-                and all(isinstance(_item, str) for _item in item)
-            ):
-                raise ValueError("Invalid indexing arguments.")
-            res = self.tensordict[item]
-            return _TensorClass(_tensordict=res)  # device=res.device)
-
-        def __setitem__(self, item, value):
-            if isinstance(item, str) or (
-                isinstance(item, tuple)
-                and all(isinstance(_item, str) for _item in item)
-            ):
-                raise ValueError("Invalid indexing arguments.")
-            if not isinstance(value, _TensorClass):
-                raise ValueError(
-                    "__setitem__ is only allowed for same-class assignement"
-                )
-            self.tensordict[item] = value.tensordict
-
-        def __repr__(self) -> str:
-            fields = _all_td_fields_as_str(self.tensordict)
-            field_str = fields
-            batch_size_str = indent(f"batch_size={self.batch_size}", 4 * " ")
-            device_str = indent(f"device={self.device}", 4 * " ")
-            is_shared_str = indent(f"is_shared={self.is_shared()}", 4 * " ")
-            string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
-            return f"{name}(\n{string})"
-
-        def __len__(self) -> int:
-            """Returns the length of first dimension, if there is, otherwise 0."""
-            return len(self.tensordict)
-
-        def to_tensordict(self) -> TensorDict:
-            """Convert the tensorclass into a regular TensorDict.
-
-            Makes a copy of all entries. Memmap and shared memory tensors are converted to
-            regular tensors.
-
-            Returns:
-                A new TensorDict object containing the same values as the tensorclass.
-            """
-            return self.tensordict.to_tensordict()
-
-        @property
-        def device(self):
-            return self.tensordict.device
-
-        @device.setter
-        def device(self, value: DEVICE_TYPING) -> None:
-            raise RuntimeError(
-                "device cannot be set using tensorclass.device = device, "
-                "because device cannot be updated in-place. To update device, use "
-                "tensorclass.to(new_device), which will return a new tensorclass "
-                "on the new device."
-            )
-
-        @property
-        def batch_size(self) -> torch.Size:
-            return self.tensordict.batch_size
-
-        @batch_size.setter
-        def batch_size(self, new_size: torch.Size) -> None:
-            self.tensordict._batch_size_setter(new_size)
+    td_handled_functions: Dict = {}
 
     def implements_for_tdc(torch_function: Callable) -> Callable:
         """Register a torch function override for _TensorClass."""
 
         @functools.wraps(torch_function)
         def decorator(func):
-            TD_HANDLED_FUNCTIONS[torch_function] = func
+            td_handled_functions[torch_function] = func
             return func
 
         return decorator
 
-    @implements_for_tdc(torch.unbind)
-    def _unbind(tdc, dim):
-        tensordicts = torch.unbind(tdc.tensordict, dim)
-        out = [_TensorClass(_tensordict=td) for td in tensordicts]
-        return out
+    def __torch_function__(
+        cls,
+        func: Callable,
+        types,
+        args: Tuple = (),
+        kwargs: Optional[dict] = None,
+    ) -> Callable:
+        if kwargs is None:
+            kwargs = {}
+        if func not in td_handled_functions or not all(
+            issubclass(t, (Tensor, cls)) for t in types
+        ):
+            return NotImplemented
+        return td_handled_functions[func](*args, **kwargs)
 
-    @implements_for_tdc(torch.full_like)
-    def _full_like(tdc, fill_value):
-        tensordict = torch.full_like(tdc.tensordict, fill_value)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
+    cls = dataclass(cls)
+    expected_keys = set(cls.__dataclass_fields__)
 
-    @implements_for_tdc(torch.zeros_like)
-    def _zeros_like(tdc):
-        return _full_like(tdc, 0.0)
+    for attr in cls.__dataclass_fields__:
+        if attr in dir(TensorDict):
+            raise AttributeError(
+                f"Attribute name {attr} can't be used with @tensorclass"
+            )
 
-    @implements_for_tdc(torch.zeros_like)
-    def _ones_like(tdc):
-        return _full_like(tdc, 1.0)
+    cls.__init__ = _init_wrapper(cls.__init__, expected_keys)
+    cls._build_from_tensordict = classmethod(_build_from_tensordict)
+    cls.__torch_function__ = classmethod(__torch_function__)
+    cls.__getstate__ = _getstate
+    cls.__setstate__ = _setstate
+    cls.__getattribute__ = _getattribute_wrapper(cls.__getattribute__)
+    cls.__setattr__ = _setattr_wrapper(cls.__setattr__, expected_keys)
+    cls.__getattr__ = _getattr
+    cls.__getitem__ = _getitem
+    cls.__setitem__ = _setitem
+    cls.__repr__ = _repr
+    cls.__len__ = _len
+    cls.to_tensordict = _to_tensordict
+    cls.device = property(_device, _device_setter)
+    cls.batch_size = property(_batch_size, _batch_size_setter)
 
-    @implements_for_tdc(torch.clone)
-    def _clone(tdc):
-        tensordict = torch.clone(tdc.tensordict)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
+    implements_for_tdc(torch.unbind)(_unbind)
+    implements_for_tdc(torch.full_like)(_full_like)
+    implements_for_tdc(torch.zeros_like)(_zeros_like)
+    implements_for_tdc(torch.zeros_like)(_ones_like)
+    implements_for_tdc(torch.clone)(_clone)
+    implements_for_tdc(torch.squeeze)(_squeeze)
+    implements_for_tdc(torch.unsqueeze)(_unsqueeze)
+    implements_for_tdc(torch.permute)(_permute)
+    implements_for_tdc(torch.split)(_split)
+    implements_for_tdc(torch.stack)(_stack)
+    implements_for_tdc(torch.cat)(_cat)
 
-    @implements_for_tdc(torch.squeeze)
-    def _squeeze(tdc):
-        tensordict = torch.squeeze(tdc.tensordict)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
+    CLASSES_DICT[cls.__name__] = cls
+    return cls
 
-    @implements_for_tdc(torch.unsqueeze)
-    def _unsqueeze(tdc, dim=0):
-        tensordict = torch.unsqueeze(tdc.tensordict, dim)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
 
-    @implements_for_tdc(torch.permute)
-    def _permute(tdc, dims):
-        tensordict = torch.permute(tdc.tensordict, dims)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
+def _init_wrapper(init, expected_keys):
+    def wrapper(self, *args, batch_size=None, device=None, _tensordict=None, **kwargs):
+        if (args or kwargs) and _tensordict is not None:
+            raise ValueError("Cannot pass both args/kwargs and _tensordict.")
 
-    @implements_for_tdc(torch.split)
-    def _split(tdc, split_size_or_sections, dim=0):
-        tensordicts = torch.split(tdc.tensordict, split_size_or_sections, dim)
-        out = [_TensorClass(_tensordict=td) for td in tensordicts]
-        return out
+        if _tensordict is not None:
+            if not all(key in expected_keys for key in _tensordict.keys()):
+                raise ValueError(
+                    f"Keys from the tensordict ({set(_tensordict.keys())}) must "
+                    f"correspond to the class attributes ({expected_keys})."
+                )
+            input_dict = {key: None for key in _tensordict.keys()}
+            init(self, **input_dict)
+            self.tensordict = _tensordict
+        else:
+            for value, key in zip(args, self.__dataclass_fields__):
+                if key in kwargs:
+                    raise ValueError(f"The key {key} is already set in kwargs")
+                kwargs[key] = value
 
-    @implements_for_tdc(torch.stack)
-    def _stack(list_of_tdc, dim):
-        tensordict = torch.stack([tdc.tensordict for tdc in list_of_tdc], dim)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
+            for key, field in self.__dataclass_fields__.items():
+                if not isinstance(field.default_factory, dataclasses._MISSING_TYPE):
+                    default = field.default_factory()
+                else:
+                    default = field.default
+                if default is not None:
+                    kwargs.setdefault(key, default)
 
-    @implements_for_tdc(torch.cat)
-    def _cat(list_of_tdc, dim):
-        tensordict = torch.cat([tdc.tensordict for tdc in list_of_tdc], dim)
-        out = _TensorClass(_tensordict=tensordict)
-        return out
+            new_kwargs = {key: None for key in kwargs}
 
-    CLASSES_DICT[name] = _TensorClass
-    return _TensorClass
+            init(self, **new_kwargs)
+            self.tensordict = TensorDict(
+                {
+                    key: _get_typed_value(value)
+                    for key, value in kwargs.items()
+                    if key not in ("batch_size",)
+                },
+                batch_size=batch_size,
+                device=device,
+            )
+
+    return wrapper
+
+
+def _build_from_tensordict(cls, tensordict):
+    return cls(_tensordict=tensordict)
+
+
+def _getstate(self):
+    return {"tensordict": self.tensordict}
+
+
+def _setstate(self, state):
+    self.tensordict = state.get("tensordict", None)
+
+
+def _getattribute_wrapper(getattribute):
+    def wrapper(self, item):
+        if (
+            not item.startswith("__")
+            and "tensordict" in self.__dict__
+            and item in self.__dict__["tensordict"].keys()
+        ):
+            out = self.__dict__["tensordict"][item]
+            expected_type = self.__dataclass_fields__[item].type
+            out = _get_typed_output(out, expected_type)
+            return out
+        return getattribute(self, item)
+
+    return wrapper
+
+
+def _setattr_wrapper(setattr_, expected_keys):
+    def wrapper(self, key, value):
+        if "tensordict" not in self.__dict__ or key in ("batch_size", "device"):
+            return setattr_(self, key, value)
+        if key not in expected_keys:
+            raise AttributeError(
+                f"Cannot set the attribute '{key}', expected attributes are {expected_keys}."
+            )
+        if type(value) in CLASSES_DICT.values():
+            value = value.__dict__["tensordict"]
+        self.__dict__["tensordict"][key] = value
+        assert self.__dict__["tensordict"][key] is value
+
+    return wrapper
+
+
+def _getattr(self, attr):
+    res = getattr(self.tensordict, attr)
+    if not callable(res):
+        return res
+    func = res
+
+    def wrapped_func(*args, **kwargs):
+        res = func(*args, **kwargs)
+        if isinstance(res, TensorDictBase):
+            new = self.__class__(_tensordict=res)
+            return new
+        else:
+            return res
+
+    return wrapped_func
+
+
+def _getitem(self, item):
+    if isinstance(item, str) or (
+        isinstance(item, tuple) and all(isinstance(_item, str) for _item in item)
+    ):
+        raise ValueError("Invalid indexing arguments.")
+    res = self.tensordict[item]
+    return self.__class__(_tensordict=res)  # device=res.device)
+
+
+def _setitem(self, item, value):
+    if isinstance(item, str) or (
+        isinstance(item, tuple) and all(isinstance(_item, str) for _item in item)
+    ):
+        raise ValueError("Invalid indexing arguments.")
+    if not isinstance(value, self.__class__):
+        raise ValueError("__setitem__ is only allowed for same-class assignement")
+    self.tensordict[item] = value.tensordict
+
+
+def _repr(self) -> str:
+    fields = _all_td_fields_as_str(self.tensordict)
+    field_str = fields
+    batch_size_str = indent(f"batch_size={self.batch_size}", 4 * " ")
+    device_str = indent(f"device={self.device}", 4 * " ")
+    is_shared_str = indent(f"is_shared={self.is_shared()}", 4 * " ")
+    string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
+    return f"{self.__class__.__name__}(\n{string})"
+
+
+def _len(self) -> int:
+    """Returns the length of first dimension, if there is, otherwise 0."""
+    return len(self.tensordict)
+
+
+def _to_tensordict(self) -> TensorDict:
+    """Convert the tensorclass into a regular TensorDict.
+
+    Makes a copy of all entries. Memmap and shared memory tensors are converted to
+    regular tensors.
+
+    Returns:
+        A new TensorDict object containing the same values as the tensorclass.
+    """
+    return self.tensordict.to_tensordict()
+
+
+def _device(self):
+    return self.tensordict.device
+
+
+def _device_setter(self, value: DEVICE_TYPING) -> None:
+    raise RuntimeError(
+        "device cannot be set using tensorclass.device = device, "
+        "because device cannot be updated in-place. To update device, use "
+        "tensorclass.to(new_device), which will return a new tensorclass "
+        "on the new device."
+    )
+
+
+def _batch_size(self) -> torch.Size:
+    return self.tensordict.batch_size
+
+
+def _batch_size_setter(self, new_size: torch.Size) -> None:
+    self.tensordict._batch_size_setter(new_size)
+
+
+def _unbind(tdc, dim):
+    tensordicts = torch.unbind(tdc.tensordict, dim)
+    out = [tdc.__class__(_tensordict=td) for td in tensordicts]
+    return out
+
+
+def _full_like(tdc, fill_value):
+    tensordict = torch.full_like(tdc.tensordict, fill_value)
+    out = tdc.__class__(_tensordict=tensordict)
+    return out
+
+
+def _zeros_like(tdc):
+    return _full_like(tdc, 0.0)
+
+
+def _ones_like(tdc):
+    return _full_like(tdc, 1.0)
+
+
+def _clone(tdc):
+    tensordict = torch.clone(tdc.tensordict)
+    out = tdc.__class__(_tensordict=tensordict)
+    return out
+
+
+def _squeeze(tdc):
+    tensordict = torch.squeeze(tdc.tensordict)
+    out = tdc.__class__(_tensordict=tensordict)
+    return out
+
+
+def _unsqueeze(tdc, dim=0):
+    tensordict = torch.unsqueeze(tdc.tensordict, dim)
+    out = tdc.__class__(_tensordict=tensordict)
+    return out
+
+
+def _permute(tdc, dims):
+    tensordict = torch.permute(tdc.tensordict, dims)
+    out = tdc.__class__(_tensordict=tensordict)
+    return out
+
+
+def _split(tdc, split_size_or_sections, dim=0):
+    tensordicts = torch.split(tdc.tensordict, split_size_or_sections, dim)
+    out = [tdc.__class__(_tensordict=td) for td in tensordicts]
+    return out
+
+
+def _stack(list_of_tdc, dim):
+    tensordict = torch.stack([tdc.tensordict for tdc in list_of_tdc], dim)
+    out = list_of_tdc[0].__class__(_tensordict=tensordict)
+    return out
+
+
+def _cat(list_of_tdc, dim):
+    tensordict = torch.cat([tdc.tensordict for tdc in list_of_tdc], dim)
+    out = list_of_tdc[0].__class__(_tensordict=tensordict)
+    return out
 
 
 def _get_typed_value(value):

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -60,10 +60,11 @@ def test_type():
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
         batch_size=[3, 4],
     )
-    assert isinstance(data, MyDataUndecorated)
     assert isinstance(data, MyData)
     assert is_tensorclass(data)
     assert is_tensorclass(MyData)
+    # we get an instance of the user defined class, not a dynamically defined subclass
+    assert type(data) is MyDataUndecorated
 
 
 @pytest.mark.parametrize("device", get_available_devices())

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import os
 import pickle
 import re
+from multiprocessing import Pool
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional, Union
@@ -598,6 +600,17 @@ def test_pickle():
 
     assert_allclose_td(data.to_tensordict(), data2.to_tensordict())
     assert isinstance(data2, MyData)
+
+
+def _make_data(shape):
+    return MyData(X=torch.rand(*shape), y=torch.rand(*shape), batch_size=shape[:1])
+
+
+def test_multiprocessing():
+    with Pool(os.cpu_count()) as p:
+        catted = torch.cat(p.map(_make_data, [(i, 2) for i in range(1, 9)]), dim=0)
+
+    assert catted.batch_size == torch.Size([36])
 
 
 if __name__ == "__main__":

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -16,13 +16,17 @@ from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, Tensor
 from torch import Tensor
 
 
-@tensorclass
 class MyData:
     X: torch.Tensor
     y: torch.Tensor
 
     def stuff(self):
         return self.X + self.y
+
+
+# this slightly convoluted construction of MyData allows us to check that instances of
+# the tensorclass are instances of the original class.
+MyDataUndecorated, MyData = MyData, tensorclass(MyData)
 
 
 @tensorclass
@@ -46,6 +50,7 @@ def test_type():
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
         batch_size=[3, 4],
     )
+    assert isinstance(data, MyDataUndecorated)
     assert isinstance(data, MyData)
     assert is_tensorclass(data)
     assert is_tensorclass(MyData)
@@ -513,7 +518,7 @@ def test_defaultfactory():
     @tensorclass
     class MyData:
         X: torch.Tensor = None  # TODO: do we want to allow any default, say an integer?
-        y: torch.Tensor = dataclasses.field(default_factory=torch.ones(3, 4, 5))
+        y: torch.Tensor = dataclasses.field(default_factory=lambda: torch.ones(3, 4, 5))
 
     data = MyData(batch_size=[3, 4])
     assert data.__dict__["y"] is None

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import pickle
 import re
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Optional, Union
 
 import pytest
@@ -12,7 +15,12 @@ from _utils_internal import get_available_devices
 
 from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.prototype import is_tensorclass, tensorclass
-from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, TensorDictBase
+from tensordict.tensordict import (
+    _PermutedTensorDict,
+    _ViewedTensorDict,
+    assert_allclose_td,
+    TensorDictBase,
+)
 from torch import Tensor
 
 
@@ -570,6 +578,26 @@ def test_kjt():
     assert (
         subdata.y["index_0"].to_padded_dense() == torch.tensor([[1.0, 2.0], [3.0, 0.0]])
     ).all()
+
+
+def test_pickle():
+    data = MyData(
+        X=torch.ones(3, 4, 5),
+        y=torch.zeros(3, 4, 5, dtype=torch.bool),
+        batch_size=[3, 4],
+    )
+
+    with TemporaryDirectory() as tempdir:
+        tempdir = Path(tempdir)
+
+        with open(tempdir / "test.pkl", "wb") as f:
+            pickle.dump(data, f)
+
+        with open(tempdir / "test.pkl", "rb") as f:
+            data2 = pickle.load(f)
+
+    assert_allclose_td(data.to_tensordict(), data2.to_tensordict())
+    assert isinstance(data2, MyData)
 
 
 if __name__ == "__main__":

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -58,10 +58,11 @@ def test_type():
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
         batch_size=[3, 4],
     )
-    assert isinstance(data, MyDataUndecorated)
     assert isinstance(data, MyData)
     assert is_tensorclass(data)
     assert is_tensorclass(MyData)
+    # we get an instance of the user defined class, not a dynamically defined subclass
+    assert type(data) is MyDataUndecorated
 
 
 @pytest.mark.parametrize("device", get_available_devices())

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -1,7 +1,9 @@
 import argparse
 import dataclasses
+import os
 import pickle
 import re
+from multiprocessing import Pool
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional, Union
@@ -596,6 +598,17 @@ def test_pickle():
 
     assert_allclose_td(data.to_tensordict(), data2.to_tensordict())
     assert isinstance(data2, MyData)
+
+
+def _make_data(shape):
+    return MyData(X=torch.rand(*shape), y=torch.rand(*shape), batch_size=shape[:1])
+
+
+def test_multiprocessing():
+    with Pool(os.cpu_count()) as p:
+        catted = torch.cat(p.map(_make_data, [(i, 2) for i in range(1, 9)]), dim=0)
+
+    assert catted.batch_size == torch.Size([36])
 
 
 if __name__ == "__main__":

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -14,13 +14,17 @@ from tensordict.tensordict import _PermutedTensorDict, _ViewedTensorDict, Tensor
 from torch import Tensor
 
 
-@tensorclass
 class MyData:
     X: torch.Tensor
     y: torch.Tensor
 
     def stuff(self):
         return self.X + self.y
+
+
+# this slightly convoluted construction of MyData allows us to check that instances of
+# the tensorclass are instances of the original class.
+MyDataUndecorated, MyData = MyData, tensorclass(MyData)
 
 
 @tensorclass
@@ -44,6 +48,7 @@ def test_type():
         y=torch.zeros(3, 4, 5, dtype=torch.bool),
         batch_size=[3, 4],
     )
+    assert isinstance(data, MyDataUndecorated)
     assert isinstance(data, MyData)
     assert is_tensorclass(data)
     assert is_tensorclass(MyData)
@@ -511,7 +516,7 @@ def test_defaultfactory():
     @tensorclass
     class MyData:
         X: torch.Tensor = None  # TODO: do we want to allow any default, say an integer?
-        y: torch.Tensor = dataclasses.field(default_factory=torch.ones(3, 4, 5))
+        y: torch.Tensor = dataclasses.field(default_factory=lambda: torch.ones(3, 4, 5))
 
     data = MyData(batch_size=[3, 4])
     assert data.__dict__["y"] is None


### PR DESCRIPTION
## Description

This PR updates how we create dataclasses. Instead of locally defining a class and returning that, we modify the decorated class in place. The motivation is:

1. Returning a locally defined class leads to errors when we try to pickle instances of those classes.
2. The new behaviour is closer to the behaviour of `dataclasses.dataclass` and hence less surprising to users.

While refactoring I noticed a bug with how default_factory values were handled which I have fixed.

## Test

```python
import pickle

import torch
from tensordict.prototype import tensorclass
from tensordict.tensordict import assert_allclose_td

@tensorclass
class Data:
    value: torch.Tensor

    def square_value(self):
        return self.value ** 2

d = Data(value=torch.rand(5, 10), batch_size=[5])

with open("test.pkl", "wb") as f:
    pickle.dump(d, f)

with open("test.pkl", "rb") as f:
    d2 = pickle.load(f)

assert_allclose_td(d.to_tensordict(), d2.to_tensordict())
assert isinstance(d2, Data)
```