### PR TITLE
[CI] Temporarily disable torchrec tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,64 +345,64 @@ jobs:
       - store_test_results:
           path: test-results
 
-#   unittest_linux_torchrec_gpu:
-#     <<: *binary_common
-#     machine:
-#       image: ubuntu-2004-cuda-11.4:202110-01
-#     resource_class: gpu.nvidia.medium
-#     environment:
-#       image_name: "pytorch/manylinux-cuda113"
-#       TAR_OPTIONS: --no-same-owner
-#       PYTHON_VERSION: << parameters.python_version >>
-#       CU_VERSION: << parameters.cu_version >>
+  unittest_linux_torchrec_gpu:
+    <<: *binary_common
+    machine:
+      image: ubuntu-2004-cuda-11.4:202110-01
+    resource_class: gpu.nvidia.medium
+    environment:
+      image_name: "pytorch/manylinux-cuda113"
+      TAR_OPTIONS: --no-same-owner
+      PYTHON_VERSION: << parameters.python_version >>
+      CU_VERSION: << parameters.cu_version >>
 
-#     steps:
-#       - checkout
-#       - designate_upload_channel
-#       - run:
-#           name: Generate cache key
-#           # This will refresh cache on Sundays, nightly build should generate new cache.
-#           command: echo "$(date +"%Y-%U")" > .circleci-weekly
-#       - restore_cache:
+    steps:
+      - checkout
+      - designate_upload_channel
+      - run:
+          name: Generate cache key
+          # This will refresh cache on Sundays, nightly build should generate new cache.
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+      - restore_cache:
 
-#           keys:
-#             - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          keys:
+            - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
 
-#       - run:
-#           name: Setup
-#           command: docker run -e PYTHON_VERSION -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/setup_env.sh
-#       - save_cache:
+      - run:
+          name: Setup
+          command: docker run -e PYTHON_VERSION -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/setup_env.sh
+      - save_cache:
 
-#           key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
 
