### PR TITLE
[Refactor] TensorClass drop _tensordict argument in constructor

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -165,7 +165,7 @@ def _init_wrapper(init, expected_keys):
     required_params = [p.name for p in params[1:] if p.default is inspect._empty]
 
     @functools.wraps(init)
-    def wrapper(self, *args, batch_size=None, device=None, **kwargs):
+    def wrapper(self, *args, batch_size, device=None, **kwargs):
         for value, key in zip(args, self.__dataclass_fields__):
             if key in kwargs:
                 raise ValueError(f"The key {key} is already set in kwargs")
@@ -192,12 +192,8 @@ def _init_wrapper(init, expected_keys):
         init(self, **{key: _get_typed_value(value) for key, value in kwargs.items()})
 
     new_params = [
-        inspect.Parameter(
-            "batch_size", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
-        ),
-        inspect.Parameter(
-            "device", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
-        ),
+        inspect.Parameter("batch_size", inspect.Parameter.KEYWORD_ONLY),
+        inspect.Parameter("device", inspect.Parameter.KEYWORD_ONLY, default=None),
     ]
     wrapper.__signature__ = init_sig.replace(parameters=params + new_params)
 

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -546,7 +546,7 @@ def test_post_init():
     assert (data.y == y.abs()).all()
 
     # initialising from tensordict is fine
-    data = MyDataPostInit._build_from_tensordict(
+    data = MyDataPostInit.from_tensordict(
         TensorDict({"X": torch.rand(3, 4), "y": y}, batch_size=[3, 4])
     )
 
@@ -554,7 +554,7 @@ def test_post_init():
         MyDataPostInit(X=-torch.ones(2), y=torch.rand(2), batch_size=[2])
 
     with pytest.raises(AssertionError):
-        MyDataPostInit._build_from_tensordict(
+        MyDataPostInit.from_tensordict(
             TensorDict({"X": -torch.ones(2), "y": torch.rand(2)}, batch_size=[2])
         )
 

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -70,7 +70,7 @@ def test_type():
 
 def test_signature():
     sig = inspect.signature(MyData)
-    assert list(sig.parameters) == ["X", "y", "batch_size", "device", "_tensordict"]
+    assert list(sig.parameters) == ["X", "y", "batch_size", "device"]
 
     with pytest.raises(TypeError, match="missing 2 required positional arguments"):
         MyData()
@@ -84,13 +84,6 @@ def test_signature():
     # if all positional arguments are specified, ommitting batch_size gives error
     with pytest.raises(ValueError, match="batch size was not specified"):
         MyData(X=torch.rand(10), y=torch.rand(10))
-
-    # instantiation via _tensordict ignores argument checks, no TypeError
-    MyData(
-        _tensordict=TensorDict(
-            {"X": torch.rand(10), "y": torch.rand(10)}, batch_size=[10]
-        )
-    )
 
     # all positional arguments + batch_size is fine
     MyData(X=torch.rand(10), y=torch.rand(10), batch_size=[10])
@@ -158,7 +151,7 @@ def test_banned_types():
         subclass: Union[MyOptionalClass, TensorDict] = None
 
     data = MyUnionClass(
-        subclass=MyUnionClass(_tensordict=TensorDict({}, [3])), batch_size=[3]
+        subclass=MyUnionClass.from_tensordict(TensorDict({}, [3])), batch_size=[3]
     )
     with pytest.raises(TypeError, match="can't be deterministically cast."):
         assert data.subclass is not None

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -73,16 +73,18 @@ def test_signature():
     assert list(sig.parameters) == ["X", "y", "batch_size", "device"]
 
     with pytest.raises(TypeError, match="missing 2 required positional arguments"):
-        MyData()
+        MyData(batch_size=[10])
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):
-        MyData(X=torch.rand(10))
+        MyData(X=torch.rand(10), batch_size=[10])
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):
         MyData(X=torch.rand(10), batch_size=[10], device="cpu")
 
     # if all positional arguments are specified, ommitting batch_size gives error
