### PR TITLE
[BugFix] Fix sorting of keys in send and recv

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -883,7 +883,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                     _tag += 1
                 else:
                     _tag = int_generator(_tag + 1)
-                future_list.append(dist.irecv(value, src=src, tag=_tag).get_future())
+                future_list.append(dist.irecv(value, src=src, tag=_tag))
                 self.set(key, value, inplace=True)
             elif isinstance(value, TensorDictBase):
                 _tag, future_list = value._irecv(
@@ -898,7 +898,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                 else:
                     _tag = int_generator(_tag + 1)
                 value = value.as_tensor()
-                future_list.append(dist.irecv(value, src=src, tag=_tag).get_future())
+                future_list.append(dist.irecv(value, src=src, tag=_tag))
                 self.set(key, value, inplace=True)
             else:
                 raise NotImplementedError(f"Type {type(value)} is not supported.")

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -824,7 +824,9 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         for key in sorted(self.keys()):
             value = self.get(key)
             if isinstance(value, TensorDictBase):
-                _tag = value._isend(dst, _tag=_tag, pseudo_rand=pseudo_rand, _futures=_futures)
+                _tag = value._isend(
+                    dst, _tag=_tag, pseudo_rand=pseudo_rand, _futures=_futures
+                )
                 continue
             elif isinstance(value, Tensor):
                 pass

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -883,7 +883,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                     _tag += 1
                 else:
                     _tag = int_generator(_tag + 1)
-                future_list.append(dist.irecv(value, src=src, tag=_tag))
+                future_list.append(dist.irecv(value, src=src, tag=_tag).get_future())
                 self.set(key, value, inplace=True)
             elif isinstance(value, TensorDictBase):
                 _tag, future_list = value._irecv(
@@ -898,7 +898,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                 else:
                     _tag = int_generator(_tag + 1)
                 value = value.as_tensor()
-                future_list.append(dist.irecv(value, src=src, tag=_tag))
+                future_list.append(dist.irecv(value, src=src, tag=_tag).get_future())
                 self.set(key, value, inplace=True)
             else:
                 raise NotImplementedError(f"Type {type(value)} is not supported.")

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -677,7 +677,8 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         self._send(dst, _tag=init_tag - 1, pseudo_rand=pseudo_rand)
 
     def _send(self, dst, _tag=-1, pseudo_rand=False):
-        for value in self.values():
+        for key in sorted(self.keys()):
+            value = self.get(key)
             if isinstance(value, Tensor):
                 if not pseudo_rand:
                     _tag += 1
@@ -817,7 +818,8 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         return self._recv(src, _tag=init_tag - 1, pseudo_rand=pseudo_rand)
 
     def _recv(self, src, _tag=-1, pseudo_rand=False):
-        for key, value in self.items():
+        for key in sorted(self.keys()):
+            value = self.get(key)
             if isinstance(value, Tensor):
                 if not pseudo_rand:
                     _tag += 1

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -262,6 +262,7 @@ class TestiSend:
             main_worker.join()
             secondary_worker.join()
 
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -23,7 +23,7 @@ class TestGather:
             "gloo",
             rank=1,
             world_size=2,
-            init_method="tcp://localhost:10006",
+            init_method="tcp://localhost:10017",
         )
 
         td = TensorDict(
@@ -44,7 +44,7 @@ class TestGather:
             "gloo",
             rank=0,
             world_size=2,
-            init_method="tcp://localhost:10006",
+            init_method="tcp://localhost:10017",
         )
 
         td = (
@@ -72,10 +72,12 @@ class TestGather:
 
         main_worker.start()
         secondary_worker.start()
-        out = queue.get(timeout=10)
-        assert out == "yuppie"
-        main_worker.join()
-        secondary_worker.join()
+        try:
+            out = queue.get(timeout=10)
+            assert out == "yuppie"
+        finally:
+            main_worker.join()
+            secondary_worker.join()
 
 
 @pytest.mark.parametrize("pseudo_rand", [True, False])
@@ -86,18 +88,18 @@ class TestSend:
             "gloo",
             rank=1,
             world_size=2,
-            init_method="tcp://localhost:10006",
+            init_method="tcp://localhost:10017",
         )
 
         td = TensorDict(
             {
                 ("a", "b"): torch.randn(2),
                 "c": torch.randn(2, 3),
-                "_": torch.ones(2, 1, 5),
                 ("d", "e", "f"): MemmapTensor.from_tensor(torch.ones(2, 2)),
             },
             [2],
         )
+        td["_"] = torch.ones(2, 1, 5)
         td.send(0, pseudo_rand=pseudo_rand)
 
     @staticmethod
@@ -106,17 +108,17 @@ class TestSend:
             "gloo",
             rank=0,
             world_size=2,
-            init_method="tcp://localhost:10006",
+            init_method="tcp://localhost:10017",
         )
         td = TensorDict(
             {
                 ("a", "b"): torch.zeros(2),
-                "c": torch.zeros(2, 3),
                 "_": torch.zeros(2, 1, 5),
                 ("d", "e", "f"): MemmapTensor.from_tensor(torch.zeros(2, 2)),
             },
             [2],
         )
+        td["c"] = torch.zeros(2, 3)
         td.recv(1, pseudo_rand=pseudo_rand)
         assert (td != 0).all()
         queue.put("yuppie")
@@ -128,21 +130,23 @@ class TestSend:
 
         main_worker.start()
         secondary_worker.start()
