### PR TITLE
[BugFix] Return self from `clear_device`

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -390,8 +390,9 @@ class TensorDictBase(MutableMapping):
     def device(self, value: DeviceType) -> None:
         raise NotImplementedError
 
-    def clear_device(self) -> None:
+    def clear_device(self) -> TensorDictBase:
         self._device = None
+        return self
 
     def is_shared(self) -> bool:
         """Checks if tensordict is in shared memory.

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -391,6 +391,11 @@ class TensorDictBase(MutableMapping):
         raise NotImplementedError
 
     def clear_device(self) -> TensorDictBase:
+        """Clears the device of the tensordict.
+        
+        Returns: self
+        
+        """
         self._device = None
         return self
 


### PR DESCRIPTION
## Description

While working on the tutorials I noticed that `clear_device` doesn't return anything, unlike the closely related `to` method.

This small change returns `self`, allowing `clear_device` to be chained with other methods.