### PR TITLE
[BugFix] Relax error matching in tensorclass tests

### DIFF
--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -269,10 +269,9 @@ def test_stack():
 
     with pytest.raises(
         TypeError,
-        match=re.escape(
+        match=(
             "no implementation found for 'torch.stack' on types that implement "
-            "__torch_function__: [<class 'test_tensorclass_nofuture.MyData'>, "
-            "<class 'test_tensorclass_nofuture.MyData2'>]"
+            "__torch_function__"
         ),
     ):
         torch.stack([data1, data3], dim=0)
@@ -295,10 +294,9 @@ def test_cat():
 
     with pytest.raises(
         TypeError,
-        match=re.escape(
+        match=(
             "no implementation found for 'torch.cat' on types that implement "
-            "__torch_function__: [<class 'test_tensorclass_nofuture.MyData'>, "
-            "<class 'test_tensorclass_nofuture.MyData2'>]"
+            "__torch_function__"
         ),
     ):
         torch.cat([data1, data3], dim=0)


### PR DESCRIPTION
## Description

Relax error matching in TensorClass tests. Largely motivated by FBCode compatibility, but since #165 the need to check the representation of types in error messages is less important anyway.