-        out = queue.get(timeout=10)
-        assert out == "yuppie"
-        main_worker.join()
-        secondary_worker.join()
+        try:
+            out = queue.get(timeout=10)
+            assert out == "yuppie"
+        finally:
+            main_worker.join()
+            secondary_worker.join()
 
 
 @pytest.mark.parametrize("pseudo_rand", [True, False])
-class TestiSend:
+class TestiRecv:
     @staticmethod
     def client(pseudo_rand):
         torch.distributed.init_process_group(
             "gloo",
             rank=1,
             world_size=2,
-            init_method="tcp://localhost:10006",
+            init_method="tcp://localhost:10017",
         )
 
         td = TensorDict(
@@ -154,7 +158,7 @@ class TestiSend:
             },
             [2],
         )
-        td.isend(0, pseudo_rand=pseudo_rand)
+        td.send(0, pseudo_rand=pseudo_rand)
 
     @staticmethod
     def server(queue, return_premature, pseudo_rand):
@@ -162,7 +166,7 @@ class TestiSend:
             "gloo",
             rank=0,
             world_size=2,
-            init_method="tcp://localhost:10006",
+            init_method="tcp://localhost:10017",
         )
         td = TensorDict(
             {
@@ -184,17 +188,79 @@ class TestiSend:
     def test_isend(self, pseudo_rand, return_premature, set_context):
         queue = mp.Queue(1)
         main_worker = mp.Process(
-            target=TestiSend.server, args=(queue, return_premature, pseudo_rand)
+            target=TestiRecv.server, args=(queue, return_premature, pseudo_rand)
         )
+        secondary_worker = mp.Process(target=TestiRecv.client, args=(pseudo_rand,))
+
+        main_worker.start()
+        secondary_worker.start()
+        try:
+            out = queue.get(timeout=10)
+            assert out == "yuppie"
+        finally:
+            main_worker.join()
+            secondary_worker.join()
+
+
+@pytest.mark.parametrize("pseudo_rand", [True, False])
+class TestiSend:
+    @staticmethod
+    def client(pseudo_rand):
+        torch.distributed.init_process_group(
+            "gloo",
+            rank=1,
+            world_size=2,
+            init_method="tcp://localhost:10017",
+        )
+
+        td = TensorDict(
+            {
+                ("a", "b"): torch.randn(2),
+                "c": torch.randn(2, 3),
+                ("d", "e", "f"): MemmapTensor.from_tensor(torch.ones(2, 2)),
+            },
+            [2],
+        )
+        td["_"] = torch.ones(2, 1, 5)
+        td.isend(0, pseudo_rand=pseudo_rand)
+
+    @staticmethod
+    def server(queue, pseudo_rand):
+        torch.distributed.init_process_group(
+            "gloo",
+            rank=0,
+            world_size=2,
+            init_method="tcp://localhost:10017",
+        )
+        td = TensorDict(
+            {
+                ("a", "b"): torch.zeros(2),
+                "_": torch.zeros(2, 1, 5),
+                ("d", "e", "f"): MemmapTensor.from_tensor(torch.zeros(2, 2)),
+            },
+            [2],
+        )
+        td["c"] = torch.zeros(2, 3)
+        td.recv(1, pseudo_rand=pseudo_rand)
+        assert (td != 0).all()
+        queue.put("yuppie")
+
+    def test_send(self, pseudo_rand, set_context):
+        queue = mp.Queue(1)
+        main_worker = mp.Process(target=TestiSend.server, args=(queue, pseudo_rand))
         secondary_worker = mp.Process(target=TestiSend.client, args=(pseudo_rand,))
 
         main_worker.start()
         secondary_worker.start()
-        out = queue.get(timeout=10)
-        assert out == "yuppie"
-        main_worker.join()
-        secondary_worker.join()
-
+        try:
+            out = queue.get(timeout=10)
+            assert out == "yuppie"
+        except Exception as err:
+            # otherwise pytest does not capture it
+            raise err
+        finally:
+            main_worker.join()
+            secondary_worker.join()
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -726,9 +726,10 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         sorted_keys = td.sorted_keys
-        for _i, (key1, key2) in enumerate(zip(sorted_keys, td.keys())):
+        i = -1
+        for i, (key1, key2) in enumerate(zip(sorted_keys, td.keys())):  # noqa: B007
             assert key1 == key2
-        assert _i == len(td.keys()) - 1
+        assert i == len(td.keys()) - 1
         if td.is_locked:
             assert td._sorted_keys is not None
             td.unlock()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -722,6 +722,25 @@ class TestTensorDicts(TestTensorDictsBase):
         assert td.device.type == "cuda" or not td.is_shared()
         assert not td.is_memmap()
 
+    def test_sorted_keys(self, td_name, device):
+        torch.manual_seed(1)
+        td = getattr(self, td_name)(device)
+        sorted_keys = td.sorted_keys
+        for _i, (key1, key2) in enumerate(zip(sorted_keys, td.keys())):
+            assert key1 == key2
+        assert _i == len(td.keys()) - 1
+        if td.is_locked:
+            assert td._sorted_keys is not None
+            td.unlock()
+            assert td._sorted_keys is None
+        else:
+            assert td._sorted_keys is None
+            td.lock()
+            _ = td.sorted_keys
+            assert td._sorted_keys is not None
+            td.unlock()
+            assert td._sorted_keys is None
+
     def test_masked_fill(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)


### PR DESCRIPTION
## Description

Fixes cases where the key order mismatch between a src and dest tensordict.

The `sorted_keys` attribute is intentionally not adapted to `tensorclass` as this would require to duplicate a lot of code + we will probably refactor tensorclass soon.