### PR TITLE
[BugFix] MemmapTensor from MemmapTensor __dir__ issue

### DIFF
--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -49,15 +49,7 @@ def test_grad():
         torch.bool,
     ],
 )
-@pytest.mark.parametrize(
-    "shape",
-    [
-        [
-            2,
-        ],
-        [1, 2],
-    ],
-)
+@pytest.mark.parametrize("shape", [[2], [1, 2]])
 def test_memmap_data_type(dtype, shape):
     """Test that MemmapTensor can be created with a given data type and shape."""
     t = torch.tensor([1, 0], dtype=dtype).reshape(shape)
@@ -406,6 +398,11 @@ def test_as_tensor():
     assert isinstance(y, MemmapTensor)
     assert isinstance(y[idx], MemmapTensor)
     assert (y[idx] == y.as_tensor()[idx]).all()
+
+
+def test_memmap_from_memmap():
+    mt2 = MemmapTensor.from_tensor(MemmapTensor(4, 3, 2, 1))
+    assert mt2.squeeze(-1).shape == torch.Size([4, 3, 2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR fixes a bug that arises when you construct one `MemmapTensor` from another which I noticed while working on #189 

Repro:

```python
>>> import torch
>>> from tensordict import MemmapTensor
>>> mt = MemmapTensor(4, 3, 2, 1)
>>> assert mt.squeeze(-1).shape == torch.Size([4, 3, 2])  # this is fine
>>> mt2 = MemmapTensor(mt)
>>> mt2.squeeze(-1)  # AttributeError: squeeze not found
```

Issue is that internal attribute `self._tensor_dir` was constructed from `elem.__dir__()`, but this leads to attributes not being found.