### PR TITLE
[Feature] apply across multiple TDs

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2699,7 +2699,7 @@ class TensorDict(TensorDictBase):
             if isinstance(value, TensorDictBase):
                 self._tensordict[key] = value.memmap_()
                 continue
-            self._tensordict[key] = MemmapTensor(value, prefix=prefix)
+            self._tensordict[key] = MemmapTensor.from_tensor(value, prefix=prefix)
         self._is_memmap = True
         self.lock()
         return self
@@ -3455,7 +3455,7 @@ torch.Size([3, 2])
             if self.is_shared() and self.device.type == "cpu":
                 tensor_expand.share_memory_()
             elif self.is_memmap():
-                tensor_expand = MemmapTensor(tensor_expand)
+                tensor_expand = MemmapTensor.from_tensor(tensor_expand)
         parent.set(key, tensor_expand, _run_checks=_run_checks)
         self.set_(key, tensor)
         return self

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -18,23 +18,23 @@ from torch import multiprocessing as mp
 def test_memmap_type():
     array = np.random.rand(1)
     with pytest.raises(
-        TypeError, match="convert input to torch.Tensor before calling MemmapTensor"
+        TypeError, match="Convert input to torch.Tensor before calling MemmapTensor"
     ):
-        MemmapTensor(array)
+        MemmapTensor.from_tensor(array)
 
 
 def test_grad():
     t = torch.tensor([1.0])
-    MemmapTensor(t)
+    MemmapTensor.from_tensor(t)
     t = t.requires_grad_()
     with pytest.raises(
-        RuntimeError, match="MemmapTensor is incompatible with tensor.requires_grad"
+        RuntimeError, match="MemmapTensor is incompatible with tensor.requires_grad."
     ):
-        MemmapTensor(t)
+        MemmapTensor.from_tensor(t)
     with pytest.raises(
-        RuntimeError, match="MemmapTensor is incompatible with tensor.requires_grad"
+        RuntimeError, match="MemmapTensor is incompatible with tensor.requires_grad."
     ):
-        MemmapTensor(t + 1)
+        MemmapTensor.from_tensor(t + 1)
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ def test_grad():
 def test_memmap_data_type(dtype, shape):
     """Test that MemmapTensor can be created with a given data type and shape."""
     t = torch.tensor([1, 0], dtype=dtype).reshape(shape)
-    m = MemmapTensor(t)
+    m = MemmapTensor.from_tensor(t)
     assert m.dtype == t.dtype
     assert (m == t).all()
     assert m.shape == t.shape
@@ -77,7 +77,7 @@ def test_memmap_data_type(dtype, shape):
 
 def test_memmap_del():
     t = torch.tensor([1])
-    m = MemmapTensor(t)
+    m = MemmapTensor.from_tensor(t)
     filename = m.filename
     assert os.path.isfile(filename)
     del m
@@ -88,7 +88,7 @@ def test_memmap_del():
 @pytest.mark.parametrize("transfer_ownership", [True, False])
 def test_memmap_ownership(transfer_ownership):
     t = torch.tensor([1])
-    m = MemmapTensor(t, transfer_ownership=transfer_ownership)
+    m = MemmapTensor.from_tensor(t, transfer_ownership=transfer_ownership)
     assert not m.file.delete
     with tempfile.NamedTemporaryFile(suffix=".pkl") as tmp:
         pickle.dump(m, tmp)
@@ -118,7 +118,7 @@ def test_memmap_ownership(transfer_ownership):
 @pytest.mark.parametrize("value", [True, False])
 def test_memmap_ownership_2pass(value):
     t = torch.tensor([1])
-    m1 = MemmapTensor(t, transfer_ownership=value)
+    m1 = MemmapTensor.from_tensor(t, transfer_ownership=value)
     with tempfile.NamedTemporaryFile(suffix=".pkl") as tmp2:
         pickle.dump(m1, tmp2)
         m2 = pickle.load(open(tmp2.name, "rb"))
