### PR TITLE
[BugFix] Fix `_getitem_batch_size` in various edge cases.

### DIFF
--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -101,7 +101,7 @@ def _getitem_batch_size(shape: torch.Size, items: INDEX_TYPING) -> torch.Size:
     for _item in items:
         if isinstance(_item, (list, np.ndarray)):
             _item = torch.tensor(_item)
-        if isinstance(_item, torch.Tensor):
+        elif isinstance(_item, torch.Tensor):
             # np.broadcast will complain if we give it CUDA tensors
             _item = _item.cpu()
         if isinstance(_item, torch.Tensor) and _item.dtype is torch.bool:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -101,6 +101,9 @@ def _getitem_batch_size(shape: torch.Size, items: INDEX_TYPING) -> torch.Size:
     for _item in items:
         if isinstance(_item, (list, np.ndarray)):
             _item = torch.tensor(_item)
+        if isinstance(_item, torch.Tensor):
+            # np.broadcast will complain if we give it CUDA tensors
+            _item = _item.cpu()
         if isinstance(_item, torch.Tensor) and _item.dtype is torch.bool:
             # when using NumPy's advanced indexing patterns, any index containing a
             # boolean array can be equivalently replaced with index.nonzero()

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -67,10 +67,7 @@ def _sub_index(tensor: torch.Tensor, idx: INDEX_TYPING) -> torch.Tensor:
     return tensor[idx]
 
 
