### PR TITLE
[BugFix] Fix infinite loop in memmap tests

### DIFF
--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -6,6 +6,7 @@ import argparse
 import os.path
 import pickle
 import tempfile
+import time
 
 import numpy as np
 import pytest
@@ -213,7 +214,10 @@ class TestIndexing:
         assert (t == 0).all()
         msg = "done"
         queue.put(msg)
-        while queue.full():
+        count = 0
+        while queue.full() and count < 100:
+            count += 1
+            time.sleep(0.1)
             continue
 
         msg = queue.get(timeout=10.0)
@@ -271,21 +275,30 @@ class TestIndexing:
         try:
             p.start()
             queue.put(t, block=True)
-            while queue.full():
+            count = 0
+            while queue.full() and count < 100:
+                count += 1
+                time.sleep(0.1)
                 continue
             msg = queue.get(timeout=10.0)
             assert msg == "done"
 
             t.fill_(1.0)
             queue.put("modified", block=True)
-            while queue.full():
+            count = 0
+            while queue.full() and count < 100:
+                count += 1
+                time.sleep(0.1)
                 continue
             msg = queue.get(timeout=10.0)
             assert msg == "done!!"
 
             del t
             queue.put("deleted")
-            while queue.full():
+            count = 0
+            while queue.full() and count < 100:
+                count += 1
+                time.sleep(0.1)
                 continue
             msg = queue.get(timeout=10.0)
             assert msg == "done again"

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -6,7 +6,6 @@ import argparse
 import os.path
 import pickle
 import tempfile
-import time
 
 import numpy as np
 import pytest
@@ -206,7 +205,12 @@ def test_memmap_zero_value(device, value, shape):
 
 class TestIndexing:
     @staticmethod
-    def _recv_and_send(queue_out, queue_in, filename, shape, ):
+    def _recv_and_send(
+        queue_out,
+        queue_in,
+        filename,
+        shape,
+    ):
         t = queue_in.get(timeout=10.0)
         assert isinstance(t, MemmapTensor)
         assert t.filename == filename
@@ -266,7 +270,8 @@ class TestIndexing:
         queue_out = mp.Queue(1)
         filename = t.filename
         p = mp.Process(
-            target=TestIndexing._recv_and_send, args=(queue_in, queue_out, filename, torch.Size([10]))
+            target=TestIndexing._recv_and_send,
+            args=(queue_in, queue_out, filename, torch.Size([10])),
         )
         try:
             p.start()
@@ -294,7 +299,8 @@ class TestIndexing:
         queue_out = mp.Queue(1)
         filename = t.filename
         p = mp.Process(
-            target=TestIndexing._recv_and_send, args=(queue_in, queue_out, filename, torch.Size([3]))
+            target=TestIndexing._recv_and_send,
+            args=(queue_in, queue_out, filename, torch.Size([3])),
         )
         try:
             p.start()


### PR DESCRIPTION
## Description

Solves the tests failing with python 3.10 and mp tests with memmap tensors