@@ -128,7 +128,7 @@ def test_memmap_ownership_2pass(value):
             assert m1._has_ownership + m2._has_ownership + m3._has_ownership == 1
 
     del m1, m2, m3
-    m1 = MemmapTensor(t, transfer_ownership=value)
+    m1 = MemmapTensor.from_tensor(t, transfer_ownership=value)
     with tempfile.NamedTemporaryFile(suffix=".pkl") as tmp2:
         pickle.dump(m1, tmp2)
         m2 = pickle.load(open(tmp2.name, "rb"))
@@ -138,14 +138,29 @@ def test_memmap_ownership_2pass(value):
             assert m1._has_ownership + m2._has_ownership + m3._has_ownership == 1
 
 
-def test_memmap_new():
+@pytest.mark.parametrize(
+    "index",
+    [
+        None,
+        [
+            0,
+        ],
+    ],
+)
+def test_memmap_new(index):
     t = torch.tensor([1])
-    m1 = MemmapTensor(t)
-    m2 = MemmapTensor(m1)
+    m = MemmapTensor.from_tensor(t)
+    if index is not None:
+        m1 = m[index]
+    else:
+        m1 = m
+    m2 = MemmapTensor.from_tensor(m1)
     assert isinstance(m2, MemmapTensor)
-    assert m2.filename != m1.filename
+    assert m2.filename == m1.filename
     assert m2.filename == m2.file.name
     assert m2.filename == m2.file._closer.name
+    if index is not None:
+        assert m2.contiguous() == t[index]
     m2c = m2.contiguous()
     assert isinstance(m2c, torch.Tensor)
     assert m2c == m1
@@ -158,7 +173,7 @@ def test_memmap_same_device_as_tensor(device):
     Check if device is correct when .to(device) is called.
     """
     t = torch.tensor([1], device=device)
-    m = MemmapTensor(t)
+    m = MemmapTensor.from_tensor(t)
     assert m.device == torch.device(device)
     for other_device in get_available_devices():
         if other_device != device:
@@ -181,7 +196,7 @@ def test_memmap_create_on_same_device(device):
 
 @pytest.mark.parametrize("device", get_available_devices())
 @pytest.mark.parametrize(
-    "value", [torch.zeros([3, 4]), MemmapTensor(torch.zeros([3, 4]))]
+    "value", [torch.zeros([3, 4]), MemmapTensor.from_tensor(torch.zeros([3, 4]))]
 )
 @pytest.mark.parametrize("shape", [[3, 4], [[3, 4]]])
 def test_memmap_zero_value(device, value, shape):
@@ -189,7 +204,7 @@ def test_memmap_zero_value(device, value, shape):
     Test if all entries are zeros when MemmapTensor is created with size.
     """
     value = value.to(device)
-    expected_memmap_tensor = MemmapTensor(value)
+    expected_memmap_tensor = MemmapTensor.from_tensor(value)
     m = MemmapTensor(*shape, device=device)
     assert m.shape == (3, 4)
     assert torch.all(m == expected_memmap_tensor)
@@ -223,7 +238,7 @@ class TestIndexing:
         del queue
 
     def test_simple_index(self):
-        t = MemmapTensor(torch.zeros(10))
+        t = MemmapTensor.from_tensor(torch.zeros(10))
         # int
         assert isinstance(t[0], MemmapTensor)
         assert t[0].filename == t.filename
@@ -231,7 +246,7 @@ class TestIndexing:
         assert t.shape == torch.Size([10])
 
     def test_range_index(self):
-        t = MemmapTensor(torch.zeros(10))
+        t = MemmapTensor.from_tensor(torch.zeros(10))
         # int
         assert isinstance(t[:2], MemmapTensor)
         assert t[:2].filename == t.filename
@@ -239,7 +254,7 @@ class TestIndexing:
         assert t.shape == torch.Size([10])
 
     def test_double_index(self):
-        t = MemmapTensor(torch.zeros(10))
+        t = MemmapTensor.from_tensor(torch.zeros(10))
         y = t[:2][-1:]
         # int
         assert isinstance(y, MemmapTensor)
