### PR TITLE
[Test] use temp_path instead of tmpdir

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,10 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import tempfile
 from pathlib import Path
-
-import pytest
 
 HERE = Path(__file__).parent
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,11 +35,3 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session):
     (HERE / "test_tensorclass.py").unlink()
-
-
-@pytest.fixture
-def tmpdir():
-    # creates a pathlib.Path pointing to a temporary directory that exists for the
-    # duration of the test
-    with tempfile.TemporaryDirectory() as td:
-        yield Path(td)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -400,45 +400,45 @@ def test_as_tensor():
     assert (y[idx] == y.as_tensor()[idx]).all()
 
 
-def test_filename(tmpdir):
-    mt = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
-    assert mt.filename == str(tmpdir / "test.memmap")
+def test_filename(tmp_path):
+    mt = MemmapTensor(10, dtype=torch.float32, filename=tmp_path / "test.memmap")
+    assert mt.filename == str(tmp_path / "test.memmap")
 
     mt2 = MemmapTensor.from_tensor(mt)
-    assert mt2.filename == str(tmpdir / "test.memmap")
+    assert mt2.filename == str(tmp_path / "test.memmap")
     assert mt2 is mt
 
-    mt3 = MemmapTensor.from_tensor(mt, filename=tmpdir / "test.memmap")
-    assert mt3.filename == str(tmpdir / "test.memmap")
+    mt3 = MemmapTensor.from_tensor(mt, filename=tmp_path / "test.memmap")
+    assert mt3.filename == str(tmp_path / "test.memmap")
     assert mt3 is mt
 
-    mt4 = MemmapTensor.from_tensor(mt, filename=tmpdir / "test2.memmap")
-    assert mt4.filename == str(tmpdir / "test2.memmap")
+    mt4 = MemmapTensor.from_tensor(mt, filename=tmp_path / "test2.memmap")
+    assert mt4.filename == str(tmp_path / "test2.memmap")
     assert mt4 is not mt
 
     del mt
     del mt4
     # files should persist
-    assert (tmpdir / "test.memmap").exists()
-    assert (tmpdir / "test2.memmap").exists()
+    assert (tmp_path / "test.memmap").exists()
+    assert (tmp_path / "test2.memmap").exists()
 
 
 @pytest.mark.parametrize(
     "mode", ["r", "r+", "w+", "c", "readonly", "readwrite", "write", "copyonwrite"]
 )
-def test_mode(mode, tmpdir):
-    mt = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
+def test_mode(mode, tmp_path):
+    mt = MemmapTensor(10, dtype=torch.float32, filename=tmp_path / "test.memmap")
     mt[:] = torch.ones(10) * 1.5
     del mt
 
     if mode in ("r", "readonly"):
         with pytest.raises(ValueError, match=r"Accepted values for mode are"):
             MemmapTensor(
-                10, dtype=torch.float32, filename=tmpdir / "test.memmap", mode=mode
+                10, dtype=torch.float32, filename=tmp_path / "test.memmap", mode=mode
             )
         return
     mt = MemmapTensor(
-        10, dtype=torch.float32, filename=tmpdir / "test.memmap", mode=mode
+        10, dtype=torch.float32, filename=tmp_path / "test.memmap", mode=mode
     )
     if mode in ("r+", "readwrite", "c", "copyonwrite"):
         # data in memmap persists
@@ -451,7 +451,7 @@ def test_mode(mode, tmpdir):
     assert (mt.as_tensor() == 2.5).all()
     del mt
 
-    mt2 = MemmapTensor(10, dtype=torch.float32, filename=tmpdir / "test.memmap")
+    mt2 = MemmapTensor(10, dtype=torch.float32, filename=tmp_path / "test.memmap")
     if mode in ("c", "copyonwrite"):
         # tensor was only mutated in memory, not on disk
         assert (mt2.as_tensor() == 1.5).all()

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -1020,7 +1020,7 @@ def test_multiprocessing():
     assert catted.z == "test_tensorclass"
 
 
