### PR TITLE
[Feature] More arguments for MemmapTensor construction

### DIFF
--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -220,7 +220,13 @@ class MemmapTensor:
                     "from_tensor(memmap_tensor, transfer_ownership=True) is not permitted, as this method will "
                     "simply return the original MemmapTensor instance."
                 )
-            return tensor
+            elif prefix is None and (
+                filename is None
+                or Path(filename).absolute() == Path(tensor.filename).absolute()
+            ):
+                # either location was not specified, or memmap is already in the
+                # correct location, so just return the MemmapTensor unmodified
+                return tensor
         elif isinstance(tensor, np.ndarray):
             raise TypeError(
                 "Convert input to torch.Tensor before calling MemmapTensor."
@@ -232,7 +238,7 @@ class MemmapTensor:
         device = tensor.device if hasattr(tensor, "device") else torch.device("cpu")
         dtype = (
             tensor.dtype
-            if isinstance(tensor, torch.Tensor)
+            if isinstance(tensor, (torch.Tensor, MemmapTensor))
             else numpy_to_torch_dtype_dict[tensor.dtype.name]
         )
         shape = tensor.shape

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2743,10 +2743,15 @@ class TensorDict(TensorDictBase):
                 if path == prefix / "meta.pt":
                     # skip prefix / "meta.pt" as we've already read it
                     continue
+                key = key[:-1]  # drop "meta.pt" from key
                 metadata = torch.load(path)
-                out[key[:-1]] = cls(
-                    {}, batch_size=metadata["batch_size"], device=metadata["device"]
-                )
+                if key in out.keys(include_nested=True):
+                    out[key].batch_size = metadata["batch_size"]
+                    out[key] = out[key].to(metadata["device"])
+                else:
+                    out[key] = cls(
+                        {}, batch_size=metadata["batch_size"], device=metadata["device"]
+                    )
             else:
                 leaf, *_ = key[-1].rsplit(".", 2)  # remove .meta.pt suffix
                 key = (*key[:-1], leaf)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import tempfile
 from pathlib import Path
+
+import pytest
 
 HERE = Path(__file__).parent
 
@@ -28,3 +35,11 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session):
     (HERE / "test_tensorclass.py").unlink()
+
+
+@pytest.fixture
+def tmpdir():
+    # creates a pathlib.Path pointing to a temporary directory that exists for the
+    # duration of the test
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -403,10 +403,23 @@ def test_as_tensor():
 def test_filename(tmpdir):
     mt = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
     assert mt.filename == str(tmpdir / "test.memmap")
-    del mt
 
-    # file should persist
+    mt2 = MemmapTensor.from_tensor(mt)
+    assert mt2.filename == str(tmpdir / "test.memmap")
+    assert mt2 is mt
+
+    mt3 = MemmapTensor.from_tensor(mt, filename=tmpdir / "test.memmap")
+    assert mt3.filename == str(tmpdir / "test.memmap")
+    assert mt3 is mt
+
+    mt4 = MemmapTensor.from_tensor(mt, filename=tmpdir / "test2.memmap")
+    assert mt4.filename == str(tmpdir / "test2.memmap")
+    assert mt4 is not mt
+
+    del mt
+    # files should persist
     assert (tmpdir / "test.memmap").exists()
