### PR TITLE
[Feature] Full type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.0.1
     hooks:
       - id: check-docstring-first
       - id: check-toml
@@ -11,25 +11,26 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/omnilib/ufmt
-    rev: v2.0.1
+    rev: v2.0.0b2
     hooks:
       - id: ufmt
         additional_dependencies:
-          - black == 23.1.0
-          - usort == 1.0.5
-          - libcst == 0.4.9
+          - black == 22.3.0
+          - usort == 1.0.3
+          - libcst == 0.4.7
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 4.0.1
     hooks:
       - id: flake8
         args: [--config=setup.cfg]
         additional_dependencies:
-          - flake8-bugbear == 23.2.13
-          - flake8-comprehensions == 3.10.1
+          - flake8-bugbear==22.10.27
+          - flake8-comprehensions==3.10.1
+
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.3.0
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
         files: ^torchrl/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-docstring-first
       - id: check-toml
@@ -11,26 +11,25 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/omnilib/ufmt
-    rev: v2.0.0b2
+    rev: v2.0.1
     hooks:
       - id: ufmt
         additional_dependencies:
-          - black == 22.3.0
-          - usort == 1.0.3
-          - libcst == 0.4.7
+          - black == 23.1.0
+          - usort == 1.0.5
+          - libcst == 0.4.9
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: [--config=setup.cfg]
         additional_dependencies:
-          - flake8-bugbear==22.10.27
-          - flake8-comprehensions==3.10.1
-
+          - flake8-bugbear == 23.2.13
+          - flake8-comprehensions == 3.10.1
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         files: ^torchrl/

--- a/benchmarks/common/common_ops_test.py
+++ b/benchmarks/common/common_ops_test.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from tensordict import TensorDict
 
 

--- a/benchmarks/common/pytree_benchmarks_test.py
+++ b/benchmarks/common/pytree_benchmarks_test.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from tensordict import TensorDict
 from torch.utils._pytree import tree_map
 

--- a/benchmarks/distributed/dataloading.py
+++ b/benchmarks/distributed/dataloading.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import tenacity
 import torch
 import tqdm
+
 from tensordict import MemmapTensor
 from tensordict.prototype import tensorclass
 from torch import multiprocessing as mp, nn
@@ -482,7 +483,6 @@ def func(rank, world_size, args, train_data_tc, single_gpu, trainer_transform):
     # access GPU
     torch.randn(1, device="cuda:0")
     if rank == 0:
-
         trainer = DummyTrainerNode(
             world_size, single_gpu, local_transform=not trainer_transform
         )

--- a/benchmarks/distributed/distributed_benchmark_test.py
+++ b/benchmarks/distributed/distributed_benchmark_test.py
@@ -2,8 +2,8 @@ import os
 import time
 
 import pytest
-
 import torch
+
 from tensordict import MemmapTensor, TensorDict
 from torch.distributed import rpc
 

--- a/benchmarks/fx_benchmarks.py
+++ b/benchmarks/fx_benchmarks.py
@@ -2,6 +2,7 @@ import timeit
 
 import torch
 import torch.nn as nn
+
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from tensordict.prototype.fx import symbolic_trace

--- a/benchmarks/nn/functional_benchmarks_test.py
+++ b/benchmarks/nn/functional_benchmarks_test.py
@@ -2,9 +2,9 @@
 from copy import deepcopy
 
 import pytest
-
 import torch
 from functorch import make_functional_with_buffers as functorch_make_functional
+
 from tensordict.nn.functional_modules import make_functional
 from torch import nn
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ import os
 import sys
 
 import pytorch_sphinx_theme
+
 import tensordict
 
 project = "tensordict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
-[tool.usort]
-first_party_detection = false
-
 [build-system]
 requires = ["setuptools", "wheel", "torch"]
 
+[tool.black]
+safe = true
+line-length = 88
+target-version = ["py37", "py38", "py39", "py310", "py311"]
+
+[tool.usort]
 first_party_detection = false
-
 target-version = ["py38"]
