### PR TITLE
[BugFix] Typo in tensorclass.__ne__

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -337,17 +337,13 @@ def _batch_size_setter(self, new_size: torch.Size) -> None:
 def __eq__(self, other):
     if not isinstance(other, self.__class__):
         return False
-    if is_tensorclass(other):
-        return self.tensordict.__eq__(other.tensordict)
-    return self == other
+    return self.tensordict == other.tensordict
 
 
 def __ne__(self, other):
     if not isinstance(other, self.__class__):
         return True
-    if is_tensorclass(other):
-        return self.tensordict != other.tensordict
-    return self != other
+    return self.tensordict != other.tensordict
 
 
 def _unbind(tdc, dim):

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -347,7 +347,7 @@ def __ne__(self, other):
         return True
     if is_tensorclass(other):
         return self.tensordict != other.tensordict
-    return self == other
+    return self != other
 
 
 def _unbind(tdc, dim):


### PR DESCRIPTION
## Description

Noticed a small bug in the definition of tensorclass' `__ne__` method. I don't think it was actually reachable though...

If we fail the first if statement, we are guaranteed to pass the second (because `other` must be an instance of `self.__class__` and hence `is_tensorclass` will be `True`). So we'll always hit one of the first two return statements.

In some sense then, the bugfix is irrelevant. I think we could probably refactor this to

```python
def __eq__(self, other):
    if not isinstance(other, self.__class__):
        return False
    return self.tensordict == other.tensordict
```

or the even more compact

```python
def __eq__(self, other):
    return isinstance(other, self.__class__) and self.tensordict == other.tensordict
```

We also could drop `__ne__` completely because default behaviour of `object.__ne__` is to return `not object.__eq__(self, other)`.