-    with pytest.raises(ValueError, match="batch size was not specified"):
+    with pytest.raises(
+        TypeError, match="missing 1 required keyword-only argument: 'batch_size'"
+    ):
         MyData(X=torch.rand(10), y=torch.rand(10))
 
     # all positional arguments + batch_size is fine

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -71,16 +71,18 @@ def test_signature():
     assert list(sig.parameters) == ["X", "y", "batch_size", "device"]
 
     with pytest.raises(TypeError, match="missing 2 required positional arguments"):
-        MyData()
+        MyData(batch_size=[10])
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):
-        MyData(X=torch.rand(10))
+        MyData(X=torch.rand(10), batch_size=[10])
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):
         MyData(X=torch.rand(10), batch_size=[10], device="cpu")
 
     # if all positional arguments are specified, ommitting batch_size gives error
-    with pytest.raises(ValueError, match="batch size was not specified"):
+    with pytest.raises(
+        TypeError, match="missing 1 required keyword-only argument: 'batch_size'"
+    ):
         MyData(X=torch.rand(10), y=torch.rand(10))
 
     # all positional arguments + batch_size is fine

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -544,7 +544,7 @@ def test_post_init():
     assert (data.y == y.abs()).all()
 
     # initialising from tensordict is fine
-    data = MyDataPostInit._build_from_tensordict(
+    data = MyDataPostInit.from_tensordict(
         TensorDict({"X": torch.rand(3, 4), "y": y}, batch_size=[3, 4])
     )
 
@@ -552,7 +552,7 @@ def test_post_init():
         MyDataPostInit(X=-torch.ones(2), y=torch.rand(2), batch_size=[2])
 
     with pytest.raises(AssertionError):
-        MyDataPostInit._build_from_tensordict(
+        MyDataPostInit.from_tensordict(
             TensorDict({"X": -torch.ones(2), "y": torch.rand(2)}, batch_size=[2])
         )
 

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -68,7 +68,7 @@ def test_type():
 
 def test_signature():
     sig = inspect.signature(MyData)
-    assert list(sig.parameters) == ["X", "y", "batch_size", "device", "_tensordict"]
+    assert list(sig.parameters) == ["X", "y", "batch_size", "device"]
 
     with pytest.raises(TypeError, match="missing 2 required positional arguments"):
         MyData()
@@ -82,13 +82,6 @@ def test_signature():
     # if all positional arguments are specified, ommitting batch_size gives error
     with pytest.raises(ValueError, match="batch size was not specified"):
         MyData(X=torch.rand(10), y=torch.rand(10))
-
-    # instantiation via _tensordict ignores argument checks, no TypeError
-    MyData(
-        _tensordict=TensorDict(
-            {"X": torch.rand(10), "y": torch.rand(10)}, batch_size=[10]
-        )
-    )
 
     # all positional arguments + batch_size is fine
     MyData(X=torch.rand(10), y=torch.rand(10), batch_size=[10])
@@ -156,7 +149,7 @@ def test_banned_types():
         subclass: Union[MyOptionalClass, TensorDict] = None
 
     data = MyUnionClass(
-        subclass=MyUnionClass(_tensordict=TensorDict({}, [3])), batch_size=[3]
+        subclass=MyUnionClass.from_tensordict(TensorDict({}, [3])), batch_size=[3]
     )
     with pytest.raises(TypeError, match="can't be deterministically cast."):
         assert data.subclass is not None


### PR DESCRIPTION
## Description

This PR refactors the generated init method of tensorclasses. The motivation was to try and make the signature less confusing. 

Previously `batch_size` was a positional or keyword argument with default value `None`, however, usually if `batch_size` was not specified, this would lead to a `ValueError`, so during normal instantiation `batch_size` was a required argument.

However, `batch_size` was **not** required if the user constructed a tensorclass by passing a `TensorDict` via the `_tensordict` argument.  Hence it was not possible for us to make `batch_size` a required argument.

The changes:
- `batch_size` is now a required keyword-only argument. If you don't specify it, Python will raise a `TypeError`.
- There is no longer a `_tensordict` argument in tensorclass constructors.
- Constructing a tensorclass from a tensordict is still possible, but like this: `tc = MyTensorClass.from_tensordict(td)`.

I've opened this as a separate PR to get specific feedback on whether we want to adopt this approach.

CC @apbard 