### PR TITLE
[Refactor] Rename set_default -> setdefault

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2577,6 +2577,12 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def set_default(
         self, key: NESTED_KEY, default: COMPATIBLE_TYPES, **kwargs
     ) -> COMPATIBLE_TYPES:
+        warn("set_default has been deprecated. Use setdefault instead")
+        return self.setdefault(key, default, **kwargs)
+
+    def setdefault(
+        self, key: NESTED_KEY, default: COMPATIBLE_TYPES, **kwargs
+    ) -> COMPATIBLE_TYPES:
         """Insert key with a value of default if key is not in the dictionary.
 
         Return the value for key if key is in the dictionary, else default.

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1852,18 +1852,18 @@ class TestTensorDicts(TestTensorDictsBase):
                     for key, value in td2.items(include_nested=True, leaves_only=True)
                 )
 
-    def test_set_default_missing_key(self, td_name, device):
+    def test_setdefault_missing_key(self, td_name, device):
         td = getattr(self, td_name)(device)
         td.unlock()
         expected = torch.ones_like(td.get("a"))
-        inserted = td.set_default("z", expected, _run_checks=True)
+        inserted = td.setdefault("z", expected, _run_checks=True)
         assert (inserted == expected).all()
 
-    def test_set_default_existing_key(self, td_name, device):
+    def test_setdefault_existing_key(self, td_name, device):
         td = getattr(self, td_name)(device)
         td.unlock()
         expected = td.get("a")
-        inserted = td.set_default("a", torch.ones_like(td.get("b")))
+        inserted = td.setdefault("a", torch.ones_like(td.get("b")))
         assert (inserted == expected).all()
 
     def test_setdefault_nested(self, td_name, device):
@@ -1891,12 +1891,10 @@ class TestTensorDicts(TestTensorDictsBase):
             td.set("a", sub_tensordict)
 
         # if key exists we return the existing value
-        torch.testing.assert_close(td.set_default(("a", "b", "c"), tensor2), tensor)
+        torch.testing.assert_close(td.setdefault(("a", "b", "c"), tensor2), tensor)
 
         if not td_name == "stacked_td":
-            torch.testing.assert_close(
-                td.set_default(("a", "b", "d"), tensor2), tensor2
-            )
+            torch.testing.assert_close(td.setdefault(("a", "b", "d"), tensor2), tensor2)
             torch.testing.assert_close(td.get(("a", "b", "d")), tensor2)
 
     @pytest.mark.parametrize("performer", ["torch", "tensordict"])
@@ -2879,9 +2877,9 @@ def test_setdefault_nested():
     tensordict = TensorDict({"a": sub_tensordict}, [4])
 
     # if key exists we return the existing value
-    assert tensordict.set_default(("a", "b", "c"), tensor2) is tensor
+    assert tensordict.setdefault(("a", "b", "c"), tensor2) is tensor
 
-    assert tensordict.set_default(("a", "b", "d"), tensor2) is tensor2
+    assert tensordict.setdefault(("a", "b", "d"), tensor2) is tensor2
     assert (tensordict["a", "b", "d"] == 1).all()
     assert tensordict.get(("a", "b", "d")) is tensor2
 


### PR DESCRIPTION
## Description

This PR renames `set_default` to `setdefault` for parity with Python's `dict`.

I've actually left `set_default` in place for now with a deprecation warning as TorchRL uses `setdefault` and so we would break their CI with a straight switch. Once this lands, we can update TorchRL, then drop the alias here and hopefully not cause any disruption.