### PR TITLE
[BugFix] Using set_interaction_mode as decorator

### DIFF
--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -17,7 +17,6 @@ from tensordict.tensordict import TensorDictBase
 from torch import distributions as d, Tensor
 from torch.autograd.grad_mode import _DecoratorContextManager
 
-
 __all__ = ["ProbabilisticTensorDictModule", "ProbabilisticTensorDictSequential"]
 
 
@@ -39,6 +38,10 @@ class set_interaction_mode(_DecoratorContextManager):
     def __init__(self, mode: str = "mode"):
         super().__init__()
         self.mode = mode
+
+    def clone(self):
+        # override this method if your children class takes __init__ parameters
+        return self.__class__(self.mode)
 
     def __enter__(self) -> None:
         global _INTERACTION_MODE

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from tensordict import TensorDict
 from tensordict.nn import (
+    probabilistic as nn_probabilistic,
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
     TensorDictModule,
@@ -19,7 +20,6 @@ from tensordict.nn.functional_modules import make_functional
 from tensordict.nn.probabilistic import set_interaction_mode
 from torch import nn
 from torch.distributions import Normal
-
 
 try:
     import functorch  # noqa
@@ -1376,6 +1376,20 @@ class TestTDSequence:
 
         assert not torch.allclose(copy, sub_seq_1[0].module.weight)
         assert torch.allclose(td_module[0].module.weight, sub_seq_1[0].module.weight)
+
+
+@pytest.mark.parametrize("mode", ["random", "mode"])
+class TestSIM:
+    def test_cm(self, mode):
+        with set_interaction_mode(mode):
+            assert nn_probabilistic._INTERACTION_MODE == mode
+
+    def test_dec(self, mode):
+        @set_interaction_mode(mode)
+        def dummy():
+            assert nn_probabilistic._INTERACTION_MODE == mode
+
+        dummy()
 
 
 def test_probabilistic_sequential_type_checks():


### PR DESCRIPTION
## Description

Using `set_interaction_mode` as a decorator did not have the desired behaviour bc the `clone` method had to be adapted.