-def _getitem_batch_size(
-    shape: torch.Size,
-    items: INDEX_TYPING,
-) -> torch.Size:
+def _getitem_batch_size(shape: torch.Size, items: INDEX_TYPING) -> torch.Size:
     """Given an input shape and an index, returns the size of the resulting indexed tensor.
 
     This function is aimed to be used when indexing is an
@@ -99,32 +96,69 @@ def _getitem_batch_size(
 
     if not isinstance(items, tuple):
         items = (items,)
-    bs = []
-    iter_bs = iter(shape)
-    if all(isinstance(_item, torch.Tensor) for _item in items) and len(items) == len(
-        shape
-    ):
-        shape0 = items[0].shape
-        for _item in items[1:]:
-            if _item.shape != shape0:
-                raise RuntimeError(
-                    f"all tensor indices must have the same shape, "
-                    f"got {_item.shape} and {shape0}"
-                )
-        return shape0
 
+    sanitized_items = []
     for _item in items:
+        if isinstance(_item, (list, np.ndarray)):
+            _item = torch.tensor(_item)
+        if isinstance(_item, torch.Tensor) and _item.dtype is torch.bool:
+            # when using NumPy's advanced indexing patterns, any index containing a
+            # boolean array can be equivalently replaced with index.nonzero()
+            # note we add unbind(-1) since behaviour of numpy.ndarray.nonzero returns
+            # tuples of arrays whereas torch.Tensor.nonzero returns a single tensor
+            # https://numpy.org/doc/stable/user/basics.indexing.html#boolean-array-indexing
+            sanitized_items.extend(_item.nonzero().unbind(-1))
+        else:
+            sanitized_items.append(_item)
+
+    # when multiple tensor-like indices are present, they must be broadcastable onto a
+    # common shape. if this is satisfied then they are broadcast to that shape, and used
+    # to extract diagonal entries of the array.
+    # if the tensor indices are contiguous, or separated by scalars, they are replaced
+    # in-place by the broadcast shape. if they are separated by non-scalar indices, the
+    # broadcast shape is prepended to the new batch size
+    # https://numpy.org/doc/stable/user/basics.indexing.html#integer-array-indexing
+    tensor_indices = []
+    contiguous, prev = True, None
+
+    for i, _item in enumerate(sanitized_items):
+        if isinstance(_item, torch.Tensor):
+            tensor_indices.append(_item)
+            if prev is not None and i != prev + 1:
+                contiguous = False
+            prev = i
+        elif isinstance(_item, Number) and prev is not None and i == prev + 1:
+            prev = i
+
+    bs = []
+    if tensor_indices:
+        try:
+            b = np.broadcast(*tensor_indices)
+        except ValueError:
+            raise ValueError(
+                "When indexing with tensor-like indices, each of those indices must be "
+                "broadcastable to a common shape."
+            )
+        if not contiguous:
+            bs.extend(b.shape)
+            b = None
+    else:
+        b = None
+
+    iter_bs = iter(shape)
+
+    for _item in sanitized_items:
         if isinstance(_item, slice):
             batch = next(iter_bs)
-            v = len(range(*_item.indices(batch)))
+            bs.append(len(range(*_item.indices(batch))))
         elif isinstance(_item, (list, torch.Tensor, np.ndarray)):
             batch = next(iter_bs)
-            if isinstance(_item, torch.Tensor) and _item.dtype is torch.bool:
-                v = _item.sum()
-            else:
-                v = len(_item)
+            if b is not None:
+                # we haven't yet accounted for tensor indices, so we insert in-place
+                bs.extend(b.shape)
+                b = None
         elif _item is None:
-            v = 1
+            bs.append(1)
         elif isinstance(_item, Number):
             try:
                 batch = next(iter_bs)
@@ -137,7 +171,7 @@ def _getitem_batch_size(
             raise NotImplementedError(
                 f"batch dim cannot be computed for type {type(_item)}"
             )
-        bs.append(v)
+
     list_iter_bs = list(iter_bs)
     bs += list_iter_bs
     return torch.Size(bs)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,3 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+
 import numpy as np
 import pytest
 import torch
@@ -82,3 +89,8 @@ def test_getitem_batch_size_mask(tensor, idx, ndim, slice_leading_dims):
     else:
         index = (0,) * idx + (mask,)
     assert tensor[index].shape == _getitem_batch_size(tensor.shape, index)
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pytest
+import torch
+from tensordict.utils import _getitem_batch_size
+
+
+@pytest.mark.parametrize("tensor", [torch.rand(2, 3, 4, 5), torch.rand(2, 3, 4, 5, 6)])
+@pytest.mark.parametrize(
+    "index1",
+    [
+        slice(None),
+        slice(0, 1),
+        0,
+        [0],
+        [0, 1],
+        np.arange(2),
+        torch.arange(2),
+        [True, True],
+    ],
+)
+@pytest.mark.parametrize(
+    "index2",
+    [
+        slice(None),
+        slice(1, 3, 1),
+        slice(-3, -1),
+        0,
+        [0],
+        [0, 1],
+        np.arange(0, 1),
+        torch.arange(2),
+        [True, False, True],
+    ],
+)
+@pytest.mark.parametrize(
+    "index3",
+    [
+        slice(None),
+        slice(1, 3, 1),
+        slice(-3, -1),
+        0,
+        [0],
+        [0, 1],
+        np.arange(1, 3),
+        torch.arange(2),
+        [True, False, True, False],
+    ],
+)
+@pytest.mark.parametrize(
+    "index4",
+    [
+        slice(None),
+        slice(0, 4, 2),
+        slice(-4, -2),
+        0,
+        [0],
+        [0, 1],
+        np.arange(0, 4, 2),
+        torch.arange(2),
+        [True, False, False, False, True],
+    ],
+)
+def test_getitem_batch_size(tensor, index1, index2, index3, index4):
+    index = (index1, index2, index3, index4)
+    assert tensor[index].shape == _getitem_batch_size(tensor.shape, index)
+
+
+@pytest.mark.parametrize("tensor", [torch.rand(2, 3, 4, 5), torch.rand(2, 3, 4, 5, 6)])
+@pytest.mark.parametrize("idx", range(3))
+@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("slice_leading_dims", [True, False])
+def test_getitem_batch_size_mask(tensor, idx, ndim, slice_leading_dims):
+    # test n-dimensional boolean masks are handled correctly
+    if idx + ndim > 4:
+        pytest.skip(
+            "Not enough dimensions in test tensor for this combination of parameters"
+        )
+    mask_shape = (2, 3, 4, 5)[idx : idx + ndim]
+    mask = torch.randint(2, mask_shape, dtype=torch.bool)
+    if slice_leading_dims:
+        index = (slice(None),) * idx + (mask,)
+    else:
+        index = (0,) * idx + (mask,)
+    assert tensor[index].shape == _getitem_batch_size(tensor.shape, index)


### PR DESCRIPTION
## Description

This PR fixes various bugs I encountered in `_getitem_batch_size` where for particular choices of index the following test would fail

```python
assert tensor[index].shape == _getitem_batch_size(tensor, index)
```

I first noticed this in the case where the index was a tuple of tensor-like indices. Indeed something as simple as

```python
tensor = torch.rand(2, 2)
index = ([0], [0])
assert tensor[index].shape == _getitem_batch_size(tensor, index)
```

currently fails on `main`. The correct behaviour when there are tuples of tensor-like indices present is to broadcast them onto a common shape, and then extract the diagonal entry. So `tensor[list1, list1]` is roughly equivalent to `torch.stack([tensor[i, j] for i, j in zip(list1, list2)])`. The final shape depends slightly on whether those tensor-like indices were contiguous or not.

Handling Boolean masks is also a bit delicate. From the [NumPy docs on advanced indexing](https://numpy.org/doc/stable/user/basics.indexing.html#advanced-indexing) it turns out that masking is equivalent to converting the mask to a tuple of integer indices with `mask.nonzero()` which can equivalently be written `mask.nonzero().unbind(-1)` if `mask` is a PyTorch tensor rather than a NumPy array.

I've added tests which check thousands of indexing combinations (these can probably be relaxed a bit), though it's possible I've missed something so feedback is welcome!