-#           paths:
-#             - conda
-#             - env
-# #      - run:
-# #          # Here we create an envlist file that contains some env variables that we want the docker container to be aware of.
-# #          # Normally, the CIRCLECI variable is set and available on all CI workflows: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
-# #          # They're available in all the other workflows (OSX and Windows).
-# #          # But here, we're running the unittest_linux_gpu workflows in a docker container, where those variables aren't accessible.
-# #          # So instead we dump the variables we need in env.list and we pass that file when invoking "docker run".
-# #          name: export CIRCLECI env var
-# #          command: echo "CIRCLECI=true" >> ./env.list
-#       - run:
-#           name: Install tensordict
-# #          command: bash .circleci/unittest/linux_torchrec/scripts/install.sh
-#           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_torchrec/scripts/install.sh
-#       - run:
-#           name: Run tests
-#           command: bash .circleci/unittest/linux_torchrec/scripts/run_test.sh
-# #          command: docker run --env-file ./env.list -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/run_test.sh
-#       - run:
-#           name: Codecov upload
-#           command: |
-#             bash <(curl -s https://codecov.io/bash) -Z -F linux-torchrec-gpu
-#       - run:
-#           name: Post Process
-#           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/post_process.sh
-#       - store_test_results:
-#           path: test-results
+          paths:
+            - conda
+            - env
+#      - run:
+#          # Here we create an envlist file that contains some env variables that we want the docker container to be aware of.
+#          # Normally, the CIRCLECI variable is set and available on all CI workflows: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+#          # They're available in all the other workflows (OSX and Windows).
+#          # But here, we're running the unittest_linux_gpu workflows in a docker container, where those variables aren't accessible.
+#          # So instead we dump the variables we need in env.list and we pass that file when invoking "docker run".
+#          name: export CIRCLECI env var
+#          command: echo "CIRCLECI=true" >> ./env.list
+      - run:
+          name: Install tensordict
+#          command: bash .circleci/unittest/linux_torchrec/scripts/install.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_torchrec/scripts/install.sh
+      - run:
+          name: Run tests
+          command: bash .circleci/unittest/linux_torchrec/scripts/run_test.sh
+#          command: docker run --env-file ./env.list -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/run_test.sh
+      - run:
+          name: Codecov upload
+          command: |
+            bash <(curl -s https://codecov.io/bash) -Z -F linux-torchrec-gpu
+      - run:
+          name: Post Process
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/post_process.sh
+      - store_test_results:
+          path: test-results
 
   unittest_linux_stable_cpu:
     <<: *binary_common
@@ -684,11 +684,10 @@ workflows:
           cu_version: cu113
           name: unittest_linux_stable_gpu_py3.9
           python_version: '3.9'
-      - unittest_linux_torchrec_gpu:
-          cu_version: cu113
-          name: unittest_linux_torchrec_gpu_py3.9
-          python_version: '3.9'
-
+      # - unittest_linux_torchrec_gpu:
+      #     cu_version: cu113
+      #     name: unittest_linux_torchrec_gpu_py3.9
+      #     python_version: '3.9'
       - unittest_macos_cpu:
           cu_version: cpu
           name: unittest_macos_cpu_py3.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,64 +345,64 @@ jobs:
       - store_test_results:
           path: test-results
 
-  unittest_linux_torchrec_gpu:
-    <<: *binary_common
-    machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.medium
-    environment:
-      image_name: "pytorch/manylinux-cuda113"
-      TAR_OPTIONS: --no-same-owner
-      PYTHON_VERSION: << parameters.python_version >>
-      CU_VERSION: << parameters.cu_version >>
+#   unittest_linux_torchrec_gpu:
+#     <<: *binary_common
+#     machine:
+#       image: ubuntu-2004-cuda-11.4:202110-01
+#     resource_class: gpu.nvidia.medium
+#     environment:
+#       image_name: "pytorch/manylinux-cuda113"
+#       TAR_OPTIONS: --no-same-owner
+#       PYTHON_VERSION: << parameters.python_version >>
+#       CU_VERSION: << parameters.cu_version >>
 
-    steps:
-      - checkout
-      - designate_upload_channel
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
-      - restore_cache:
+#     steps:
+#       - checkout
+#       - designate_upload_channel
+#       - run:
+#           name: Generate cache key
+#           # This will refresh cache on Sundays, nightly build should generate new cache.
+#           command: echo "$(date +"%Y-%U")" > .circleci-weekly
+#       - restore_cache:
 
-          keys:
-            - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+#           keys:
+#             - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
 
-      - run:
-          name: Setup
-          command: docker run -e PYTHON_VERSION -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/setup_env.sh
-      - save_cache:
+#       - run:
+#           name: Setup
+#           command: docker run -e PYTHON_VERSION -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/setup_env.sh
+#       - save_cache:
 
-          key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+#           key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux_torchrec/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
 
-          paths:
-            - conda
-            - env
-#      - run:
-#          # Here we create an envlist file that contains some env variables that we want the docker container to be aware of.
-#          # Normally, the CIRCLECI variable is set and available on all CI workflows: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
-#          # They're available in all the other workflows (OSX and Windows).
-#          # But here, we're running the unittest_linux_gpu workflows in a docker container, where those variables aren't accessible.
-#          # So instead we dump the variables we need in env.list and we pass that file when invoking "docker run".
-#          name: export CIRCLECI env var
-#          command: echo "CIRCLECI=true" >> ./env.list
-      - run:
-          name: Install tensordict
-#          command: bash .circleci/unittest/linux_torchrec/scripts/install.sh
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_torchrec/scripts/install.sh
-      - run:
-          name: Run tests
-          command: bash .circleci/unittest/linux_torchrec/scripts/run_test.sh
-#          command: docker run --env-file ./env.list -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/run_test.sh
-      - run:
-          name: Codecov upload
-          command: |
-            bash <(curl -s https://codecov.io/bash) -Z -F linux-torchrec-gpu
-      - run:
-          name: Post Process
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+#           paths:
+#             - conda
+#             - env
+# #      - run:
+# #          # Here we create an envlist file that contains some env variables that we want the docker container to be aware of.
+# #          # Normally, the CIRCLECI variable is set and available on all CI workflows: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+# #          # They're available in all the other workflows (OSX and Windows).
+# #          # But here, we're running the unittest_linux_gpu workflows in a docker container, where those variables aren't accessible.
+# #          # So instead we dump the variables we need in env.list and we pass that file when invoking "docker run".
+# #          name: export CIRCLECI env var
+# #          command: echo "CIRCLECI=true" >> ./env.list
+#       - run:
+#           name: Install tensordict
+# #          command: bash .circleci/unittest/linux_torchrec/scripts/install.sh
+#           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e UPLOAD_CHANNEL -e CU_VERSION "${image_name}" .circleci/unittest/linux_torchrec/scripts/install.sh
+#       - run:
+#           name: Run tests
+#           command: bash .circleci/unittest/linux_torchrec/scripts/run_test.sh
+# #          command: docker run --env-file ./env.list -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/run_test.sh
+#       - run:
+#           name: Codecov upload
+#           command: |
+#             bash <(curl -s https://codecov.io/bash) -Z -F linux-torchrec-gpu
+#       - run:
+#           name: Post Process
+#           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux_torchrec/scripts/post_process.sh
+#       - store_test_results:
+#           path: test-results
 
   unittest_linux_stable_cpu:
     <<: *binary_common


### PR DESCRIPTION
torchrec tests consistently fail due to upstream library. We should disable them until upstream is fixed and they can pass