-
 excludes = [
     "gallery",
     "tutorials",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = ["setuptools", "wheel", "torch"]
 [tool.black]
 safe = true
 line-length = 88
-target-version = ["py37", "py38", "py39", "py310", "py311"]
 
 [tool.usort]
 first_party_detection = false

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ def get_nightly_version():
 def write_version_file(version):
     version_path = ROOT_DIR / "tensordict" / "version.py"
     with version_path.open("w") as f:
-        f.write("__version__ = '{}'\n".format(version))
-        f.write("git_version = {}\n".format(repr(sha)))
+        f.write(f"__version__ = '{version}'\n")
+        f.write(f"git_version = {repr(sha)}\n")
 
 
 def _get_pytorch_version():
@@ -98,10 +98,7 @@ def _main(argv):
     name = args.package_name
     is_nightly = "nightly" in name
 
-    if is_nightly:
-        version = get_nightly_version()
-    else:
-        version = get_version()
+    version = get_nightly_version() if is_nightly else get_version()
 
     write_version_file(version)
     print(f"Building wheel {package_name}-{version}")
@@ -111,7 +108,7 @@ def _main(argv):
     print("-- PyTorch dependency:", pytorch_package_dep)
 
     long_description = (ROOT_DIR / "README.md").read_text()
-    sys.argv = [sys.argv[0]] + unknown
+    sys.argv = [sys.argv[0], *unknown]
 
     setup(
         # Metadata

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ def _main(argv):
             "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
             "clean": clean,
         },
-        install_requires=[pytorch_package_dep, "numpy", "packaging", "cloudpickle"],
+        install_requires=[pytorch_package_dep, "numpy", "cloudpickle"],
         extras_require={
             "tests": ["pytest", "pyyaml", "pytest-instafail"],
             "checkpointing": ["torchsnapshot-nightly"],

--- a/tensordict/__init__.py
+++ b/tensordict/__init__.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .memmap import MemmapTensor, set_transfer_ownership
-from .tensordict import (
+from tensordict.memmap import MemmapTensor, set_transfer_ownership
+from tensordict.tensordict import (
     LazyStackedTensorDict,
     merge_tensordicts,
     SubTensorDict,
@@ -12,9 +12,10 @@ from .tensordict import (
 )
 
 try:
-    from .version import __version__
+    from tensordict.version import __version__
 except ImportError:
     __version__ = None
+
 
 __all__ = [
     "LazyStackedTensorDict",

--- a/tensordict/nn/__init__.py
+++ b/tensordict/nn/__init__.py
@@ -3,20 +3,24 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .common import (
+from tensordict.nn.common import (
     dispatch_kwargs,
     make_tensordict,
     TensorDictModule,
     TensorDictModuleWrapper,
 )
-from .functional_modules import get_functional, make_functional, repopulate_module
-from .probabilistic import (
+from tensordict.nn.functional_modules import (
+    get_functional,
+    make_functional,
+    repopulate_module,
+)
+from tensordict.nn.probabilistic import (
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
     set_interaction_mode,
 )
-from .sequence import TensorDictSequential
-from .utils import biased_softplus, inv_softplus
+from tensordict.nn.sequence import TensorDictSequential
+from tensordict.nn.utils import biased_softplus, inv_softplus
 
 __all__ = [
     "dispatch_kwargs",

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -10,7 +10,7 @@ import inspect
 
 import warnings
 from textwrap import indent
-from typing import Any, Iterable, List, Optional, Sequence, Union
+from typing import Any, Iterable, Sequence
 
 import torch
 
@@ -216,16 +216,15 @@ class TensorDictModule(nn.Module):
 
     def __init__(
         self,
-        module: Union[
-            "FunctionalModule",
-            "FunctionalModuleWithBuffers",
-            TensorDictModule,
-            nn.Module,
-        ],
+        module: (
+            FunctionalModule
+            | FunctionalModuleWithBuffers
+            | TensorDictModule
+            | nn.Module
+        ),
         in_keys: Iterable[NESTED_KEY],
         out_keys: Iterable[NESTED_KEY],
     ):
-
         super().__init__()
 
         if not out_keys:
@@ -239,7 +238,8 @@ class TensorDictModule(nn.Module):
 
         if "_" in in_keys:
             warnings.warn(
-                'key "_" is for ignoring output, it should not be used in input keys'
+                'key "_" is for ignoring output, it should not be used in input keys',
+                stacklevel=2,
             )
 
         self.module = module
@@ -254,11 +254,10 @@ class TensorDictModule(nn.Module):
     def _write_to_tensordict(
         self,
         tensordict: TensorDictBase,
-        tensors: List,
-        tensordict_out: Optional[TensorDictBase] = None,
-        out_keys: Optional[Iterable[NESTED_KEY]] = None,
+        tensors: list,
+        tensordict_out: TensorDictBase | None = None,
+        out_keys: Iterable[NESTED_KEY] | None = None,
     ) -> TensorDictBase:
-
         if out_keys is None:
             out_keys = self.out_keys
         if tensordict_out is None:
@@ -270,7 +269,7 @@ class TensorDictModule(nn.Module):
 
     def _call_module(
         self, tensors: Sequence[Tensor], **kwargs
-    ) -> Union[Tensor, Sequence[Tensor]]:
+    ) -> Tensor | Sequence[Tensor]:
         out = self.module(*tensors, **kwargs)
         return out
 
@@ -278,7 +277,7 @@ class TensorDictModule(nn.Module):
     def forward(
         self,
         tensordict: TensorDictBase,
-        tensordict_out: Optional[TensorDictBase] = None,
+        tensordict_out: TensorDictBase | None = None,
         **kwargs,
     ) -> TensorDictBase:
         """When the tensordict parameter is not set, kwargs are used to create an instance of TensorDict."""

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -15,7 +15,7 @@ from typing import Any, Iterable, Sequence
 import torch
 
 from tensordict.tensordict import make_tensordict, TensorDictBase
-from tensordict.utils import _nested_key_type_check, _normalize_key, NESTED_KEY
+from tensordict.utils import _nested_key_type_check, _normalize_key, NestedKey
 from torch import nn, Tensor
 
 
@@ -222,8 +222,8 @@ class TensorDictModule(nn.Module):
             | TensorDictModule
             | nn.Module
         ),
-        in_keys: Iterable[NESTED_KEY],
-        out_keys: Iterable[NESTED_KEY],
+        in_keys: Iterable[NestedKey],
+        out_keys: Iterable[NestedKey],
     ):
         super().__init__()
 
@@ -256,7 +256,7 @@ class TensorDictModule(nn.Module):
         tensordict: TensorDictBase,
         tensors: list,
         tensordict_out: TensorDictBase | None = None,
-        out_keys: Iterable[NESTED_KEY] | None = None,
+        out_keys: Iterable[NestedKey] | None = None,
     ) -> TensorDictBase:
         if out_keys is None:
             out_keys = self.out_keys

--- a/tensordict/nn/distributions/__init__.py
+++ b/tensordict/nn/distributions/__init__.py
@@ -3,12 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .continuous import *
-from .continuous import __all__ as _all_continuous
-from .discrete import *
-from .discrete import __all__ as _all_discrete
+from tensordict.nn.distributions import continuous, discrete
+from tensordict.nn.distributions.continuous import *
+from tensordict.nn.distributions.discrete import *
 
 distributions_maps = {
     distribution_class.lower(): eval(distribution_class)
-    for distribution_class in _all_continuous + _all_discrete
+    for distribution_class in (*continuous.__all__, *discrete.__all__)
 }

--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -3,8 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from numbers import Number
-from typing import Dict, Sequence, Tuple, Union
+from typing import Sequence
 
 import numpy as np
 import torch
@@ -60,7 +62,7 @@ class NormalParamWrapper(nn.Module):
         self.scale_mapping = scale_mapping
         self.scale_lb = scale_lb
 
-    def forward(self, *tensors: torch.Tensor) -> Tuple[torch.Tensor]:
+    def forward(self, *tensors: torch.Tensor) -> tuple[torch.Tensor]:
         net_output = self.operator(*tensors)
         others = ()
         if not isinstance(net_output, torch.Tensor):
@@ -111,7 +113,7 @@ class NormalParamExtractor(nn.Module):
         self.scale_mapping = scale_mapping
         self.scale_lb = scale_lb
 
-    def forward(self, *tensors: torch.Tensor) -> Tuple[torch.Tensor]:
+    def forward(self, *tensors: torch.Tensor) -> tuple[torch.Tensor]:
         tensor, *others = tensors
         loc, scale = tensor.chunk(2, -1)
         scale = mappings(self.scale_mapping)(scale).clamp_min(self.scale_lb)
@@ -132,15 +134,15 @@ class Delta(D.Distribution):
 
     """
 
-    arg_constraints: Dict = {}
+    arg_constraints: dict = {}
 
     def __init__(
         self,
         param: torch.Tensor,
         atol: float = 1e-6,
         rtol: float = 1e-6,
-        batch_shape: Union[torch.Size, Sequence[int]] = None,
-        event_shape: Union[torch.Size, Sequence[int]] = None,
+        batch_shape: torch.Size | Sequence[int] = None,
+        event_shape: torch.Size | Sequence[int] = None,
     ):
         if batch_shape is None:
             batch_shape = torch.Size([])

--- a/tensordict/nn/distributions/discrete.py
+++ b/tensordict/nn/distributions/discrete.py
@@ -3,7 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Sequence, Union
+from __future__ import annotations
+
+from typing import Sequence
 
 import torch
 from torch import distributions as D
@@ -14,8 +16,8 @@ __all__ = [
 
 
 def _treat_categorical_params(
-    params: Optional[torch.Tensor] = None,
-) -> Optional[torch.Tensor]:
+    params: torch.Tensor | None = None,
+) -> torch.Tensor | None:
     if params is None:
         return None
     if params.shape[-1] == 1:
@@ -43,8 +45,8 @@ class OneHotCategorical(D.Categorical):
 
     def __init__(
         self,
-        logits: Optional[torch.Tensor] = None,
-        probs: Optional[torch.Tensor] = None,
+        logits: torch.Tensor | None = None,
+        probs: torch.Tensor | None = None,
         **kwargs,
     ) -> None:
         logits = _treat_categorical_params(logits)
@@ -61,16 +63,14 @@ class OneHotCategorical(D.Categorical):
         else:
             return (self.probs == self.probs.max(-1, True)[0]).to(torch.long)
 
-    def sample(
-        self, sample_shape: Optional[Union[torch.Size, Sequence]] = None
-    ) -> torch.Tensor:
+    def sample(self, sample_shape: torch.Size | Sequence | None = None) -> torch.Tensor:
         if sample_shape is None:
             sample_shape = torch.Size([])
         out = super().sample(sample_shape=sample_shape)
         out = torch.nn.functional.one_hot(out, self.logits.shape[-1]).to(torch.long)
         return out
 
-    def rsample(self, sample_shape: Union[torch.Size, Sequence] = None) -> torch.Tensor:
+    def rsample(self, sample_shape: torch.Size | Sequence = None) -> torch.Tensor:
         if sample_shape is None:
             sample_shape = torch.Size([])
         d = D.relaxed_categorical.RelaxedOneHotCategorical(

--- a/tensordict/nn/distributions/discrete.py
+++ b/tensordict/nn/distributions/discrete.py
@@ -63,14 +63,20 @@ class OneHotCategorical(D.Categorical):
         else:
             return (self.probs == self.probs.max(-1, True)[0]).to(torch.long)
 
-    def sample(self, sample_shape: torch.Size | Sequence | None = None) -> torch.Tensor:
+    def sample(
+        self,
+        sample_shape: torch.Size | Sequence[int] | None = None,
+    ) -> torch.Tensor:
         if sample_shape is None:
             sample_shape = torch.Size([])
         out = super().sample(sample_shape=sample_shape)
         out = torch.nn.functional.one_hot(out, self.logits.shape[-1]).to(torch.long)
         return out
 
-    def rsample(self, sample_shape: torch.Size | Sequence = None) -> torch.Tensor:
+    def rsample(
+        self,
+        sample_shape: torch.Size | Sequence[int] | None = None,
+    ) -> torch.Tensor:
         if sample_shape is None:
             sample_shape = torch.Size([])
         d = D.relaxed_categorical.RelaxedOneHotCategorical(

--- a/tensordict/nn/distributions/truncated_normal.py
+++ b/tensordict/nn/distributions/truncated_normal.py
@@ -3,8 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 # from https://github.com/toshas/torch_truncnorm
+
+from __future__ import annotations
 
 import math
 from numbers import Number
@@ -39,9 +40,7 @@ class TruncatedStandardNormal(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self.a.size()
-        super(TruncatedStandardNormal, self).__init__(
-            batch_shape, validate_args=validate_args
-        )
+        super().__init__(batch_shape, validate_args=validate_args)
         if self.a.dtype != self.b.dtype:
             raise ValueError("Truncation bounds types are different")
         if any(
@@ -148,7 +147,7 @@ class TruncatedNormal(TruncatedStandardNormal):
         self._non_std_b = b
         a = (a - self.loc) / self.scale
         b = (b - self.loc) / self.scale
-        super(TruncatedNormal, self).__init__(a, b, validate_args=validate_args)
+        super().__init__(a, b, validate_args=validate_args)
         self._log_scale = self.scale.log()
         self._mean = self._mean * self.scale + self.loc
         self._variance = self._variance * self.scale**2
@@ -161,7 +160,7 @@ class TruncatedNormal(TruncatedStandardNormal):
         return value * self.scale + self.loc
 
     def cdf(self, value):
-        return super(TruncatedNormal, self).cdf(self._to_std_rv(value))
+        return super().cdf(self._to_std_rv(value))
 
     def icdf(self, value):
         sample = self._from_std_rv(super().icdf(value))
@@ -178,4 +177,4 @@ class TruncatedNormal(TruncatedStandardNormal):
 
     def log_prob(self, value):
         value = self._to_std_rv(value)
-        return super(TruncatedNormal, self).log_prob(value) - self._log_scale
+        return super().log_prob(value) - self._log_scale

--- a/tensordict/nn/distributions/truncated_normal.py
+++ b/tensordict/nn/distributions/truncated_normal.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 from numbers import Number
+from typing import Sequence
 
 import torch
 from torch.distributions import constraints, Distribution
@@ -34,7 +35,12 @@ class TruncatedStandardNormal(Distribution):
     has_rsample = True
     eps = 1e-6
 
-    def __init__(self, a, b, validate_args=None):
+    def __init__(
+        self,
+        a: Number | torch.Tensor,
+        b: Number | torch.Tensor,
+        validate_args: bool | None = None,
+    ) -> None:
         self.a, self.b = broadcast_all(a, b)
         if isinstance(a, Number) and isinstance(b, Number):
             batch_shape = torch.Size()
@@ -43,13 +49,7 @@ class TruncatedStandardNormal(Distribution):
         super().__init__(batch_shape, validate_args=validate_args)
         if self.a.dtype != self.b.dtype:
             raise ValueError("Truncation bounds types are different")
-        if any(
-            (self.a >= self.b)
-            .view(
-                -1,
-            )
-            .tolist()
-        ):
+        if any((self.a >= self.b).view(-1).tolist()):
             raise ValueError("Incorrect truncation range")
         # eps = torch.finfo(self.a.dtype).eps * 10
         eps = self.eps
@@ -76,53 +76,56 @@ class TruncatedStandardNormal(Distribution):
         self._entropy = CONST_LOG_SQRT_2PI_E + self._log_Z - 0.5 * self._lpbb_m_lpaa_d_Z
 
     @constraints.dependent_property
-    def support(self):
+    def support(self) -> constraints.Constraints:
         return constraints.interval(self.a, self.b)
 
     @property
-    def mean(self):
+    def mean(self) -> torch.Tensor:
         return self._mean
 
     @property
-    def variance(self):
+    def variance(self) -> torch.Tensor:
         return self._variance
 
     @property
-    def entropy(self):
+    def entropy(self) -> torch.Tensor:
         return self._entropy
 
     @property
-    def auc(self):
+    def auc(self) -> torch.Tensor:
         return self._Z
 
     @staticmethod
-    def _little_phi(x):
+    def _little_phi(x: torch.Tensor) -> torch.Tensor:
         return (-(x**2) * 0.5).exp() * CONST_INV_SQRT_2PI
 
-    def _big_phi(self, x):
+    def _big_phi(self, x: torch.Tensor) -> torch.Tensor:
         phi = 0.5 * (1 + (x * CONST_INV_SQRT_2).erf())
         return phi.clamp(self.eps, 1 - self.eps)
 
     @staticmethod
-    def _inv_big_phi(x):
+    def _inv_big_phi(x: torch.Tensor) -> torch.Tensor:
         return CONST_SQRT_2 * (2 * x - 1).erfinv()
 
-    def cdf(self, value):
+    def cdf(self, value: torch.Tensor) -> torch.Tensor:
         if self._validate_args:
             self._validate_sample(value)
         return ((self._big_phi(value) - self._big_phi_a) / self._Z).clamp(0, 1)
 
-    def icdf(self, value):
+    def icdf(self, value: torch.Tensor) -> torch.Tensor:
         y = self._big_phi_a + value * self._Z
         y = y.clamp(self.eps, 1 - self.eps)
         return self._inv_big_phi(y)
 
-    def log_prob(self, value):
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         if self._validate_args:
             self._validate_sample(value)
         return CONST_LOG_INV_SQRT_2PI - self._log_Z - (value**2) * 0.5
 
-    def rsample(self, sample_shape=None):
+    def rsample(
+        self,
+        sample_shape: torch.Size | Sequence[int] | None = None,
+    ) -> torch.Tensor:
         if sample_shape is None:
             sample_shape = torch.Size([])
         shape = self._extended_shape(sample_shape)
@@ -140,7 +143,14 @@ class TruncatedNormal(TruncatedStandardNormal):
 
     has_rsample = True
 
-    def __init__(self, loc, scale, a, b, validate_args=None):
+    def __init__(
+        self,
+        loc: Number | torch.Tensor,
+        scale: Number | torch.Tensor,
+        a: Number | torch.Tensor,
+        b: Number | torch.Tensor,
+        validate_args: bool | None = None,
+    ) -> None:
         scale = scale.clamp_min(self.eps)
         self.loc, self.scale, a, b = broadcast_all(loc, scale, a, b)
         self._non_std_a = a
@@ -153,16 +163,16 @@ class TruncatedNormal(TruncatedStandardNormal):
         self._variance = self._variance * self.scale**2
         self._entropy += self._log_scale
 
-    def _to_std_rv(self, value):
+    def _to_std_rv(self, value: torch.Tensor) -> torch.Tensor:
         return (value - self.loc) / self.scale
 
-    def _from_std_rv(self, value):
+    def _from_std_rv(self, value: torch.Tensor) -> torch.Tensor:
         return value * self.scale + self.loc
 
-    def cdf(self, value):
+    def cdf(self, value: torch.Tensor) -> torch.Tensor:
         return super().cdf(self._to_std_rv(value))
 
-    def icdf(self, value):
+    def icdf(self, value: torch.Tensor) -> torch.Tensor:
         sample = self._from_std_rv(super().icdf(value))
 
         # clamp data but keep gradients
@@ -175,6 +185,6 @@ class TruncatedNormal(TruncatedStandardNormal):
         sample.data.copy_(sample_clip)
         return sample
 
-    def log_prob(self, value):
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         value = self._to_std_rv(value)
         return super().log_prob(value) - self._log_scale

--- a/tensordict/nn/distributions/utils.py
+++ b/tensordict/nn/distributions/utils.py
@@ -6,22 +6,29 @@
 from __future__ import annotations
 
 import torch
-from torch import distributions as d
+from tensordict.utils import DeviceType
+from torch import distributions as D
 
 
-def _cast_device(elt: torch.Tensor | float, device) -> torch.Tensor | float:
+def _cast_device(
+    elt: torch.Tensor | float,
+    device: DeviceType,
+) -> torch.Tensor | float:
     if isinstance(elt, torch.Tensor):
         return elt.to(device)
     return elt
 
 
-def _cast_transform_device(transform, device):
+def _cast_transform_device(
+    transform: D.Transform | None,
+    device: DeviceType,
+) -> D.Transform | None:
     if transform is None:
         return transform
-    elif isinstance(transform, d.ComposeTransform):
+    elif isinstance(transform, D.ComposeTransform):
         for i, t in enumerate(transform.parts):
             transform.parts[i] = _cast_transform_device(t, device)
-    elif isinstance(transform, d.Transform):
+    elif isinstance(transform, D.Transform):
         for attribute in dir(transform):
             value = getattr(transform, attribute)
             if isinstance(value, torch.Tensor):

--- a/tensordict/nn/distributions/utils.py
+++ b/tensordict/nn/distributions/utils.py
@@ -3,13 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Union
+from __future__ import annotations
 
 import torch
 from torch import distributions as d
 
 
-def _cast_device(elt: Union[torch.Tensor, float], device) -> Union[torch.Tensor, float]:
+def _cast_device(elt: torch.Tensor | float, device) -> torch.Tensor | float:
     if isinstance(elt, torch.Tensor):
         return elt.to(device)
     return elt

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -2,6 +2,9 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
 import inspect
 
 import types
@@ -48,7 +51,6 @@ except ImportError:
 
 # Monkey-patch functorch, mainly for cases where a "isinstance(obj, Tensor) is invoked
 if _has_functorch:
-
     # Monkey-patches
 
     def _process_batched_inputs(in_dims, args, func):

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -6,10 +6,10 @@
 from __future__ import annotations
 
 import inspect
-
 import types
 from copy import deepcopy
 from functools import wraps
+from typing import Any, Callable, Iterable
 
 import torch
 from tensordict import TensorDict
@@ -53,7 +53,9 @@ except ImportError:
 if _has_functorch:
     # Monkey-patches
 
-    def _process_batched_inputs(in_dims, args, func):
+    def _process_batched_inputs(
+        in_dims: int | tuple[int, ...], args: Any, func: Callable
+    ) -> tuple[Any, ...]:
         if not isinstance(in_dims, int) and not isinstance(in_dims, tuple):
             raise ValueError(
                 f"""vmap({_get_name(func)}, in_dims={in_dims}, ...)(<inputs>):
@@ -112,7 +114,9 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
 
     vmap_src._process_batched_inputs = _process_batched_inputs
 
-    def _create_batched_inputs(flat_in_dims, flat_args, vmap_level: int, args_spec):
+    def _create_batched_inputs(
+        flat_in_dims: list[int], flat_args: list[Any], vmap_level: int, args_spec
+    ) -> Any:
         # See NOTE [Ignored _remove_batch_dim, _add_batch_dim]
         # If tensordict, we remove the dim at batch_size[in_dim] such that the TensorDict can accept
         # the batched tensors. This will be added in _unwrap_batched
@@ -132,8 +136,12 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
     vmap_src._create_batched_inputs = _create_batched_inputs
 
     def _unwrap_batched(
-        batched_outputs, out_dims, vmap_level: int, batch_size: int, func
-    ):
+        batched_outputs: Any,
+        out_dims: int | tuple[int, ...],
+        vmap_level: int,
+        batch_size: int,
+        func: Callable,
+    ) -> Any:
         flat_batched_outputs, output_spec = tree_flatten(batched_outputs)
 
         for out in flat_batched_outputs:
@@ -191,7 +199,11 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
 # Tensordict-compatible Functional modules
 
 
-def extract_weights_and_buffers(model: nn.Module, funs_to_decorate=None, recurse=True):
+def extract_weights_and_buffers(
+    model: nn.Module,
+    funs_to_decorate: Iterable[str] | None = None,
+    recurse: bool = True,
+) -> TensorDict:
     """Extracts the weights and buffers of a model in a tensordict, and adapts the modules to read those inputs."""
     tensordict = {}
     for name, param in list(model.named_parameters(recurse=False)):
@@ -226,8 +238,12 @@ def extract_weights_and_buffers(model: nn.Module, funs_to_decorate=None, recurse
 
 
 def _swap_state(
-    model, tensordict, is_stateless, return_old_tensordict=False, old_tensordict=None
-):
+    model: nn.Module,
+    tensordict: TensorDict,
+    is_stateless: bool,
+    return_old_tensordict: bool = False,
+    old_tensordict: dict[str, torch.Tensor] | TensorDict | None = None,
+) -> dict[str, torch.Tensor] | TensorDict | None:
     model.__dict__["_is_stateless"] = is_stateless
     if return_old_tensordict and old_tensordict is None:
         old_tensordict = {}
@@ -246,10 +262,7 @@ def _swap_state(
             # faster than get(key, Tensordict(...))
             value = {}
 
-        if return_old_tensordict:
-            _old_value = old_tensordict.get(key, None)
-        else:
-            _old_value = None
+        _old_value = old_tensordict.get(key, None) if return_old_tensordict else None
         _old_value = _swap_state(
             child,
             value,
@@ -272,21 +285,28 @@ def _swap_state(
         setattr(model, key, value)
     if return_old_tensordict:
         return old_tensordict
+    return None
 
 
-def make_functional(module, funs_to_decorate=None):
+def make_functional(
+    module: nn.Module,
+    funs_to_decorate: Iterable[str] | None = None,
+) -> TensorDict:
     params = extract_weights_and_buffers(module, funs_to_decorate=funs_to_decorate)
     return params
 
 
-def get_functional(module, funs_to_decorate=None):
+def get_functional(
+    module: nn.Module,
+    funs_to_decorate: Iterable[str] | None = None,
+) -> nn.Module:
     params = make_functional(module, funs_to_decorate=funs_to_decorate)
     out = deepcopy(module)
     repopulate_module(module, params)
     return out
 
 
-def _make_decorator(module, fun_name):
+def _make_decorator(module: nn.Module, fun_name: str) -> Callable:
     fun = getattr(module, fun_name)
     # we need to update the signature so that params can be the last positional arg
     oldsig = inspect.signature(fun)
@@ -351,13 +371,20 @@ def _make_decorator(module, fun_name):
     return new_fun
 
 
-def _assign_params(module, params, make_stateless, return_old_tensordict):
+def _assign_params(
+    module: nn.Module,
+    params: TensorDict,
+    make_stateless: bool,
+    return_old_tensordict: bool,
+) -> TensorDict | None:
     if params is not None:
         out = _swap_state(module, params, make_stateless, return_old_tensordict)
         if out is not None:
             return TensorDict(out, [], _run_checks=False)
+        return None
+    return None
 
 
-def repopulate_module(model, tensordict):
+def repopulate_module(model: nn.Module, tensordict: TensorDict) -> nn.Module:
     _swap_state(model, tensordict, is_stateless=False)
     return model

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -3,9 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import re
 from textwrap import indent
-from typing import Any, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Sequence
 
 import torch.nn as nn
 
@@ -23,7 +25,7 @@ __all__ = ["ProbabilisticTensorDictModule", "ProbabilisticTensorDictSequential"]
 _INTERACTION_MODE = None
 
 
-def interaction_mode() -> Union[str, None]:
+def interaction_mode() -> str | None:
     """Returns the current sampling mode."""
     return _INTERACTION_MODE
 
@@ -186,11 +188,11 @@ class ProbabilisticTensorDictModule(nn.Module):
 
     def __init__(
         self,
-        in_keys: Union[str, Sequence[str], dict],
-        out_keys: Optional[Union[str, Sequence[str]]] = None,
+        in_keys: str | Sequence[str] | dict,
+        out_keys: str | Sequence[str] | None = None,
         default_interaction_mode: str = "mode",
-        distribution_class: Type = Delta,
-        distribution_kwargs: Optional[dict] = None,
+        distribution_class: type = Delta,
+        distribution_kwargs: dict | None = None,
         return_log_prob: bool = False,
         cache_dist: bool = False,
         n_empirical_estimate: int = 1000,
@@ -247,7 +249,7 @@ class ProbabilisticTensorDictModule(nn.Module):
     def forward(
         self,
         tensordict: TensorDictBase,
-        tensordict_out: Optional[TensorDictBase] = None,
+        tensordict_out: TensorDictBase | None = None,
         _requires_sample: bool = True,
     ) -> TensorDictBase:
         if tensordict_out is None:
@@ -278,7 +280,7 @@ class ProbabilisticTensorDictModule(nn.Module):
 
     def _dist_sample(
         self, dist: d.Distribution, interaction_mode: bool = None
-    ) -> Union[Tuple[Tensor], Tensor]:
+    ) -> tuple[Tensor] | Tensor:
         if interaction_mode is None or interaction_mode == "":
             interaction_mode = self.default_interaction_mode
         if not isinstance(dist, d.Distribution):
@@ -341,7 +343,7 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
 
     def __init__(
         self,
-        *modules: Union[TensorDictModule, ProbabilisticTensorDictModule],
+        *modules: TensorDictModule | ProbabilisticTensorDictModule,
         partial_tolerant: bool = False,
     ) -> None:
         if len(modules) == 0:
@@ -369,9 +371,9 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
     def get_dist_params(
         self,
         tensordict: TensorDictBase,
-        tensordict_out: Optional[TensorDictBase] = None,
+        tensordict_out: TensorDictBase | None = None,
         **kwargs,
-    ) -> Tuple[d.Distribution, TensorDictBase]:
+    ) -> tuple[d.Distribution, TensorDictBase]:
         tds = TensorDictSequential(*self.module[:-1])
         if self.__dict__.get("_is_stateless", False):
             tds = repopulate_module(tds, kwargs.pop("params"))
@@ -384,7 +386,7 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
     def get_dist(
         self,
         tensordict: TensorDictBase,
-        tensordict_out: Optional[TensorDictBase] = None,
+        tensordict_out: TensorDictBase | None = None,
         **kwargs,
     ) -> d.Distribution:
         """Get the distribution that results from passing the input tensordict through
@@ -402,7 +404,7 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
     def forward(
         self,
         tensordict: TensorDictBase,
-        tensordict_out: Optional[TensorDictBase] = None,
+        tensordict_out: TensorDictBase | None = None,
         **kwargs,
     ) -> TensorDictBase:
         tensordict_out = self.get_dist_params(tensordict, tensordict_out, **kwargs)

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -24,7 +24,7 @@ except ImportError:
 
 from tensordict.nn.common import dispatch_kwargs, TensorDictModule
 from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
-from tensordict.utils import _normalize_key, NESTED_KEY
+from tensordict.utils import _normalize_key, NestedKey
 from torch import nn
 
 __all__ = ["TensorDictSequential"]
@@ -170,8 +170,8 @@ class TensorDictSequential(TensorDictModule):
 
     def select_subsequence(
         self,
-        in_keys: Iterable[NESTED_KEY] = None,
-        out_keys: Iterable[NESTED_KEY] = None,
+        in_keys: Iterable[NestedKey] = None,
+        out_keys: Iterable[NestedKey] = None,
     ) -> TensorDictSequential:
         """Returns a new TensorDictSequential with only the modules that are necessary to compute the given output keys with the given input keys.
 

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Iterable
+from typing import Any, Iterable
 
 _has_functorch = False
 try:
@@ -123,7 +123,7 @@ class TensorDictSequential(TensorDictModule):
         self,
         *modules: TensorDictModule,
         partial_tolerant: bool = False,
-    ):
+    ) -> None:
         in_keys, out_keys = self._compute_in_and_out_keys(modules)
 
         super().__init__(
@@ -132,7 +132,9 @@ class TensorDictSequential(TensorDictModule):
 
         self.partial_tolerant = partial_tolerant
 
-    def _compute_in_and_out_keys(self, modules: list[TensorDictModule]) -> tuple[list]:
+    def _compute_in_and_out_keys(
+        self, modules: list[TensorDictModule]
+    ) -> tuple[list[NestedKey], list[NestedKey]]:
         in_keys = []
         out_keys = []
         for module in modules:
@@ -170,8 +172,8 @@ class TensorDictSequential(TensorDictModule):
 
     def select_subsequence(
         self,
-        in_keys: Iterable[NestedKey] = None,
-        out_keys: Iterable[NestedKey] = None,
+        in_keys: Iterable[NestedKey] | None = None,
+        out_keys: Iterable[NestedKey] | None = None,
     ) -> TensorDictSequential:
         """Returns a new TensorDictSequential with only the modules that are necessary to compute the given output keys with the given input keys.
 
@@ -215,10 +217,10 @@ class TensorDictSequential(TensorDictModule):
 
     def _run_module(
         self,
-        module,
-        tensordict,
-        **kwargs,
-    ):
+        module: TensorDictModule,
+        tensordict: TensorDictBase,
+        **kwargs: Any,
+    ) -> Any:
         tensordict_keys = set(tensordict.keys(include_nested=True))
         if not self.partial_tolerant or all(
             key in tensordict_keys for key in module.in_keys
@@ -236,8 +238,8 @@ class TensorDictSequential(TensorDictModule):
     def forward(
         self,
         tensordict: TensorDictBase,
-        tensordict_out=None,
-        **kwargs,
+        tensordict_out: TensorDictBase | None = None,
+        **kwargs: Any,
     ) -> TensorDictBase:
         if not len(kwargs):
             for module in self.module:
@@ -251,7 +253,7 @@ class TensorDictSequential(TensorDictModule):
             return tensordict_out
         return tensordict
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.module)
 
     def __getitem__(self, index: int | slice) -> TensorDictModule:

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable
 
 _has_functorch = False
 try:
@@ -132,7 +132,7 @@ class TensorDictSequential(TensorDictModule):
 
         self.partial_tolerant = partial_tolerant
 
-    def _compute_in_and_out_keys(self, modules: List[TensorDictModule]) -> Tuple[List]:
+    def _compute_in_and_out_keys(self, modules: list[TensorDictModule]) -> tuple[list]:
         in_keys = []
         out_keys = []
         for module in modules:
@@ -172,7 +172,7 @@ class TensorDictSequential(TensorDictModule):
         self,
         in_keys: Iterable[NESTED_KEY] = None,
         out_keys: Iterable[NESTED_KEY] = None,
-    ) -> "TensorDictSequential":
+    ) -> TensorDictSequential:
         """Returns a new TensorDictSequential with only the modules that are necessary to compute the given output keys with the given input keys.
 
         Args:
@@ -254,7 +254,7 @@ class TensorDictSequential(TensorDictModule):
     def __len__(self):
         return len(self.module)
 
-    def __getitem__(self, index: Union[int, slice]) -> TensorDictModule:
+    def __getitem__(self, index: int | slice) -> TensorDictModule:
         if isinstance(index, int):
             return self.module.__getitem__(index)
         else:
@@ -263,5 +263,5 @@ class TensorDictSequential(TensorDictModule):
     def __setitem__(self, index: int, tensordict_module: TensorDictModule) -> None:
         return self.module.__setitem__(idx=index, module=tensordict_module)
 
-    def __delitem__(self, index: Union[int, slice]) -> None:
+    def __delitem__(self, index: int | slice) -> None:
         self.module.__delitem__(idx=index)

--- a/tensordict/nn/utils.py
+++ b/tensordict/nn/utils.py
@@ -42,7 +42,7 @@ class biased_softplus(nn.Module):
             default: 0.1
     """
 
-    def __init__(self, bias: float, min_val: float = 0.01):
+    def __init__(self, bias: float, min_val: float = 0.01) -> None:
         super().__init__()
         self.bias = inv_softplus(bias - min_val)
         self.min_val = min_val
@@ -67,7 +67,7 @@ def mappings(key: str) -> Callable:
          a Callable
 
     """
-    _mappings = {
+    _mappings: dict[str, Callable] = {
         "softplus": torch.nn.functional.softplus,
         "exp": torch.exp,
         "relu": torch.relu,

--- a/tensordict/nn/utils.py
+++ b/tensordict/nn/utils.py
@@ -3,7 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Union
+from __future__ import annotations
+
+from typing import Callable
 
 import torch
 from torch import nn
@@ -11,7 +13,7 @@ from torch import nn
 __all__ = ["mappings", "inv_softplus", "biased_softplus"]
 
 
-def inv_softplus(bias: Union[float, torch.Tensor]) -> Union[float, torch.Tensor]:
+def inv_softplus(bias: float | torch.Tensor) -> float | torch.Tensor:
     """Inverse softplus function.
 
     Args:

--- a/tensordict/prototype/__init__.py
+++ b/tensordict/prototype/__init__.py
@@ -1,5 +1,10 @@
-from .fx import symbolic_trace
-from .tensorclass import is_tensorclass, tensorclass
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from tensordict.prototype.fx import symbolic_trace
+from tensordict.prototype.tensorclass import is_tensorclass, tensorclass
 
 __all__ = [
     "is_tensorclass",

--- a/tensordict/prototype/fx.py
+++ b/tensordict/prototype/fx.py
@@ -7,23 +7,32 @@ from __future__ import annotations
 
 import operator
 from itertools import filterfalse, tee
-
-import torch.fx as fx
-import torch.nn as nn
+from typing import Any, Callable, Iterable
 
 from tensordict.nn import TensorDictModule, TensorDictSequential
-
+from tensordict.tensordict import TensorDictBase
+from tensordict.utils import NestedKey
+from torch import fx, nn
 
 __all__ = ["symbolic_trace"]
 
 
 class TDGraphModule(nn.Module):
-    def __init__(self, graph_module, out_keys):
+    def __init__(
+        self,
+        graph_module: fx.GraphModule,
+        out_keys: list[NestedKey],
+    ) -> None:
         super().__init__()
         self.out_keys = out_keys
         self._gm = graph_module
 
-    def forward(self, tensordict, tensordict_out=None, **kwargs):
+    def forward(
+        self,
+        tensordict: TensorDictBase,
+        tensordict_out: TensorDictBase | None = None,
+        **kwargs,
+    ) -> TensorDictBase:
         outputs = self._gm(tensordict, **kwargs)
 
         if tensordict_out is None:
@@ -35,14 +44,14 @@ class TDGraphModule(nn.Module):
 
         return tensordict_out
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         try:
             return super().__getattr__(name)
         except AttributeError:
             return getattr(self._gm, name)
 
 
-def symbolic_trace(td_module):
+def symbolic_trace(td_module: TensorDictModule) -> TDGraphModule:
     if isinstance(td_module, TensorDictSequential):
         return _trace_tensordictsequential(td_module)
     elif isinstance(td_module, TensorDictModule):
@@ -51,14 +60,18 @@ def symbolic_trace(td_module):
 
 
 # cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
-def _partition(pred, iterable):
+def _partition(
+    pred: Callable[..., bool], iterable: Iterable[Any]
+) -> tuple[Iterable[Any], Iterable[Any]]:
     "Use a predicate to partition entries into false entries and true entries"
     # partition(is_odd, range(10)) --> 0 2 4 6 8   and  1 3 5 7 9
     t1, t2 = tee(iterable)
     return filterfalse(pred, t1), filter(pred, t2)
 
 
-def _parse_input_nodes(in_keys, nodes, td, inputs, env):
+def _parse_input_nodes(
+    in_keys: list[NestedKey], nodes, td: TensorDictBase, inputs: tuple[Any, ...], env
+):
     for in_key, node in zip(in_keys, nodes):
         if in_key in inputs:
             new_node = inputs[in_key]
@@ -69,7 +82,7 @@ def _parse_input_nodes(in_keys, nodes, td, inputs, env):
         env[node.name] = new_node
 
 
-def _trace_tensordictmodule(td_module):
+def _trace_tensordictmodule(td_module: TensorDictModule) -> TDGraphModule:
     # this graph manipulation is based heavily on example in the PyTorch docs
     # https://pytorch.org/docs/stable/fx.html#proxy-retracing
 
@@ -99,7 +112,7 @@ def _trace_tensordictmodule(td_module):
     )
 
 
-def _trace_tensordictsequential(td_sequential):
+def _trace_tensordictsequential(td_sequential: TensorDictSequential) -> TDGraphModule:
     # we track values previously read from / written to the tensordict by storing the
     # nodes / proxy values in the inputs / outputs dictionaries
     inputs = {}

--- a/tensordict/prototype/fx.py
+++ b/tensordict/prototype/fx.py
@@ -1,3 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
 import operator
 from itertools import filterfalse, tee
 

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -3,17 +3,15 @@ import functools
 import inspect
 import numbers
 import re
+import sys
 import typing
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from platform import python_version
 from textwrap import indent
 from typing import Callable, Dict, Optional, Tuple, Union
 
 import torch
-
-from packaging import version
 
 from tensordict.tensordict import (
     _accepted_classes,
@@ -27,7 +25,7 @@ from tensordict.utils import DEVICE_TYPING
 from torch import Tensor
 
 T = typing.TypeVar("T", bound=TensorDictBase)
-PY37 = version.parse(python_version()) < version.parse("3.8")
+PY37 = sys.version_info < (3, 8)
 
 # For __future__.annotations, we keep a dict of str -> class to call the class based on the string
 CLASSES_DICT = {}
@@ -466,6 +464,7 @@ def _setitem(self, item, value):
                     f"Meta data at {repr(key)} may or may not be equal, this may result in "
                     f"undefined behaviours",
                     category=UserWarning,
+                    stacklevel=2,
                 )
 
     for key in value._tensordict.keys():

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -21,13 +21,13 @@ from typing import Callable, Union
 import torch
 
 from tensordict.tensordict import (
-    _accepted_classes,
+    _ACCEPTED_CLASSES,
     get_repr,
     is_tensordict,
     TensorDict,
     TensorDictBase,
 )
-from tensordict.utils import DEVICE_TYPING
+from tensordict.utils import DeviceType
 
 from torch import Tensor
 
@@ -355,7 +355,7 @@ def _setattr_wrapper(setattr_, expected_keys):
                 f"Cannot set the attribute '{key}', expected attributes are {expected_keys}."
             )
 
-        if isinstance(value, _accepted_classes):
+        if isinstance(value, _ACCEPTED_CLASSES):
             # Avoiding key clash, honoring the user input to assign tensor type data to the key
             if key in self._non_tensordict.keys():
                 del self._non_tensordict[key]
@@ -600,7 +600,7 @@ def _device(self):
     return self._tensordict.device
 
 
-def _device_setter(self, value: DEVICE_TYPING) -> None:
+def _device_setter(self, value: DeviceType) -> None:
     raise RuntimeError(
         "device cannot be set using tensorclass.device = device, "
         "because device cannot be updated in-place. To update device, use "

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -1,3 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
 import dataclasses
 import functools
 import inspect
@@ -9,7 +16,7 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import indent
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Union
 
 import torch
 
@@ -97,7 +104,7 @@ def tensorclass(cls: T) -> T:
 
 
     """
-    td_handled_functions: Dict = {}
+    td_handled_functions: dict = {}
 
     def implements_for_tdc(torch_function: Callable) -> Callable:
         """Register a torch function override for _TensorClass."""
@@ -113,8 +120,8 @@ def tensorclass(cls: T) -> T:
         cls,
         func: Callable,
         types,
-        args: Tuple = (),
-        kwargs: Optional[dict] = None,
+        args: tuple = (),
+        kwargs: dict | None = None,
     ) -> Callable:
         if kwargs is None:
             kwargs = {}

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3125,7 +3125,7 @@ class TensorDict(TensorDictBase):
             tensor_in = _sub_index(tensor_in, idx)
             tensor_in.copy_(value)
         else:
-            _set_item(tensor_in, value, idx)
+            _set_item(tensor_in, idx, value)
 
         return self
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -11,7 +11,7 @@ import functools
 import numbers
 import textwrap
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 from copy import copy, deepcopy
 from numbers import Number
 from pathlib import Path
@@ -261,12 +261,10 @@ class _TensorDictKeysView:
         )
 
 
-class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
+class TensorDictBase(MutableMapping):
     """TensorDictBase is an abstract parent class for TensorDicts, a torch.Tensor data container."""
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        cls = kwargs.get("subcls", cls)
+    def __new__(cls, *args: Any, **kwargs: Any) -> TensorDictBase:
         cls._safe = kwargs.get("_safe", False)
         cls._lazy = kwargs.get("_lazy", False)
         cls._inplace_set = kwargs.get("_inplace_set", False)
@@ -2716,17 +2714,10 @@ class TensorDict(TensorDictBase):
 
     """
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> TensorDict:
         cls._is_shared = False
         cls._is_memmap = False
-        return TensorDictBase.__new__(
-            subcls=cls,
-            *args,
-            _safe=True,
-            _lazy=False,
-            **kwargs,
-        )
+        return super().__new__(cls, *args, _safe=True, _lazy=False, **kwargs)
 
     def __init__(
         self,
@@ -3973,13 +3964,10 @@ torch.Size([3, 2])
 
     """
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> SubTensorDict:
         cls._is_shared = False
         cls._is_memmap = False
-        return TensorDictBase.__new__(
-            subcls=cls, _safe=False, _lazy=True, _inplace_set=True
-        )
+        return super().__new__(cls, _safe=False, _lazy=True, _inplace_set=True)
 
     def __init__(
         self,
@@ -4471,9 +4459,8 @@ class LazyStackedTensorDict(TensorDictBase):
 
     """
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(*args, subcls=cls, _safe=False, _lazy=True, **kwargs)
+    def __new__(cls, *args: Any, **kwargs: Any) -> LazyStackedTensorDict:
+        return super().__new__(cls, *args, _safe=False, _lazy=True, **kwargs)
 
     def __init__(
         self,
@@ -5268,9 +5255,8 @@ class LazyStackedTensorDict(TensorDictBase):
 class _CustomOpTensorDict(TensorDictBase):
     """Encodes lazy operations on tensors contained in a TensorDict."""
 
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(*args, subcls=cls, _safe=False, _lazy=True, **kwargs)
+    def __new__(cls, *args: Any, **kwargs: Any) -> _CustomOpTensorDict:
+        return super().__new__(cls, *args, _safe=False, _lazy=True, **kwargs)
 
     def __init__(
         self,

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -16,21 +16,7 @@ from copy import copy, deepcopy
 from numbers import Number
 from pathlib import Path
 from textwrap import indent
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    Optional,
-    OrderedDict,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, Generator, Iterator, OrderedDict, Sequence, Union
 from warnings import warn
 
 import numpy as np
@@ -101,7 +87,7 @@ except ImportError as err:
 # some complex string used as separator to concatenate and split keys in
 # distributed frameworks
 DIST_SEPARATOR = ".-|-."
-TD_HANDLED_FUNCTIONS: Dict = {}
+TD_HANDLED_FUNCTIONS: dict = {}
 COMPATIBLE_TYPES = Union[
     Tensor,
     MemmapTensor,
@@ -116,7 +102,7 @@ if _has_torchrec:
 _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-only or string-free indices are supported."
 
 
-def is_tensordict(datatype: Union[type, Any]) -> bool:
+def is_tensordict(datatype: type | Any) -> bool:
     return (
         issubclass(datatype, TensorDictBase)
         if isinstance(datatype, type)
@@ -156,7 +142,7 @@ class _TensorDictKeysView:
     """
 
     def __init__(
-        self, tensordict: "TensorDictBase", include_nested: bool, leaves_only: bool
+        self, tensordict: TensorDictBase, include_nested: bool, leaves_only: bool
     ):
         self.tensordict = tensordict
         self.include_nested = include_nested
@@ -289,11 +275,11 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         cls._sorted_keys = None
         return super().__new__(cls)
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         return state
 
-    def __setstate__(self, state: Dict[str, Any]) -> Dict[str, Any]:
+    def __setstate__(self, state: dict[str, Any]) -> dict[str, Any]:
         self.__dict__.update(state)
 
     @property
@@ -318,7 +304,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def size(self, dim: Optional[int] = None):
+    def size(self, dim: int | None = None):
         """Returns the size of the dimension indicated by :obj:`dim`.
 
         If dim is not specified, returns the batch_size (or shape) of the TensorDict.
@@ -378,7 +364,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def device(self) -> Union[None, torch.device]:
+    def device(self) -> None | torch.device:
         """Device of a TensorDict.
 
         If the TensorDict has a specified device, all
@@ -476,7 +462,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         raise NotImplementedError(f"{self.__class__.__name__}")
 
     @abc.abstractmethod
-    def entry_class(self, key: Union[str, Tuple]) -> type:
+    def entry_class(self, key: str | tuple) -> type:
         """Returns the class of an entry, avoiding a call to `isinstance(td.get(key), type)`."""
         raise NotImplementedError(f"{self.__class__.__name__}")
 
@@ -520,7 +506,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def _stack_onto_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
     ) -> TensorDictBase:
         """Stacks a list of values onto an existing key while keeping the original storage.
@@ -915,7 +901,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def _stack_onto_at_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
         idx: INDEX_TYPING,
     ) -> TensorDictBase:
@@ -928,7 +914,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         )
 
     def _default_get(
-        self, key: str, default: Union[str, COMPATIBLE_TYPES] = "_no_default_"
+        self, key: str, default: str | COMPATIBLE_TYPES = "_no_default_"
     ) -> COMPATIBLE_TYPES:
         if not isinstance(default, str):
             return default
@@ -944,7 +930,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get(
-        self, key: NESTED_KEY, default: Union[str, COMPATIBLE_TYPES] = "_no_default_"
+        self, key: NESTED_KEY, default: str | COMPATIBLE_TYPES = "_no_default_"
     ) -> COMPATIBLE_TYPES:
         """Gets the value stored with the input key.
 
@@ -956,7 +942,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         raise NotImplementedError(f"{self.__class__.__name__}")
 
     def pop(
-        self, key: NESTED_KEY, default: Union[str, COMPATIBLE_TYPES] = "_no_default_"
+        self, key: NESTED_KEY, default: str | COMPATIBLE_TYPES = "_no_default_"
     ) -> COMPATIBLE_TYPES:
         _nested_key_type_check(key)
         try:
@@ -990,7 +976,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         self,
         fn: Callable,
         *others: TensorDictBase,
-        batch_size: Optional[Sequence[int]] = None,
+        batch_size: Sequence[int] | None = None,
         inplace: bool = False,
         **constructor_kwargs,
     ) -> TensorDictBase:
@@ -1075,7 +1061,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     def update(
         self,
-        input_dict_or_td: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
+        input_dict_or_td: dict[str, COMPATIBLE_TYPES] | TensorDictBase,
         clone: bool = False,
         inplace: bool = False,
         **kwargs,
@@ -1124,7 +1110,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     def update_(
         self,
-        input_dict_or_td: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
+        input_dict_or_td: dict[str, COMPATIBLE_TYPES] | TensorDictBase,
         clone: bool = False,
     ) -> TensorDictBase:
         """Updates the TensorDict in-place with values from either a dictionary or another TensorDict.
@@ -1159,7 +1145,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     def update_at_(
         self,
-        input_dict_or_td: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
+        input_dict_or_td: dict[str, COMPATIBLE_TYPES] | TensorDictBase,
         idx: INDEX_TYPING,
         clone: bool = False,
     ) -> TensorDictBase:
@@ -1210,20 +1196,19 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             )
         return self
 
-    def _convert_to_tensor(self, array: np.ndarray) -> Union[Tensor, MemmapTensor]:
+    def _convert_to_tensor(self, array: np.ndarray) -> Tensor | MemmapTensor:
         return torch.as_tensor(array, device=self.device)
 
-    def _convert_to_tensordict(self, dict_value: Dict[str, Any]) -> TensorDictBase:
+    def _convert_to_tensordict(self, dict_value: dict[str, Any]) -> TensorDictBase:
         return TensorDict(dict_value, batch_size=self.batch_size, device=self.device)
 
     def _process_input(
         self,
-        input: Union[COMPATIBLE_TYPES, dict, np.ndarray],
+        input: COMPATIBLE_TYPES | dict | np.ndarray,
         check_device: bool = True,
         check_tensor_shape: bool = True,
         check_shared: bool = False,
-    ) -> Union[Tensor, MemmapTensor]:
-
+    ) -> Tensor | MemmapTensor:
         if isinstance(input, dict):
             tensor = self._convert_to_tensordict(input)
         elif not isinstance(input, _accepted_classes):
@@ -1259,7 +1244,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     def items(
         self, include_nested: bool = False, leaves_only: bool = False
-    ) -> Iterator[Tuple[str, COMPATIBLE_TYPES]]:
+    ) -> Iterator[tuple[str, COMPATIBLE_TYPES]]:
         """Returns a generator of key-value pairs for the tensordict."""
         for k in self.keys(include_nested=include_nested, leaves_only=leaves_only):
             yield k, self.get(k)
@@ -1378,7 +1363,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                     f"keys in {self} and {other} mismatch, got {keys1} and {keys2}"
                 )
             d = {}
-            for (key, item1) in self.items():
+            for key, item1 in self.items():
                 d[key] = item1 != other.get(key)
             return TensorDict(batch_size=self.batch_size, source=d, device=self.device)
         if isinstance(other, (numbers.Number, torch.Tensor)):
@@ -1408,7 +1393,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
                 raise KeyError(f"keys in tensordicts mismatch, got {keys1} and {keys2}")
             d = {}
-            for (key, item1) in self.items():
+            for key, item1 in self.items():
                 d[key] = item1 == other.get(key)
             return TensorDict(batch_size=self.batch_size, source=d, device=self.device)
         if isinstance(other, (numbers.Number, torch.Tensor)):
@@ -1668,7 +1653,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             self.fill_(key, 0)
         return self
 
-    def unbind(self, dim: int) -> Tuple[TensorDictBase, ...]:
+    def unbind(self, dim: int) -> tuple[TensorDictBase, ...]:
         """Returns a tuple of indexed tensordicts unbound along the indicated dimension.
 
         Resulting tensordicts will share the storage of the initial tensordict.
@@ -1695,7 +1680,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
                 out[-1].memmap_()
         return tuple(out)
 
-    def chunk(self, chunks: int, dim: int = 0) -> Tuple[TensorDictBase, ...]:
+    def chunk(self, chunks: int, dim: int = 0) -> tuple[TensorDictBase, ...]:
         """Splits a tendordict into the specified number of chunks, if possible.
 
         Each chunk is a view of the input tensordict.
@@ -1750,8 +1735,8 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         cls,
         func: Callable,
         types,
-        args: Tuple = (),
-        kwargs: Optional[dict] = None,
+        args: tuple = (),
+        kwargs: dict | None = None,
     ) -> Callable:
         if kwargs is None:
             kwargs = {}
@@ -1762,9 +1747,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         return TD_HANDLED_FUNCTIONS[func](*args, **kwargs)
 
     @abc.abstractmethod
-    def to(
-        self, dest: Union[DEVICE_TYPING, Type, torch.Size], **kwargs
-    ) -> TensorDictBase:
+    def to(self, dest: DEVICE_TYPING | type | torch.Size, **kwargs) -> TensorDictBase:
         """Maps a TensorDictBase subclass either on a new device or to another TensorDictBase subclass (if permitted).
 
         Casting tensors to a new dtype is not allowed, as tensordicts are not bound to contain a single
@@ -1805,7 +1788,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         return self.to(f"cuda:{device}")
 
     @abc.abstractmethod
-    def masked_fill_(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill_(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         """Fills the values corresponding to the mask with the desired value.
 
         Args:
@@ -1829,7 +1812,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def masked_fill(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         """Out-of-place version of masked_fill.
 
         Args:
@@ -1889,7 +1872,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         """Returns a new tensordict of the same type with contiguous values (or self if values are already contiguous)."""
         raise NotImplementedError
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Returns a dictionary with key-value pairs matching those of the tensordict."""
         return {
             key: value.to_dict() if isinstance(value, TensorDictBase) else value
@@ -1920,7 +1903,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             inv_op_kwargs={"dim": dim},
         )
 
-    def squeeze(self, dim: Optional[int] = None) -> TensorDictBase:
+    def squeeze(self, dim: int | None = None) -> TensorDictBase:
         """Squeezes all tensors for a dimension comprised in between `-td.batch_dims+1` and `td.batch_dims-1` and returns them in a new tensordict.
 
         Args:
@@ -1965,7 +1948,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def reshape(
         self,
         *shape: int,
-        size: Optional[Union[List, Tuple, torch.Size]] = None,
+        size: list | tuple | torch.Size | None = None,
     ) -> TensorDictBase:
         """Returns a contiguous, reshaped tensor of the desired shape.
 
@@ -1997,9 +1980,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             batch_size = shape
         return TensorDict(d, batch_size, device=self.device, _run_checks=False)
 
-    def split(
-        self, split_size: Union[int, List[int]], dim: int = 0
-    ) -> List[TensorDictBase]:
+    def split(self, split_size: int | list[int], dim: int = 0) -> list[TensorDictBase]:
         """Splits each tensor in the TensorDict with the specified size in the given dimension, like `torch.split`.
         Returns a list of TensorDict with the view of split chunks of items. Nested TensorDicts will remain nested.
 
@@ -2110,7 +2091,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def view(
         self,
         *shape: int,
-        size: Optional[Union[List, Tuple, torch.Size]] = None,
+        size: list | tuple | torch.Size | None = None,
     ) -> TensorDictBase:
         """Returns a tensordict with views of the tensors according to a new shape, compatible with the tensordict batch_size.
 
@@ -2235,7 +2216,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
         return f"{type(self).__name__}(\n{string})"
 
-    def all(self, dim: int = None) -> Union[bool, TensorDictBase]:
+    def all(self, dim: int = None) -> bool | TensorDictBase:
         """Checks if all values are True/non-null in the tensordict.
 
         Args:
@@ -2261,7 +2242,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             )
         return all(value.all() for value in self.values())
 
-    def any(self, dim: int = None) -> Union[bool, TensorDictBase]:
+    def any(self, dim: int = None) -> bool | TensorDictBase:
         """Checks if any value is True/non-null in the tensordict.
 
         Args:
@@ -2373,7 +2354,6 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
         keys = set(out.keys())
         for key, list_of_keys in to_unflatten.items():
-
             if key in keys:
                 raise KeyError(
                     "Unflattening key(s) in tensordict will override existing unflattened key"
@@ -2382,7 +2362,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             tensordict = TensorDict({}, batch_size=self.batch_size, device=self.device)
             if key in self.keys():
                 tensordict.update(self[key])
-            for (old_key, new_key) in list_of_keys:
+            for old_key, new_key in list_of_keys:
                 value = self[old_key]
                 tensordict[new_key] = value
                 if inplace:
@@ -2484,9 +2464,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
 
     __getitems__ = __getitem__
 
-    def __setitem__(
-        self, index: INDEX_TYPING, value: Union[TensorDictBase, dict]
-    ) -> None:
+    def __setitem__(self, index: INDEX_TYPING, value: TensorDictBase | dict) -> None:
         if index is Ellipsis or (isinstance(index, tuple) and Ellipsis in index):
             index = convert_ellipsis_to_idx(index, self.batch_size)
         if isinstance(index, (list, range)):
@@ -2567,7 +2545,7 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def fill_(self, key: str, value: Union[float, bool]) -> TensorDictBase:
+    def fill_(self, key: str, value: float | bool) -> TensorDictBase:
         """Fills a tensor pointed by the key with the a given value.
 
         Args:
@@ -2752,14 +2730,13 @@ class TensorDict(TensorDictBase):
 
     def __init__(
         self,
-        source: Union[TensorDictBase, dict],
-        batch_size: Optional[Union[Sequence[int], torch.Size, int]] = None,
-        device: Optional[DEVICE_TYPING] = None,
+        source: TensorDictBase | dict,
+        batch_size: Sequence[int] | torch.Size | int | None = None,
+        device: DEVICE_TYPING | None = None,
         _run_checks: bool = True,
-        _is_shared: Optional[bool] = False,
-        _is_memmap: Optional[bool] = False,
+        _is_shared: bool | None = False,
+        _is_memmap: bool | None = False,
     ) -> None:
-
         self._is_shared = _is_shared
         self._is_memmap = _is_memmap
         if device is not None:
@@ -2768,9 +2745,9 @@ class TensorDict(TensorDictBase):
 
         if not _run_checks:
             if isinstance(source, dict):
-                self._tensordict: Dict = copy(source)
+                self._tensordict: dict = copy(source)
             else:
-                self._tensordict: Dict = dict(source)
+                self._tensordict: dict = dict(source)
             self._batch_size = torch.Size(batch_size)
             upd_dict = {}
             for key, value in self._tensordict.items():
@@ -2826,8 +2803,8 @@ class TensorDict(TensorDictBase):
 
     @staticmethod
     def _parse_batch_size(
-        source: Union[TensorDictBase, dict],
-        batch_size: Optional[Union[Sequence[int], torch.Size, int]] = None,
+        source: TensorDictBase | dict,
+        batch_size: Sequence[int] | torch.Size | int | None = None,
     ):
         if isinstance(batch_size, (Number, Sequence)):
             if not isinstance(batch_size, torch.Size):
@@ -2854,7 +2831,7 @@ class TensorDict(TensorDictBase):
         )
 
     @property
-    def device(self) -> Union[None, torch.device]:
+    def device(self) -> None | torch.device:
         """Device of the tensordict.
 
         Returns `None` if device hasn't been provided in the constructor or set via `tensordict.to(device)`.
@@ -2987,7 +2964,7 @@ class TensorDict(TensorDictBase):
     def set(
         self,
         key: NESTED_KEY,
-        value: Union[dict, COMPATIBLE_TYPES],
+        value: dict | COMPATIBLE_TYPES,
         inplace: bool = False,
         _run_checks: bool = True,
         _process: bool = True,
@@ -3072,7 +3049,7 @@ class TensorDict(TensorDictBase):
         return self
 
     def set_(
-        self, key: str, value: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
+        self, key: str, value: dict | COMPATIBLE_TYPES, no_check: bool = False
     ) -> TensorDictBase:
         if not no_check:
             _nested_key_type_check(key)
@@ -3105,18 +3082,18 @@ class TensorDict(TensorDictBase):
         return self
 
     def _stack_onto_(
-        self, key: str, list_item: List[COMPATIBLE_TYPES], dim: int
+        self, key: str, list_item: list[COMPATIBLE_TYPES], dim: int
     ) -> TensorDict:
         torch.stack(list_item, dim=dim, out=self.get(key))
         return self
 
-    def entry_class(self, key: Union[str, Tuple]) -> type:
+    def entry_class(self, key: str | tuple) -> type:
         return type(self.get(key))
 
     def _stack_onto_at_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
         idx: INDEX_TYPING,
     ) -> TensorDict:
@@ -3135,7 +3112,7 @@ class TensorDict(TensorDictBase):
         return self
 
     def set_at_(
-        self, key: NESTED_KEY, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
+        self, key: NESTED_KEY, value: dict | COMPATIBLE_TYPES, idx: INDEX_TYPING
     ) -> TensorDictBase:
         _nested_key_type_check(key)
         is_nested = type(key) is tuple
@@ -3162,7 +3139,7 @@ class TensorDict(TensorDictBase):
         return self
 
     def get(
-        self, key: str, default: Union[str, COMPATIBLE_TYPES] = "_no_default_"
+        self, key: str, default: str | COMPATIBLE_TYPES = "_no_default_"
     ) -> COMPATIBLE_TYPES:
         _nested_key_type_check(key)
 
@@ -3322,9 +3299,7 @@ class TensorDict(TensorDictBase):
 
         return out
 
-    def to(
-        self, dest: Union[DEVICE_TYPING, torch.Size, Type], **kwargs
-    ) -> TensorDictBase:
+    def to(self, dest: DEVICE_TYPING | torch.Size | type, **kwargs) -> TensorDictBase:
         if isinstance(dest, type) and issubclass(dest, TensorDictBase):
             if isinstance(self, dest):
                 return self
@@ -3351,15 +3326,13 @@ class TensorDict(TensorDictBase):
                 f"instance, {dest} not allowed"
             )
 
-    def masked_fill_(
-        self, mask: Tensor, value: Union[float, int, bool]
-    ) -> TensorDictBase:
+    def masked_fill_(self, mask: Tensor, value: float | int | bool) -> TensorDictBase:
         for item in self.values():
             mask_expand = expand_as_right(mask, item)
             item.masked_fill_(mask_expand, value)
         return self
 
-    def masked_fill(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         td_copy = self.clone()
         return td_copy.masked_fill_(mask, value)
 
@@ -3436,7 +3409,7 @@ class _ErrorInteceptor:
     DEFAULT_EXC_MSG = "Expected all tensors to be on the same device"
 
     def __init__(
-        self, key, prefix, exc_msg: str = None, exc_type: Type[Exception] = None
+        self, key, prefix, exc_msg: str = None, exc_type: type[Exception] = None
     ):
         self.exc_type = exc_type if exc_type is not None else RuntimeError
         self.exc_msg = exc_msg if exc_msg is not None else self.DEFAULT_EXC_MSG
@@ -3458,7 +3431,7 @@ class _ErrorInteceptor:
             exc_value.args = (self._add_key_to_error_msg(str(exc_value)),)
 
 
-def _nested_keys_to_dict(keys: Iterator[NESTED_KEY]) -> Dict[str, Any]:
+def _nested_keys_to_dict(keys: Iterator[NESTED_KEY]) -> dict[str, Any]:
     nested_keys = {}
     for key in keys:
         if type(key) is str:
@@ -3555,7 +3528,7 @@ def assert_allclose_td(
 
 
 @implements_for_td(torch.unbind)
-def _unbind(td: TensorDictBase, *args, **kwargs) -> Tuple[TensorDictBase, ...]:
+def _unbind(td: TensorDictBase, *args, **kwargs) -> tuple[TensorDictBase, ...]:
     return td.unbind(*args, **kwargs)
 
 
@@ -3566,7 +3539,7 @@ def _gather(
     index: Tensor,
     *,
     sparse_grad: bool = False,
-    out: Optional[TensorDictBase] = None,
+    out: TensorDictBase | None = None,
 ):
     if sparse_grad:
         raise NotImplementedError(
@@ -3918,7 +3891,7 @@ def pad_sequence_td(
     batch_first: bool = True,
     padding_value: float = 0.0,
     out: TensorDictBase = None,
-    device: Optional[DEVICE_TYPING] = None,
+    device: DEVICE_TYPING | None = None,
 ):
     if not list_of_tensordicts:
         raise RuntimeError("list_of_tensordicts cannot be empty")
@@ -3950,7 +3923,7 @@ def pad_sequence_td(
 
 
 @implements_for_td(torch.split)
-def _split(td: TensorDict, split_size_or_sections: Union[int, List[int]], dim: int = 0):
+def _split(td: TensorDict, split_size_or_sections: int | list[int], dim: int = 0):
     return td.split(split_size_or_sections, dim)
 
 
@@ -4012,9 +3985,8 @@ torch.Size([3, 2])
         self,
         source: TensorDictBase,
         idx: INDEX_TYPING,
-        batch_size: Optional[Sequence[int]] = None,
+        batch_size: Sequence[int] | None = None,
     ):
-
         if not isinstance(source, TensorDictBase):
             raise TypeError(
                 f"Expected source to be a subclass of TensorDictBase, "
@@ -4051,7 +4023,7 @@ torch.Size([3, 2])
         return self._batch_size_setter(new_size)
 
     @property
-    def device(self) -> Union[None, torch.device]:
+    def device(self) -> None | torch.device:
         return self._source.device
 
     @device.setter
@@ -4064,7 +4036,7 @@ torch.Size([3, 2])
     def set(
         self,
         key: NESTED_KEY,
-        tensor: Union[dict, COMPATIBLE_TYPES],
+        tensor: dict | COMPATIBLE_TYPES,
         inplace: bool = False,
         _run_checks: bool = True,
     ) -> TensorDictBase:
@@ -4126,7 +4098,7 @@ torch.Size([3, 2])
     def set_(
         self,
         key: NESTED_KEY,
-        tensor: Union[dict, COMPATIBLE_TYPES],
+        tensor: dict | COMPATIBLE_TYPES,
         no_check: bool = False,
     ) -> SubTensorDict:
         is_nested = type(key) is tuple
@@ -4149,21 +4121,19 @@ torch.Size([3, 2])
 
         return self
 
-    def entry_class(self, key: Union[str, Tuple]) -> type:
+    def entry_class(self, key: str | tuple) -> type:
         source_type = type(self._source.get(key))
         if is_tensordict(source_type):
             return self.__class__
         return source_type
 
     def _stack_onto_(
-        self, key: str, list_item: List[COMPATIBLE_TYPES], dim: int
+        self, key: str, list_item: list[COMPATIBLE_TYPES], dim: int
     ) -> TensorDict:
         self._source._stack_onto_at_(key, list_item, dim=dim, idx=self.idx)
         return self
 
-    def to(
-        self, dest: Union[DEVICE_TYPING, torch.Size, Type], **kwargs
-    ) -> TensorDictBase:
+    def to(self, dest: DEVICE_TYPING | torch.Size | type, **kwargs) -> TensorDictBase:
         if isinstance(dest, type) and issubclass(dest, TensorDictBase):
             if isinstance(self, dest):
                 return self
@@ -4198,14 +4168,14 @@ torch.Size([3, 2])
     def get(
         self,
         key: NESTED_KEY,
-        default: Optional[Union[Tensor, str]] = "_no_default_",
+        default: Tensor | str | None = "_no_default_",
     ) -> COMPATIBLE_TYPES:
         return self._source.get_at(key, self.idx, default=default)
 
     def set_at_(
         self,
         key: NESTED_KEY,
-        value: Union[dict, COMPATIBLE_TYPES],
+        value: dict | COMPATIBLE_TYPES,
         idx: INDEX_TYPING,
         discard_idx_attr: bool = False,
     ) -> SubTensorDict:
@@ -4228,7 +4198,7 @@ torch.Size([3, 2])
         key: str,
         idx: INDEX_TYPING,
         discard_idx_attr: bool = False,
-        default: Optional[Union[Tensor, str]] = "_no_default_",
+        default: Tensor | str | None = "_no_default_",
     ) -> COMPATIBLE_TYPES:
         if not isinstance(idx, tuple):
             idx = (idx,)
@@ -4242,7 +4212,7 @@ torch.Size([3, 2])
 
     def update(
         self,
-        input_dict_or_td: Union[dict, TensorDictBase],
+        input_dict_or_td: dict | TensorDictBase,
         clone: bool = False,
         inplace: bool = False,
         **kwargs,
@@ -4282,7 +4252,7 @@ torch.Size([3, 2])
 
     def update_(
         self,
-        input_dict: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
+        input_dict: dict[str, COMPATIBLE_TYPES] | TensorDictBase,
         clone: bool = False,
     ) -> SubTensorDict:
         return self.update_at_(
@@ -4291,7 +4261,7 @@ torch.Size([3, 2])
 
     def update_at_(
         self,
-        input_dict: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
+        input_dict: dict[str, COMPATIBLE_TYPES] | TensorDictBase,
         idx: INDEX_TYPING,
         discard_idx_attr: bool = False,
         clone: bool = False,
@@ -4429,12 +4399,12 @@ torch.Size([3, 2])
     def detach_(self) -> TensorDictBase:
         raise RuntimeError("Detaching a sub-tensordict in-place cannot be done.")
 
-    def masked_fill_(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill_(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         for key, item in self.items():
             self.set_(key, torch.full_like(item, value))
         return self
 
-    def masked_fill(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         td_copy = self.clone()
         return td_copy.masked_fill_(mask, value)
 
@@ -4509,9 +4479,8 @@ class LazyStackedTensorDict(TensorDictBase):
         self,
         *tensordicts: TensorDictBase,
         stack_dim: int = 0,
-        batch_size: Optional[Sequence[int]] = None,  # TODO: remove
+        batch_size: Sequence[int] | None = None,  # TODO: remove
     ):
-
         self._is_shared = False
         self._is_memmap = False
 
@@ -4550,7 +4519,7 @@ class LazyStackedTensorDict(TensorDictBase):
                     f"cannot be created. Got td[0].batch_size={_batch_size} "
                     f"and td[i].batch_size={_bs} "
                 )
-        self.tensordicts: List[TensorDictBase] = list(tensordicts)
+        self.tensordicts: list[TensorDictBase] = list(tensordicts)
         self.stack_dim = stack_dim
         self._batch_size = self._compute_batch_size(_batch_size, stack_dim, N)
         self._update_valid_keys()
@@ -4558,7 +4527,7 @@ class LazyStackedTensorDict(TensorDictBase):
             raise RuntimeError("batch_size does not match self.batch_size.")
 
     @property
-    def device(self) -> Union[None, torch.device]:
+    def device(self) -> None | torch.device:
         # devices might have changed, so we check that they're all the same
         device_set = {td.device for td in self.tensordicts}
         if len(device_set) != 1:
@@ -4604,7 +4573,7 @@ class LazyStackedTensorDict(TensorDictBase):
             )
         return all(are_memmap)
 
-    def get_valid_keys(self) -> Set[str]:
+    def get_valid_keys(self) -> set[str]:
         if self._valid_keys is None:
             self._update_valid_keys()
         return self._valid_keys
@@ -4627,9 +4596,8 @@ class LazyStackedTensorDict(TensorDictBase):
         return torch.Size(s)
 
     def set(
-        self, key: NESTED_KEY, tensor: Union[dict, COMPATIBLE_TYPES], **kwargs
+        self, key: NESTED_KEY, tensor: dict | COMPATIBLE_TYPES, **kwargs
     ) -> TensorDictBase:
-
         if self.is_locked:
             raise RuntimeError(
                 "Cannot modify locked TensorDict. For in-place modification, consider using the `set_()` method."
@@ -4657,7 +4625,7 @@ class LazyStackedTensorDict(TensorDictBase):
         return self
 
     def set_(
-        self, key: str, tensor: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
+        self, key: str, tensor: dict | COMPATIBLE_TYPES, no_check: bool = False
     ) -> TensorDictBase:
         if not no_check:
             tensor = self._process_input(
@@ -4686,7 +4654,7 @@ class LazyStackedTensorDict(TensorDictBase):
             td.set_(key, _item)
         return self
 
-    def unbind(self, dim: int) -> Tuple[TensorDictBase, ...]:
+    def unbind(self, dim: int) -> tuple[TensorDictBase, ...]:
         if dim < 0:
             dim = self.batch_dims + dim
         if dim == self.stack_dim:
@@ -4695,7 +4663,7 @@ class LazyStackedTensorDict(TensorDictBase):
             return super().unbind(dim)
 
     def set_at_(
-        self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
+        self, key: str, value: dict | COMPATIBLE_TYPES, idx: INDEX_TYPING
     ) -> TensorDictBase:
         sub_td = self[idx]
         sub_td.set_(key, value)
@@ -4704,7 +4672,7 @@ class LazyStackedTensorDict(TensorDictBase):
     def _stack_onto_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
     ) -> TensorDictBase:
         if dim == self.stack_dim:
@@ -4718,7 +4686,7 @@ class LazyStackedTensorDict(TensorDictBase):
     def get(
         self,
         key: NESTED_KEY,
-        default: Union[str, COMPATIBLE_TYPES] = "_no_default_",
+        default: str | COMPATIBLE_TYPES = "_no_default_",
     ) -> COMPATIBLE_TYPES:
         # TODO: the stacking logic below works for nested keys, but the key in
         # self.valid_keys check will fail and we'll return the default instead.
@@ -4761,7 +4729,7 @@ class LazyStackedTensorDict(TensorDictBase):
     def get_nestedtensor(
         self,
         key: NESTED_KEY,
-        default: Union[str, COMPATIBLE_TYPES] = "_no_default_",
+        default: str | COMPATIBLE_TYPES = "_no_default_",
     ) -> COMPATIBLE_TYPES:
         # disallow getting nested tensor if the stacking dimension is not 0
         if self.stack_dim != 0:
@@ -4828,7 +4796,7 @@ class LazyStackedTensorDict(TensorDictBase):
             td.pin_memory()
         return self
 
-    def to(self, dest: Union[DEVICE_TYPING, Type], **kwargs) -> TensorDictBase:
+    def to(self, dest: DEVICE_TYPING | type, **kwargs) -> TensorDictBase:
         if isinstance(dest, type) and issubclass(dest, TensorDictBase):
             if isinstance(self, dest):
                 return self
@@ -4879,7 +4847,7 @@ class LazyStackedTensorDict(TensorDictBase):
             valid_keys = valid_keys.intersection(td.keys())
         self._valid_keys = sorted(valid_keys)
 
-    def entry_class(self, key: Union[str, Tuple]) -> type:
+    def entry_class(self, key: str | tuple) -> type:
         data_type = type(self.tensordicts[0].get(key))
         if is_tensordict(data_type):
             return LazyStackedTensorDict
@@ -5163,7 +5131,7 @@ class LazyStackedTensorDict(TensorDictBase):
 
     def update_(
         self,
-        input_dict_or_td: Union[Dict[str, COMPATIBLE_TYPES], TensorDictBase],
+        input_dict_or_td: dict[str, COMPATIBLE_TYPES] | TensorDictBase,
         clone: bool = False,
         **kwargs,
     ) -> TensorDictBase:
@@ -5204,13 +5172,13 @@ class LazyStackedTensorDict(TensorDictBase):
         )
         return self
 
-    def masked_fill_(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill_(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         mask_unbind = mask.unbind(dim=self.stack_dim)
         for _mask, td in zip(mask_unbind, self.tensordicts):
             td.masked_fill_(_mask, value)
         return self
 
-    def masked_fill(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         td_copy = self.clone()
         return td_copy.masked_fill_(mask, value)
 
@@ -5308,12 +5276,11 @@ class _CustomOpTensorDict(TensorDictBase):
         self,
         source: TensorDictBase,
         custom_op: str,
-        inv_op: Optional[str] = None,
-        custom_op_kwargs: Optional[dict] = None,
-        inv_op_kwargs: Optional[dict] = None,
-        batch_size: Optional[Sequence[int]] = None,
+        inv_op: str | None = None,
+        custom_op_kwargs: dict | None = None,
+        inv_op_kwargs: dict | None = None,
+        batch_size: Sequence[int] | None = None,
     ):
-
         self._is_shared = source.is_shared()
         self._is_memmap = source.is_memmap()
 
@@ -5331,7 +5298,7 @@ class _CustomOpTensorDict(TensorDictBase):
         if batch_size is not None and batch_size != self.batch_size:
             raise RuntimeError("batch_size does not match self.batch_size.")
 
-    def _update_custom_op_kwargs(self, source_tensor) -> Dict[str, Any]:
+    def _update_custom_op_kwargs(self, source_tensor) -> dict[str, Any]:
         """Allows for a transformation to be customized for a certain shape, device or dtype.
 
         By default, this is a no-op on self.custom_op_kwargs
@@ -5346,7 +5313,7 @@ class _CustomOpTensorDict(TensorDictBase):
         """
         return self.custom_op_kwargs
 
-    def _update_inv_op_kwargs(self, source_tensor: Tensor) -> Dict[str, Any]:
+    def _update_inv_op_kwargs(self, source_tensor: Tensor) -> dict[str, Any]:
         """Allows for an inverse transformation to be customized for a certain shape, device or dtype.
 
         By default, this is a no-op on self.inv_op_kwargs
@@ -5361,11 +5328,11 @@ class _CustomOpTensorDict(TensorDictBase):
         """
         return self.inv_op_kwargs
 
-    def entry_class(self, key: Union[str, Tuple]) -> type:
+    def entry_class(self, key: str | tuple) -> type:
         return type(self._source.get(key))
 
     @property
-    def device(self) -> Union[None, torch.device]:
+    def device(self) -> None | torch.device:
         return self._source.device
 
     @device.setter
@@ -5394,7 +5361,7 @@ class _CustomOpTensorDict(TensorDictBase):
     def get(
         self,
         key: NESTED_KEY,
-        default: Union[str, COMPATIBLE_TYPES] = "_no_default_",
+        default: str | COMPATIBLE_TYPES = "_no_default_",
         _return_original_tensor: bool = False,
     ) -> COMPATIBLE_TYPES:
         # TODO: temporary hack while SavedTensorDict and LazyStackedTensorDict don't
@@ -5420,9 +5387,7 @@ class _CustomOpTensorDict(TensorDictBase):
                 )
             return self._default_get(key, default)
 
-    def set(
-        self, key: str, value: Union[dict, COMPATIBLE_TYPES], **kwargs
-    ) -> TensorDictBase:
+    def set(self, key: str, value: dict | COMPATIBLE_TYPES, **kwargs) -> TensorDictBase:
         if self.inv_op is None:
             raise Exception(
                 f"{self.__class__.__name__} does not support setting values. "
@@ -5444,7 +5409,7 @@ class _CustomOpTensorDict(TensorDictBase):
         return self
 
     def set_(
-        self, key: str, value: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
+        self, key: str, value: dict | COMPATIBLE_TYPES, no_check: bool = False
     ) -> _CustomOpTensorDict:
         if not no_check:
             if self.inv_op is None:
@@ -5463,7 +5428,7 @@ class _CustomOpTensorDict(TensorDictBase):
         return self
 
     def set_at_(
-        self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
+        self, key: str, value: dict | COMPATIBLE_TYPES, idx: INDEX_TYPING
     ) -> _CustomOpTensorDict:
         transformed_tensor, original_tensor = self.get(
             key, _return_original_tensor=True
@@ -5485,7 +5450,7 @@ class _CustomOpTensorDict(TensorDictBase):
     def _stack_onto_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
     ) -> TensorDictBase:
         raise RuntimeError(
@@ -5558,7 +5523,7 @@ class _CustomOpTensorDict(TensorDictBase):
         self._source = self._source.del_(key)
         return self
 
-    def to(self, dest: Union[DEVICE_TYPING, Type], **kwargs) -> TensorDictBase:
+    def to(self, dest: DEVICE_TYPING | type, **kwargs) -> TensorDictBase:
         if isinstance(dest, type) and issubclass(dest, TensorDictBase):
             if isinstance(self, dest):
                 return self
@@ -5583,7 +5548,7 @@ class _CustomOpTensorDict(TensorDictBase):
     def detach_(self):
         self._source.detach_()
 
-    def masked_fill_(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill_(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         for key, item in self.items():
             val = self._source.get(key)
             mask_exp = expand_right(
@@ -5596,7 +5561,7 @@ class _CustomOpTensorDict(TensorDictBase):
             self._source.set(key, val)
         return self
 
-    def masked_fill(self, mask: Tensor, value: Union[float, bool]) -> TensorDictBase:
+    def masked_fill(self, mask: Tensor, value: float | bool) -> TensorDictBase:
         td_copy = self.clone()
         return td_copy.masked_fill_(mask, value)
 
@@ -5654,7 +5619,7 @@ class _UnsqueezedTensorDict(_CustomOpTensorDict):
         True
     """
 
-    def squeeze(self, dim: Optional[int]) -> TensorDictBase:
+    def squeeze(self, dim: int | None) -> TensorDictBase:
         if dim is not None and dim < 0:
             dim = self.batch_dims + dim
         if dim == self.custom_op_kwargs.get("dim"):
@@ -5664,7 +5629,7 @@ class _UnsqueezedTensorDict(_CustomOpTensorDict):
     def _stack_onto_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
     ) -> TensorDictBase:
         unsqueezed_dim = self.custom_op_kwargs["dim"]
@@ -5695,7 +5660,7 @@ class _SqueezedTensorDict(_CustomOpTensorDict):
     def _stack_onto_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
     ) -> TensorDictBase:
         squeezed_dim = self.custom_op_kwargs["dim"]
@@ -5710,7 +5675,7 @@ class _SqueezedTensorDict(_CustomOpTensorDict):
 
 
 class _ViewedTensorDict(_CustomOpTensorDict):
-    def _update_custom_op_kwargs(self, source_tensor) -> Dict[str, Any]:
+    def _update_custom_op_kwargs(self, source_tensor) -> dict[str, Any]:
         new_dim_list = list(self.custom_op_kwargs.get("size"))
         new_dim_list += list(source_tensor.shape[self._source.batch_dims :])
         new_dim = torch.Size(new_dim_list)
@@ -5718,7 +5683,7 @@ class _ViewedTensorDict(_CustomOpTensorDict):
         new_dict.update({"size": new_dim})
         return new_dict
 
-    def _update_inv_op_kwargs(self, tensor: Tensor) -> Dict:
+    def _update_inv_op_kwargs(self, tensor: Tensor) -> dict:
         size = list(self.inv_op_kwargs.get("size"))
         size += list(_shape(tensor)[self.batch_dims :])
         new_dim = torch.Size(size)
@@ -5727,7 +5692,7 @@ class _ViewedTensorDict(_CustomOpTensorDict):
         return new_dict
 
     def view(
-        self, *shape, size: Optional[Union[List, Tuple, torch.Size]] = None
+        self, *shape, size: list | tuple | torch.Size | None = None
     ) -> TensorDictBase:
         if len(shape) == 0 and size is not None:
             return self.view(*size)
@@ -5783,7 +5748,7 @@ class _PermutedTensorDict(_CustomOpTensorDict):
             return self._source
         return super().permute(*dims_list)
 
-    def add_missing_dims(self, num_dims: int, batch_dims: Tuple[int]) -> Tuple[int]:
+    def add_missing_dims(self, num_dims: int, batch_dims: tuple[int]) -> tuple[int]:
         dim_diff = num_dims - len(batch_dims)
         all_dims = list(range(num_dims))
         for i, x in enumerate(batch_dims):
@@ -5792,7 +5757,7 @@ class _PermutedTensorDict(_CustomOpTensorDict):
             all_dims[i] = x
         return tuple(all_dims)
 
-    def _update_custom_op_kwargs(self, source_tensor) -> Dict:
+    def _update_custom_op_kwargs(self, source_tensor) -> dict:
         new_dims = self.add_missing_dims(
             len(source_tensor.shape), self.custom_op_kwargs["dims"]
         )
@@ -5800,7 +5765,7 @@ class _PermutedTensorDict(_CustomOpTensorDict):
         kwargs.update({"dims": new_dims})
         return kwargs
 
-    def _update_inv_op_kwargs(self, tensor: Tensor) -> Dict[str, Any]:
+    def _update_inv_op_kwargs(self, tensor: Tensor) -> dict[str, Any]:
         new_dims = self.add_missing_dims(
             self._source.batch_dims + len(_shape(tensor)[self.batch_dims :]),
             self.custom_op_kwargs["dims"],
@@ -5812,10 +5777,9 @@ class _PermutedTensorDict(_CustomOpTensorDict):
     def _stack_onto_(
         self,
         key: str,
-        list_item: List[COMPATIBLE_TYPES],
+        list_item: list[COMPATIBLE_TYPES],
         dim: int,
     ) -> TensorDictBase:
-
         permute_dims = self.custom_op_kwargs["dims"]
         inv_permute_dims = np.argsort(permute_dims)
         new_dim = [i for i, v in enumerate(inv_permute_dims) if v == dim][0]
@@ -5857,8 +5821,8 @@ def _td_fields(td: TensorDictBase) -> str:
 
 def _check_keys(
     list_of_tensordicts: Sequence[TensorDictBase], strict: bool = False
-) -> Set[str]:
-    keys: Set[str] = set()
+) -> set[str]:
+    keys: set[str] = set()
     for td in list_of_tensordicts:
         if not len(keys):
             keys = set(td.keys())
@@ -5906,9 +5870,9 @@ def _expand_to_match_shape(parent_batch_size, tensor, self_batch_dims, self_devi
 
 
 def make_tensordict(
-    input_dict: Optional[dict] = None,
-    batch_size: Optional[Union[Sequence[int], torch.Size, int]] = None,
-    device: Optional[DEVICE_TYPING] = None,
+    input_dict: dict | None = None,
+    batch_size: Sequence[int] | torch.Size | int | None = None,
+    device: DEVICE_TYPING | None = None,
     **kwargs,  # source
 ) -> TensorDict:
     """Returns a TensorDict created from the keyword arguments.
@@ -5936,7 +5900,7 @@ def make_tensordict(
     )  # _run_checks=False)
 
 
-def _find_max_batch_size(source: Union[TensorDictBase, dict]) -> list[int]:
+def _find_max_batch_size(source: TensorDictBase | dict) -> list[int]:
     tensor_data = list(source.values())
     batch_size = []
     if not tensor_data:  # when source is empty

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -201,7 +201,7 @@ class _TensorDictKeysView:
         return key
 
     def __len__(self) -> int:
-        return sum((1 for _ in self), start=0)
+        return sum(1 for _ in self)
 
     def _items(
         self, tensordict: TensorDict | None = None

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -652,7 +652,7 @@ def _get_item(tensor: torch.Tensor, index: IndexType) -> torch.Tensor:
 
 
 def _set_item(
-    tensor: torch.Tensor, value: torch.Tensor, index: IndexType
+    tensor: torch.Tensor, index: IndexType, value: torch.Tensor
 ) -> torch.Tensor:
     if isinstance(tensor, torch.Tensor):
         tensor[index] = value

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -11,7 +11,7 @@ import time
 import typing
 from functools import wraps
 from numbers import Number
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -180,7 +180,7 @@ def _getitem_batch_size(shape: torch.Size, items: INDEX_TYPING) -> torch.Size:
     return torch.Size(bs)
 
 
-def convert_ellipsis_to_idx(idx: Union[Tuple, Ellipsis], batch_size: List[int]):
+def convert_ellipsis_to_idx(idx: tuple | Ellipsis, batch_size: list[int]):
     """Given an index containing an ellipsis or just an ellipsis, converts any ellipsis to slice(None).
 
     Example:
@@ -235,14 +235,14 @@ def convert_ellipsis_to_idx(idx: Union[Tuple, Ellipsis], batch_size: List[int]):
     return new_index
 
 
-def _copy(self: List[int]):
-    out: List[int] = []
+def _copy(self: list[int]):
+    out: list[int] = []
     for elem in self:
         out.append(elem)
     return out
 
 
-def infer_size_impl(shape: List[int], numel: int) -> List[int]:
+def infer_size_impl(shape: list[int], numel: int) -> list[int]:
     """Infers the shape of an expanded tensor whose number of elements is indicated by :obj:`numel`.
 
     Copied from pytorch for compatibility issues (See #386).
@@ -251,7 +251,7 @@ def infer_size_impl(shape: List[int], numel: int) -> List[int]:
 
     """
     newsize = 1
-    infer_dim: Optional[int] = None
+    infer_dim: int | None = None
     for dim in range(len(shape)):
         if shape[dim] == -1:
             if infer_dim is not None:
@@ -308,8 +308,8 @@ else:
 
 
 def expand_as_right(
-    tensor: Union[torch.Tensor, "MemmapTensor", "TensorDictBase"],  # noqa: F821
-    dest: Union[torch.Tensor, "MemmapTensor", "TensorDictBase"],  # noqa: F821
+    tensor: torch.Tensor | MemmapTensor | TensorDictBase,  # noqa: F821
+    dest: torch.Tensor | MemmapTensor | TensorDictBase,  # noqa: F821
 ):
     """Expand a tensor on the right to match another tensor shape.
 
@@ -345,7 +345,7 @@ def expand_as_right(
 
 
 def expand_right(
-    tensor: Union[torch.Tensor, "MemmapTensor"], shape: Sequence[int]  # noqa: F821
+    tensor: torch.Tensor | MemmapTensor, shape: Sequence[int]  # noqa: F821
 ) -> torch.Tensor:
     """Expand a tensor on the right to match a desired shape.
 
@@ -407,8 +407,8 @@ def _normalize_key(key: NESTED_KEY) -> NESTED_KEY:
 
 
 def index_keyedjaggedtensor(
-    kjt: "torchrec.KeyedJaggedTensor",  # noqa
-    index: Union[slice, range, list, torch.Tensor, np.ndarray],  # noqa
+    kjt: torchrec.KeyedJaggedTensor,  # noqa
+    index: slice | range | list | torch.Tensor | np.ndarray,  # noqa
 ):
     """Indexes a KeyedJaggedTensor along the batch dimension.
 
@@ -468,9 +468,9 @@ def index_keyedjaggedtensor(
 
 
 def setitem_keyedjaggedtensor(
-    orig_tensor: "torchrec.KeyedJaggedTensor",  # noqa
-    index: Union[slice, range, list, torch.Tensor, np.ndarray],
-    other: "torchrec.KeyedJaggedTensor",  # noqa
+    orig_tensor: torchrec.KeyedJaggedTensor,  # noqa
+    index: slice | range | list | torch.Tensor | np.ndarray,
+    other: torchrec.KeyedJaggedTensor,  # noqa
 ):
     """Equivalent of `tensor[index] = other` for KeyedJaggedTensors indexed along the batch dimension.
 

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import math
 
 import time
-import typing
 from functools import wraps
 from numbers import Number
 from typing import Any, List, Tuple, Union
@@ -38,17 +37,12 @@ except ImportError as err:
 
     TORCHREC_ERR = str(err)
 
-INDEX_TYPING = Union[None, int, slice, str, Tensor, List[Any], Tuple[Any, ...]]
-DEVICE_TYPING = Union[torch.device, str, int]
-if hasattr(typing, "get_args"):
-    DEVICE_TYPING_ARGS = typing.get_args(DEVICE_TYPING)
-else:
-    DEVICE_TYPING_ARGS = (torch.device, str, int)
-
-NESTED_KEY = Union[str, Tuple[str, ...]]
+IndexType = Union[None, int, slice, str, Tensor, List[Any], Tuple[Any, ...]]
+DeviceType = Union[torch.device, str, int]
+NestedKey = Union[str, Tuple[str, ...]]
 
 
-def _sub_index(tensor: torch.Tensor, idx: INDEX_TYPING) -> torch.Tensor:
+def _sub_index(tensor: torch.Tensor, idx: IndexType) -> torch.Tensor:
     """Allows indexing of tensors with nested tuples.
 
      >>> sub_tensor1 = tensor[tuple1][tuple2]
@@ -67,7 +61,7 @@ def _sub_index(tensor: torch.Tensor, idx: INDEX_TYPING) -> torch.Tensor:
     return tensor[idx]
 
 
-def _getitem_batch_size(shape: torch.Size, items: INDEX_TYPING) -> torch.Size:
+def _getitem_batch_size(shape: torch.Size, items: IndexType) -> torch.Size:
     """Given an input shape and an index, returns the size of the resulting indexed tensor.
 
     This function is aimed to be used when indexing is an
@@ -370,7 +364,7 @@ def expand_right(
     return tensor_expand
 
 
-numpy_to_torch_dtype_dict = {
+NUMPY_TO_TORCH_DTYPE_DICT = {
     np.dtype("bool"): torch.bool,
     np.dtype("uint8"): torch.uint8,
     np.dtype("int8"): torch.int8,
@@ -383,8 +377,8 @@ numpy_to_torch_dtype_dict = {
     np.dtype("complex64"): torch.complex64,
     np.dtype("complex128"): torch.complex128,
 }
-torch_to_numpy_dtype_dict = {
-    value: key for key, value in numpy_to_torch_dtype_dict.items()
+TORCH_TO_NUMPY_DTYPE_DICT = {
+    value: key for key, value in NUMPY_TO_TORCH_DTYPE_DICT.items()
 }
 
 
@@ -401,7 +395,7 @@ def _nested_key_type_check(key):
                 raise TypeError(msg.format(type(subkey)))
 
 
-def _normalize_key(key: NESTED_KEY) -> NESTED_KEY:
+def _normalize_key(key: NestedKey) -> NestedKey:
     # normalises tuples of length one to their string contents
     return key if not isinstance(key, tuple) or len(key) > 1 else key[0]
 

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -5,7 +5,8 @@
 import math
 
 import numpy as np
-import torch.cuda
+import torch
+
 from tensordict import TensorDict
 from tensordict.tensordict import _stack as stack_td
 

--- a/test/test_functorch.py
+++ b/test/test_functorch.py
@@ -8,6 +8,7 @@ import argparse
 import pytest
 import torch
 from _utils_internal import expand_list
+
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from tensordict.nn.functional_modules import make_functional, repopulate_module

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3,6 +3,7 @@ import argparse
 import pytest
 import torch
 import torch.nn as nn
+
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule, TensorDictSequential
 from tensordict.prototype.fx import symbolic_trace

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 from _utils_internal import get_available_devices
+
 from tensordict import MemmapTensor
 from torch import multiprocessing as mp
 

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -12,7 +12,6 @@ from typing import Any, Optional, Union
 import pytest
 import torch
 import torchsnapshot
-
 from _utils_internal import get_available_devices
 
 from tensordict import LazyStackedTensorDict, MemmapTensor, TensorDict

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 import torchsnapshot
 from _utils_internal import get_available_devices, prod, TestTensorDictsBase
+
 from tensordict import LazyStackedTensorDict, MemmapTensor, TensorDict
 from tensordict.tensordict import (
     _stack as stack_td,
@@ -1887,7 +1888,6 @@ class TestTensorDicts(TestTensorDictsBase):
         assert (inserted == expected).all()
 
     def test_setdefault_nested(self, td_name, device):
-
         td = getattr(self, td_name)(device)
         td.unlock()
 
@@ -1928,7 +1928,6 @@ class TestTensorDicts(TestTensorDictsBase):
             # split_sizes to be [2, 2, ..., 2, 1] or [2, 2, ..., 2]
             split_sizes = [2] * rep + [1] * remainder
             for test_split_size in (2, split_sizes):
-
                 if performer == "torch":
                     tds = torch.split(td, test_split_size, dim)
                 elif performer == "tensordict":

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -7,6 +7,7 @@ import argparse
 
 import pytest
 import torch
+
 from tensordict import TensorDict
 from tensordict.nn import (
     probabilistic as nn_probabilistic,

--- a/test/test_torchrec.py
+++ b/test/test_torchrec.py
@@ -8,6 +8,7 @@ import re
 
 import pytest
 import torch
+
 from tensordict import TensorDict
 from tensordict.utils import index_keyedjaggedtensor, setitem_keyedjaggedtensor
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,6 +8,7 @@ import argparse
 import numpy as np
 import pytest
 import torch
+
 from tensordict.utils import _getitem_batch_size
 
 

--- a/tutorials/sphinx_tuto/data_fashion.py
+++ b/tutorials/sphinx_tuto/data_fashion.py
@@ -15,6 +15,7 @@ Using TensorDict for datasets
 
 import torch
 import torch.nn as nn
+
 from tensordict import MemmapTensor, TensorDict
 from torch.utils.data import DataLoader
 from torchvision import datasets

--- a/tutorials/sphinx_tuto/tensorclass_fashion.py
+++ b/tutorials/sphinx_tuto/tensorclass_fashion.py
@@ -16,6 +16,7 @@ Using tensorclasses for datasets
 
 import torch
 import torch.nn as nn
+
 from tensordict import MemmapTensor
 from tensordict.prototype import tensorclass
 from torch.utils.data import DataLoader

--- a/tutorials/sphinx_tuto/tensorclass_imagenet.py
+++ b/tutorials/sphinx_tuto/tensorclass_imagenet.py
@@ -37,6 +37,7 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 import tqdm
+
 from tensordict import MemmapTensor
 from tensordict.prototype import tensorclass
 from torch.utils.data import DataLoader


### PR DESCRIPTION
## Description

Describe your changes in detail.

Add full type annotations and fix some bugs, e.g.:

1. Add missing return statements
2. Remove extra return statements in property setters.
3. Remove extra `metaclass=abc.ABCMeta` when inheriting from `collections.abc.Mapping`
4. Change base class from `Mapping` to `MutableMapping`
5. Remove extra `@classmethod` decoration for `Class.__new__` and use `super().__new__(...)`.

Some enhancement and style fixes:

6. Change relative imports to absolute imports.
7. Use postponed type evaluation when `from __future__ import annotations` enabled.
8. Change `Union[XXX, YYY]` to `XXX | YYY` when `from __future__ import annotations` enabled.
9. CHange constants to `UPPER_CASE` and type alias to `CamelCase`.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [X] I have updated the documentation accordingly.