@@ -248,14 +263,14 @@ class TestIndexing:
         assert t.shape == torch.Size([10])
 
     def test_ownership(self):
-        t = MemmapTensor(torch.zeros(10))
+        t = MemmapTensor.from_tensor(torch.zeros(10))
         y = t[:2][-1:]
         del t
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
             y + 0
 
     def test_send_across_procs(self):
-        t = MemmapTensor(torch.zeros(10), transfer_ownership=False)
+        t = MemmapTensor.from_tensor(torch.zeros(10), transfer_ownership=False)
         queue = mp.Queue(1)
         filename = t.filename
         p = mp.Process(
@@ -288,7 +303,7 @@ class TestIndexing:
             raise e
 
     def test_send_across_procs_index(self):
-        t = MemmapTensor(torch.zeros(10), transfer_ownership=False)
+        t = MemmapTensor.from_tensor(torch.zeros(10), transfer_ownership=False)
         queue = mp.Queue(1)
         filename = t.filename
         p = mp.Process(
@@ -321,18 +336,18 @@ class TestIndexing:
             raise e
 
     def test_iteration(self):
-        t = MemmapTensor(torch.rand(10))
+        t = MemmapTensor.from_tensor(torch.rand(10))
         for i, _t in enumerate(t):
             assert _t == t[i]
 
     def test_iteration_nd(self):
-        t = MemmapTensor(torch.rand(10, 5))
+        t = MemmapTensor.from_tensor(torch.rand(10, 5))
         for i, _t in enumerate(t):
             assert (_t == t[i]).all()
 
     @staticmethod
     def _test_copy_onto_subproc(queue):
-        t = MemmapTensor(torch.rand(10, 5))
+        t = MemmapTensor.from_tensor(torch.rand(10, 5))
         idx = torch.tensor([1, 2])
         queue.put(t[idx], block=True)
         while queue.full():

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -739,6 +739,34 @@ class TestTensorDicts(TestTensorDictsBase):
         for k in td.keys():
             assert (td.get(k) == 0).all()
 
+    @pytest.mark.parametrize("inplace", [False, True])
+    def test_apply(self, td_name, device, inplace):
+        td = getattr(self, td_name)(device)
+        td_c = td.to_tensordict()
+        td_1 = td.apply(lambda x: x + 1, inplace=inplace)
+        if inplace:
+            for key in td.keys(True, True):
+                assert (td_c[key] + 1 == td[key]).all()
+                assert (td_1[key] == td[key]).all()
+        else:
+            for key in td.keys(True, True):
+                assert (td_c[key] + 1 != td[key]).any()
+                assert (td_1[key] == td[key] + 1).all()
+
+    @pytest.mark.parametrize("inplace", [False, True])
+    def test_apply_other(self, td_name, device, inplace):
+        td = getattr(self, td_name)(device)
+        td_c = td.to_tensordict()
+        td_1 = td.apply(lambda x, y: x + y, td_c, inplace=inplace)
+        if inplace:
+            for key in td.keys(True, True):
+                assert (td_c[key] * 2 == td[key]).all()
+                assert (td_1[key] == td[key]).all()
+        else:
+            for key in td.keys(True, True):
+                assert (td_c[key] * 2 != td[key]).any()
+                assert (td_1[key] == td[key] * 2).all()
+
     def test_from_empty(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)


### PR DESCRIPTION
## Description

Allows to call `apply` across multiple TDs.

EDIT:

As pointed in the conversation below, this highlighted a bug with `MemmapTensor` created from other `MemmapTensor`s. The whole thing was becoming messy and I changed the way `MemmapTensor` are built as a result of this.
This IS BC-breaking:
```python
MemmapTensor(tensor)  # not allowed anymore
MemmapTensor.from_tensor(tensor)  # proper way to do it
MemmapTensor.from_tensor(memmap_tensor)  # returns memmap_tensor (without copy)
```

We would need to see what to do with #189: I would guess that `from_tensor` could take other arguments, such as the destination etc. If any of these suggests that a copy must be done, then it will be.

Wdyt @tcbegley?

Closes #181 

cc @Daxo32