+    assert (tmpdir / "test2.memmap").exists()
 
 
 @pytest.mark.parametrize(

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -408,6 +408,51 @@ def test_as_tensor():
     assert (y[idx] == y.as_tensor()[idx]).all()
 
 
+def test_filename(tmpdir):
+    mt = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
+    assert mt.filename == str(tmpdir / "test.memmap")
+    del mt
+
+    # file should persist
+    assert (tmpdir / "test.memmap").exists()
+
+
+@pytest.mark.parametrize(
+    "mode", ["r", "r+", "w+", "c", "readonly", "readwrite", "write", "copyonwrite"]
+)
+def test_mode(mode, tmpdir):
+    mt = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
+    mt[:] = torch.ones(10) * 1.5
+    del mt
+
+    if mode in ("r", "readonly"):
+        with pytest.raises(ValueError, match=r"Accepted values for mode are"):
+            MemmapTensor(
+                10, dtype=torch.float32, filename=tmpdir / "test.memmap", mode=mode
+            )
+        return
+    mt = MemmapTensor(
+        10, dtype=torch.float32, filename=tmpdir / "test.memmap", mode=mode
+    )
+    if mode in ("r+", "readwrite", "c", "copyonwrite"):
+        # data in memmap persists
+        assert (mt.as_tensor() == 1.5).all()
+    elif mode in ("w+", "write"):
+        # memmap is initialized to zero
+        assert (mt.as_tensor() == 0).all()
+
+    mt[:] = torch.ones(10) * 2.5
+    assert (mt.as_tensor() == 2.5).all()
+    del mt
+
+    mt2 = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
+    if mode in ("c", "copyonwrite"):
+        # tensor was only mutated in memory, not on disk
+        assert (mt2.as_tensor() == 1.5).all()
+    else:
+        assert (mt2.as_tensor() == 2.5).all()
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -417,6 +417,7 @@ def test_filename(tmpdir):
     assert mt4 is not mt
 
     del mt
+    del mt4
     # files should persist
     assert (tmpdir / "test.memmap").exists()
     assert (tmpdir / "test2.memmap").exists()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1697,6 +1697,11 @@ class TestTensorDicts(TestTensorDictsBase):
             assert td.is_memmap()
 
     def test_memmap_prefix(self, td_name, device, tmpdir):
+        if td_name == "memmap_td":
+            pytest.skip(
+                "Memmap case is redundant, functionality checked by other cases"
+            )
+
         td = getattr(self, td_name)(device)
         if td_name in ("sub_td", "sub_td2"):
             with pytest.raises(
@@ -1720,7 +1725,78 @@ class TestTensorDicts(TestTensorDictsBase):
             assert metadata["device"] == td.device
 
         td2 = td.__class__.load_memmap(tmpdir / "tensordict")
-        assert all(v.all() for v in (td == td2).values(include_nested=True))
+        assert (td == td2).all()
+
+    @pytest.mark.parametrize("copy_existing", [False, True])
+    def test_memmap_existing(self, td_name, device, copy_existing, tmpdir):
+        if td_name == "memmap_td":
+            pytest.skip(
+                "Memmap case is redundant, functionality checked by other cases"
+            )
+        elif td_name in ("sub_td", "sub_td2"):
+            pytest.skip(
+                "SubTensorDict and memmap_ incompatibility is checked elsewhere"
+            )
+
+        td = getattr(self, td_name)(device).memmap_(prefix=tmpdir / "tensordict")
+        td2 = getattr(self, td_name)(device).memmap_()
+
+        if copy_existing:
+            td3 = td.memmap_(prefix=tmpdir / "tensordict2", copy_existing=True)
+            assert (td == td3).all()
+        else:
+            with pytest.raises(
+                RuntimeError, match="TensorDict already contains MemmapTensors"
+            ):
+                # calling memmap_ with prefix that is different to contents gives error
+                td.memmap_(prefix=tmpdir / "tensordict2")
+
+            # calling memmap_ without prefix means no-op, regardless of whether contents
+            # were saved in temporary or designated location (td vs. td2 resp.)
+            td3 = td.memmap_()
+            td4 = td2.memmap_()
+
+            if td_name in ("stacked_td", "nested_stacked_td"):
+                assert all(
+                    all(
+                        td3_[key] is value
+                        for key, value in td_.items(
+                            include_nested=True, leaves_only=True
+                        )
+                    )
+                    for td_, td3_ in zip(td.tensordicts, td3.tensordicts)
+                )
+                assert all(
+                    all(
+                        td4_[key] is value
+                        for key, value in td2_.items(
+                            include_nested=True, leaves_only=True
+                        )
+                    )
+                    for td2_, td4_ in zip(td2.tensordicts, td4.tensordicts)
+                )
+            elif td_name in ("permute_td", "squeezed_td", "unsqueezed_td"):
+                assert all(
+                    td3._source[key] is value
+                    for key, value in td._source.items(
+                        include_nested=True, leaves_only=True
+                    )
+                )
+                assert all(
+                    td4._source[key] is value
+                    for key, value in td2._source.items(
+                        include_nested=True, leaves_only=True
+                    )
+                )
+            else:
+                assert all(
+                    td3[key] is value
+                    for key, value in td.items(include_nested=True, leaves_only=True)
+                )
+                assert all(
+                    td4[key] is value
+                    for key, value in td2.items(include_nested=True, leaves_only=True)
+                )
 
     def test_set_default_missing_key(self, td_name, device):
         td = getattr(self, td_name)(device)


### PR DESCRIPTION
## Description

This PR addresses #178 by adding more arguments to the `MemmapTensor` constructor, and making the behaviour of `TensorDict.memmap_` richer when `prefix` is specified.

In brief:
- `MemmapTensor` now accepts two additional arguments: `filename` and `mode`.
- `filename` determines the location on disk of the underlying `memmap`.
- `mode` determines the opening mode of the underlying `memmap`. Options are `"r+"`, `"w+"` and `"c"` as well as their verbose equivalents. This is what `numpy.memmap` supports with the exception of `"r"` as `torch.Tensor` gets quite unhappy if the underlying NumPy array is not writable.
- `TensorDict.memmap_` with a specified `prefix` will now locate the contents of the tensordict in the specified directory, with a nested structure determined by the keys in the tensordict. E.g.

    ```python
    import torch
    from tensordict import TensorDict
    td = TensorDict({"a": torch.rand(10), "b": {"c": torch.rand(10)}}, [10])
    td.memmap_(prefix="tensordict")
    ```

    yields the following structure

    ```
    tensordict
    ├── a.memmap
    ├── a.meta.pt
    ├── b
    │   ├── c.memmap
    │   ├── c.meta.pt
    │   └── meta.pt
    └── meta.pt
    ```

- Other variants of tensordict work similarly (only `SubTensorDict` is not supported as they already don't support `.memmap_`.
- I've added a classmethod `load_memmap` to `TensorDict` and variants which can be used to read this directory structure back into a new tensordict.
    ```python
    import torch
    from tensordict import TensorDict
    td = TensorDict({"a": torch.rand(10), "b": {"c": torch.rand(10)}}, [10])
    td.memmap_(prefix="tensordict")
    td2 = TensorDict.load_memmap("tensordict")
    equal = td == td2
    assert all(v.all() for v in equal.values(include_nested=True))    
    ```

Note that we ended up not adding the proposed `temporary` kwarg to `TensorDict.memmap_` as it was felt that supplying `prefix` was an implicit request that the saved file should not be ephemeral.