-def test_torchsnapshot(tmpdir):
+def test_torchsnapshot(tmp_path):
     @tensorclass
     class MyClass:
         x: torch.Tensor
@@ -1039,7 +1039,7 @@ def test_torchsnapshot(tmpdir):
     assert tc.z == z
 
     app_state = {"state": torchsnapshot.StateDict(tensordict=tc.state_dict())}
-    snapshot = torchsnapshot.Snapshot.take(app_state=app_state, path=str(tmpdir))
+    snapshot = torchsnapshot.Snapshot.take(app_state=app_state, path=str(tmp_path))
 
     tc_dest = MyClass(
         x=torch.randn(3),

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1696,7 +1696,7 @@ class TestTensorDicts(TestTensorDictsBase):
             td.memmap_()
             assert td.is_memmap()
 
-    def test_memmap_prefix(self, td_name, device, tmpdir):
+    def test_memmap_prefix(self, td_name, device, tmp_path):
         if td_name == "memmap_td":
             pytest.skip(
                 "Memmap case is redundant, functionality checked by other cases"
@@ -1708,13 +1708,13 @@ class TestTensorDicts(TestTensorDictsBase):
                 RuntimeError,
                 match="Converting a sub-tensordict values to memmap cannot be done",
             ):
-                td.memmap_(tmpdir / "tensordict")
+                td.memmap_(tmp_path / "tensordict")
             return
         else:
-            td.memmap_(tmpdir / "tensordict")
+            td.memmap_(tmp_path / "tensordict")
 
-        assert (tmpdir / "tensordict" / "meta.pt").exists()
-        metadata = torch.load(tmpdir / "tensordict" / "meta.pt")
+        assert (tmp_path / "tensordict" / "meta.pt").exists()
+        metadata = torch.load(tmp_path / "tensordict" / "meta.pt")
         if td_name in ("stacked_td", "nested_stacked_td"):
             pass
         elif td_name in ("unsqueezed_td", "squeezed_td", "permute_td"):
@@ -1724,11 +1724,11 @@ class TestTensorDicts(TestTensorDictsBase):
             assert metadata["batch_size"] == td.batch_size
             assert metadata["device"] == td.device
 
-        td2 = td.__class__.load_memmap(tmpdir / "tensordict")
+        td2 = td.__class__.load_memmap(tmp_path / "tensordict")
         assert (td == td2).all()
 
     @pytest.mark.parametrize("copy_existing", [False, True])
-    def test_memmap_existing(self, td_name, device, copy_existing, tmpdir):
+    def test_memmap_existing(self, td_name, device, copy_existing, tmp_path):
         if td_name == "memmap_td":
             pytest.skip(
                 "Memmap case is redundant, functionality checked by other cases"
@@ -1738,18 +1738,18 @@ class TestTensorDicts(TestTensorDictsBase):
                 "SubTensorDict and memmap_ incompatibility is checked elsewhere"
             )
 
-        td = getattr(self, td_name)(device).memmap_(prefix=tmpdir / "tensordict")
+        td = getattr(self, td_name)(device).memmap_(prefix=tmp_path / "tensordict")
         td2 = getattr(self, td_name)(device).memmap_()
 
         if copy_existing:
-            td3 = td.memmap_(prefix=tmpdir / "tensordict2", copy_existing=True)
+            td3 = td.memmap_(prefix=tmp_path / "tensordict2", copy_existing=True)
             assert (td == td3).all()
         else:
             with pytest.raises(
                 RuntimeError, match="TensorDict already contains MemmapTensors"
             ):
                 # calling memmap_ with prefix that is different to contents gives error
-                td.memmap_(prefix=tmpdir / "tensordict2")
+                td.memmap_(prefix=tmp_path / "tensordict2")
 
             # calling memmap_ without prefix means no-op, regardless of whether contents
             # were saved in temporary or designated location (td vs. td2 resp.)


### PR DESCRIPTION
I am switching from tmpdir to the new tmp_path fixture.
@tcbegley, @vmoens is there a reason we were defining our custom tmpdir instead of using the regular pytest one? 