### PR TITLE
[Feature] Nesting tensorclass instances in tensordicts

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -18,14 +18,10 @@ from pathlib import Path
 from textwrap import indent
 from typing import Any, Callable, Sequence, TypeVar, Union
 
+import tensordict
+
 import torch
-from tensordict.tensordict import (
-    _ACCEPTED_CLASSES,
-    get_repr,
-    is_tensordict,
-    TensorDict,
-    TensorDictBase,
-)
+from tensordict.tensordict import get_repr, is_tensordict, TensorDict, TensorDictBase
 from tensordict.utils import DeviceType, NestedKey
 from torch import Tensor
 
@@ -181,6 +177,7 @@ def tensorclass(cls: T) -> T:
     cls.__doc__ = f"{cls.__name__}{inspect.signature(cls)}"
 
     CLASSES_DICT[cls.__name__] = cls
+    tensordict.tensordict._ACCEPTED_CLASSES += [cls]
     return cls
 
 
@@ -237,24 +234,26 @@ def _init_wrapper(init: Callable) -> Callable:
 
 
 def _from_tensordict_wrapper(expected_keys):
-    def wrapper(cls, tensordict, non_tensordict=None):
+    def wrapper(cls, td, non_tensordict=None):
         """Tensor class wrapper to instantiate a new tensor class object
 
         Args:
-            tensordict (TensorDict): Dictionary of tensor types
+            td (TensorDict): Dictionary of tensor types
             non_tensordict (dict): Dictionary with non-tensor and nested tensor class objects
 
         """
+        if not isinstance(td, TensorDictBase):
+            raise RuntimeError(f"Expected a TensorDictBase instance but got {type(td)}")
         # Validating keys of tensordict
-        for key in tensordict.keys():
+        for key in td.keys():
             if key not in expected_keys:
                 raise ValueError(
-                    f"Keys from the tensordict ({set(tensordict.keys())}) must "
+                    f"Keys from the tensordict ({set(td.keys())}) must "
                     f"correspond to the class attributes ({expected_keys})."
                 )
 
         # Validating non-tensor keys and for key clash
-        tensor_keys = set(tensordict.keys())
+        tensor_keys = set(td.keys())
         if non_tensordict is not None:
             for key in non_tensordict.keys():
                 if key not in expected_keys:
@@ -270,7 +269,8 @@ def _from_tensordict_wrapper(expected_keys):
         # empty tensordict and writing values to it. we can skip this because we already
         # have a tensordict to use as the underlying tensordict
         tc = cls.__new__(cls)
-        tc.__dict__["_tensordict"] = tensordict
+        assert isinstance(td, TensorDictBase), td
+        tc.__dict__["_tensordict"] = td
 
         tc.__dict__["_non_tensordict"] = (
             non_tensordict if non_tensordict is not None else {}
@@ -322,6 +322,7 @@ def _getattribute_wrapper(getattribute: Callable) -> Callable:
                 "_tensordict" in self.__dict__
                 and item in self.__dict__["_tensordict"].keys()
             ):
+                assert isinstance(self._tensordict, TensorDictBase)
                 out = self._tensordict[item]
                 expected_type = self.__dataclass_fields__[item].type
                 out = _get_typed_output(out, expected_type)
@@ -359,7 +360,7 @@ def _setattr_wrapper(setattr_: Callable, expected_keys: set[str]) -> Callable:
                 f"Cannot set the attribute '{key}', expected attributes are {expected_keys}."
             )
 
-        if isinstance(value, _ACCEPTED_CLASSES):
+        if isinstance(value, tuple(tensordict.tensordict._ACCEPTED_CLASSES)):
             # Avoiding key clash, honoring the user input to assign tensor type data to the key
             if key in self._non_tensordict.keys():
                 del self._non_tensordict[key]
@@ -427,14 +428,11 @@ def _getitem(self, item: NestedKey) -> Any:
     if isinstance(item, str) or (
         isinstance(item, tuple) and all(isinstance(_item, str) for _item in item)
     ):
-        raise ValueError("Invalid indexing arguments.")
+        raise ValueError(f"Invalid indexing arguments: {item}.")
     tensor_res = self._tensordict[item]
     non_tensor_res = {}
     for key, value in self._non_tensordict.items():
-        if is_tensorclass(value):
-            non_tensor_res[key] = _getitem(value, item)
-        else:
-            non_tensor_res[key] = value
+        non_tensor_res[key] = value
 
     return self._from_tensordict(tensor_res, non_tensor_res)  # device=res.device)
 
@@ -461,12 +459,11 @@ def _setitem(self, item: NestedKey, value: Any) -> None:
                 "compatible class (i.e. same members) assignment"
             )
 
-    # Validating the non-tensor data before setting the item
-    for key, val in value._non_tensordict.items():
-        # Setting the item for nested tensor class
-        if key in self._non_tensordict.keys() and is_tensorclass(val):
-            _setitem(self._non_tensordict[key], item, val)
-        else:
+    if isinstance(value, (TensorDictBase, dict)):
+        self._tensordict[item] = value
+    else:
+        # Validating the non-tensor data before setting the item
+        for key, val in value._non_tensordict.items():
             # Raise a warning if non_tensor data doesn't match
             if (
                 key in self._non_tensordict.keys()
@@ -479,13 +476,13 @@ def _setitem(self, item: NestedKey, value: Any) -> None:
                     stacklevel=2,
                 )
 
-    for key in value._tensordict.keys():
-        # Making sure that the key-clashes won't happen, if the key is present in tensor data in value
-        # we will honor that and remove the key-value pair from non-tensor data
-        if key in self._non_tensordict.keys():
-            del self._non_tensordict[key]
+        for key in value._tensordict.keys():
+            # Making sure that the key-clashes won't happen, if the key is present in tensor data in value
+            # we will honor that and remove the key-value pair from non-tensor data
+            if key in self._non_tensordict.keys():
+                del self._non_tensordict[key]
 
-    self._tensordict[item] = value._tensordict
+        self._tensordict[item] = value._tensordict
 
 
 def _repr(self) -> str:
@@ -525,9 +522,6 @@ def _to_tensordict(self) -> TensorDict:
 
     """
     td = self._tensordict.to_tensordict()
-    for key, val in self._non_tensordict.items():
-        if is_tensorclass(val):
-            td[key] = val.to_tensordict()
     return td
 
 
@@ -557,12 +551,6 @@ def _memmap_(self, prefix: str | None = None, copy_existing: bool = False):
     if prefix is not None:
         prefix = Path(prefix)
     self._tensordict.memmap_(prefix=prefix, copy_existing=copy_existing)
-    for key, val in self._non_tensordict.items():
-        if is_tensorclass(val):
-            if prefix is not None:
-                val.memmap_(prefix=prefix / key, copy_existing=copy_existing)
-            else:
-                val.memmap_()
     return self
 
 
@@ -590,13 +578,7 @@ def _memmap_like(
     out_td = self._tensordict.memmap_like(prefix=prefix)
     out_other = {}
     for key, val in self._non_tensordict.items():
-        if is_tensorclass(val):
-            if prefix is not None:
-                out_other[key] = val.memmap_like(prefix=prefix / key)
-            else:
-                out_other[key] = val.memmap_like()
-        else:
-            out_other[key] = val
+        out_other[key] = val
     return self._from_tensordict(out_td, out_other)
 
 
@@ -638,8 +620,7 @@ def _state_dict(self) -> dict[str, Any]:
     """Returns a state_dict dictionary that can be used to save and load data from a tensorclass."""
     state_dict = {"_tensordict": self._tensordict.state_dict()}
     state_dict["_non_tensordict"] = {
-        key: value if not is_tensorclass(value) else value.state_dict()
-        for key, value in self._non_tensordict.items()
+        key: value for key, value in self._non_tensordict.items()
     }
     return state_dict
 
@@ -653,10 +634,8 @@ def _load_state_dict(self, state_dict: dict[str, Any]):
             raise TypeError("Only str keys are allowed when calling load_state_dict.")
         if key == "_non_tensordict":
             for sub_key, sub_item in item.items():
-                if is_tensorclass(self._non_tensordict.get(sub_key, None)):
-                    self._non_tensordict[sub_key].load_state_dict(sub_item)
                 # sub_item is the state dict of a tensorclass
-                elif isinstance(sub_item, dict) and "_non_tensordict" in sub_item:
+                if isinstance(sub_item, dict) and "_non_tensordict" in sub_item:
                     raise RuntimeError(
                         "Loading a saved tensorclass on a uninitialized tensorclass is not allowed"
                     )
@@ -731,21 +710,12 @@ def _any(self, dim: int | None = None) -> bool:
 
     """
     if dim is None:
-        if self._tensordict.any():
-            return True
-        return any(
-            value.any()
-            for value in self._non_tensordict.values()
-            if is_tensorclass(value)
-        )
+        return self._tensordict.any()
 
     if dim < 0:
         dim = self.batch_dims + dim
 
-    non_tensor = {
-        key: None if not is_tensorclass(obj) else obj.any(dim=dim)
-        for key, obj in self._non_tensordict.items()
-    }
+    non_tensor = {key: None for key, obj in self._non_tensordict.items()}
     return self._from_tensordict(
         self._tensordict.any(dim=dim),
         non_tensor,
@@ -799,19 +769,12 @@ def _all(self, dim: int | None = None) -> bool:
 
     """
     if dim is None:
-        return self._tensordict.all() and all(
-            value.all()
-            for value in self._non_tensordict.values()
-            if is_tensorclass(value)
-        )
+        return self._tensordict.all()
 
     if dim < 0:
         dim = self.batch_dims + dim
 
-    non_tensor = {
-        key: None if not is_tensorclass(obj) else obj.all(dim=dim)
-        for key, obj in self._non_tensordict.items()
-    }
+    non_tensor = {key: None for key, obj in self._non_tensordict.items()}
     return self._from_tensordict(
         self._tensordict.all(dim=dim),
         non_tensor,
@@ -855,21 +818,7 @@ def _gather(self, dim: int, index: torch.Tensor, out: TensorDictBase | None = No
         else:
             return out._tensordict
 
-    def _expand_index(obj):
-        index_expand = index
-        while index_expand.ndimension() < obj.ndimension():
-            index_expand = index_expand.unsqueeze(-1)
-        target_shape = list(obj.shape)
-        target_shape[dim] = index_expand.shape[dim]
-        index_expand = index_expand.expand(target_shape)
-        return index_expand
-
-    non_tensor = {
-        key: obj
-        if not is_tensorclass(obj)
-        else obj.gather(dim=dim, index=_expand_index(obj), out=_get_out(key, True))
-        for key, obj in self._non_tensordict.items()
-    }
+    non_tensor = {key: obj for key, obj in self._non_tensordict.items()}
     return self._from_tensordict(
         self._tensordict.gather(dim=dim, index=index, out=_get_out(None, False)),
         non_tensor,
@@ -926,28 +875,13 @@ def __eq__(self, other: object) -> bool:
         >>> assert not (c1 == c2.apply(lambda x: x+1)).all()
 
     """
-    if not is_tensorclass(other) and not isinstance(
-        other, (TensorDictBase, numbers.Number, Tensor)
+    if not is_tensordict(other) and not isinstance(
+        other, (dict, numbers.Number, Tensor)
     ):
         return False
-    non_tensor = {}
-    for key, value in self._non_tensordict.items():
-        if is_tensorclass(value):
-            if is_tensorclass(other):
-                non_tensor[key] = value == other._non_tensordict[key]
-            elif isinstance(other, TensorDictBase):
-                non_tensor[key] = value == other[key]
-                # remove tensorclass keys to make sure that the following tensordict comparison works
-                other = other.exclude(key)
-            else:
-                # attempt a broadcast comparison
-                non_tensor[key] = value == other
-        else:
-            non_tensor[key] = None
+    non_tensor = {key: None for key in self._non_tensordict.keys()}
     if is_tensorclass(other):
         tensor = self._tensordict == other._tensordict
-    elif isinstance(other, TensorDictBase):
-        tensor = self._tensordict == other
     else:
         tensor = self._tensordict == other
     out = self._from_tensordict(tensor, non_tensor)
@@ -1000,86 +934,17 @@ def __ne__(self, other: object) -> bool:
         >>> assert (c1 != c2).all()
 
     """
-    if not is_tensorclass(other) and not isinstance(
-        other, (TensorDictBase, numbers.Number, Tensor)
+    if not is_tensordict(other) and not isinstance(
+        other, (dict, numbers.Number, Tensor)
     ):
         return True
-    non_tensor = {}
-    for key, value in self._non_tensordict.items():
-        if is_tensorclass(value):
-            if is_tensorclass(other):
-                non_tensor[key] = value != other._non_tensordict[key]
-            elif isinstance(other, TensorDictBase):
-                non_tensor[key] = value != other[key]
-                # remove tensorclass keys to make sure that the following tensordict comparison works
-                other = other.exclude(key)
-            else:
-                # attempt a broadcast comparison
-                non_tensor[key] = value == other
-        else:
-            non_tensor[key] = None
+    non_tensor = {key: None for key in self._non_tensordict.keys()}
     if is_tensorclass(other):
         tensor = self._tensordict != other._tensordict
-    elif isinstance(other, TensorDictBase):
-        tensor = self._tensordict != other
     else:
         tensor = self._tensordict != other
     out = self._from_tensordict(tensor, non_tensor)
     return out
-
-
-def _handle_non_tensor_dict(
-    func, non_tensor_dict: dict[str, Any], *args: Any, **kwargs: Any
-) -> dict[str, Any]:
-    """Helper function to handle  non_tensor_dict in a given tensor class especially the nestor tensor objects
-
-    Args:
-        func (callable): Function to apply on nested Tensor classes
-        non_tensor_dict (dict): Dictionary containing non-tensor and nestor tensor class data
-        *args (tuple): Positional arguments to pass to the 'func'
-        **kwargs (dict): Keyword arguments to pass to the 'func'
-
-    Returns:
-        non_tensor_dict (dict): non_tensor_dict after processing
-
-    """
-
-    for key, value in non_tensor_dict.items():
-        if is_tensorclass(value):
-            non_tensor_dict[key] = func(value, *args, **kwargs)
-    return non_tensor_dict
-
-
-def _handle_list_non_tensor_dict(
-    func: Callable, list_of_tdc: list[type], *args: Any, **kwargs: Any
-) -> dict[str, Any]:
-    """Helper function to handle  list of non_tensor_dict in a given tensor class especially the nestor tensor objects
-
-    Args:
-        func (callable): Function to apply on nested Tensor classes
-        list_of_tdc (list): list of tensor class objects
-        *args (tuple): Positional arguments to pass to the 'func'
-        **kwargs (dict): Keyword arguments to pass to the 'func'
-
-    Returns:
-        non_tensor_dict (dict): non_tensor_dict after processing
-
-    """
-    tdc = list_of_tdc[0]
-    non_tensordict = tdc._non_tensordict
-    for key, value in non_tensordict.items():
-        if is_tensorclass(value):
-            list_non_tdc = []
-            for tdc in list_of_tdc:
-                if not isinstance(value, type(tdc._non_tensordict[key])):
-                    raise ValueError(
-                        f"The values assigned for the attribute "
-                        f"{repr(key)} are not matching"
-                    )
-                list_non_tdc.append(tdc._non_tensordict[key])
-            non_tensordict[key] = func(list_non_tdc, *args, **kwargs)
-
-    return non_tensordict
 
 
 def _unbind(tdc, dim: int = 0) -> list:
@@ -1094,7 +959,7 @@ def _unbind(tdc, dim: int = 0) -> list:
 
     """
     tensordicts = torch.unbind(tdc._tensordict, dim)
-    non_tensor_dict = _handle_non_tensor_dict(_unbind, tdc._non_tensordict, dim)
+    non_tensor_dict = tdc._non_tensordict
     out = [tdc._from_tensordict(td, non_tensor_dict) for td in tensordicts]
     return out
 
@@ -1111,9 +976,7 @@ def _full_like(tdc, fill_value: float):
 
     """
     tensordict = torch.full_like(tdc._tensordict, fill_value)
-    non_tensor_dict = _handle_non_tensor_dict(
-        _full_like, tdc._non_tensordict, fill_value
-    )
+    non_tensor_dict = tdc._non_tensordict
     out = tdc._from_tensordict(tensordict, non_tensor_dict)
     return out
 
@@ -1155,7 +1018,7 @@ def _clone(tdc):
 
     """
     tensordict = torch.clone(tdc._tensordict)
-    non_tensor_dict = _handle_non_tensor_dict(_clone, tdc._non_tensordict)
+    non_tensor_dict = tdc._non_tensordict
     out = tdc._from_tensordict(tensordict, non_tensor_dict)
     return out
 
@@ -1171,7 +1034,7 @@ def _squeeze(tdc):
 
     """
     tensordict = torch.squeeze(tdc._tensordict)
-    non_tensor_dict = _handle_non_tensor_dict(_squeeze, tdc._non_tensordict)
+    non_tensor_dict = tdc._non_tensordict
     out = tdc._from_tensordict(tensordict, non_tensor_dict)
     return out
 
@@ -1188,7 +1051,7 @@ def _unsqueeze(tdc, dim: int = 0):
 
     """
     tensordict = torch.unsqueeze(tdc._tensordict, dim)
-    non_tensor_dict = _handle_non_tensor_dict(_unsqueeze, tdc._non_tensordict, dim)
+    non_tensor_dict = tdc._non_tensordict
     out = tdc._from_tensordict(tensordict, non_tensor_dict)
     return out
 
@@ -1205,7 +1068,7 @@ def _permute(tdc, dims: int | Sequence[int]):
 
     """
     tensordict = torch.permute(tdc._tensordict, dims)
-    non_tensor_dict = _handle_non_tensor_dict(_permute, tdc._non_tensordict, dims)
+    non_tensor_dict = tdc._non_tensordict
     out = tdc._from_tensordict(tensordict, non_tensor_dict)
     return out
 
@@ -1227,14 +1090,12 @@ def _split(tdc, split_size_or_sections: int | Sequence[int], dim: int = 0):
 
     """
     tensordicts = torch.split(tdc._tensordict, split_size_or_sections, dim)
-    non_tensor_dict = _handle_non_tensor_dict(
-        _split, tdc._non_tensordict, split_size_or_sections, dim
-    )
+    non_tensor_dict = tdc._non_tensordict
     out = [tdc._from_tensordict(td, non_tensor_dict) for td in tensordicts]
     return out
 
 
-def _stack(list_of_tdc: Sequence, dim: int = 0):
+def _stack(list_of_tdc: Sequence[Any], dim: int = 0, out: Any = None):
     """Stack tensor class objects along a given dimension, the behavior is extended to nested tensor classes. (no impact on non-tensor data)
 
     Args:
@@ -1246,7 +1107,11 @@ def _stack(list_of_tdc: Sequence, dim: int = 0):
 
     """
     tensordict = torch.stack([tdc._tensordict for tdc in list_of_tdc], dim)
-    non_tensordict = _handle_list_non_tensor_dict(_stack, list_of_tdc, dim)
+    non_tensordict = list_of_tdc[0]._non_tensordict
+    if out is not None:
+        out.update_(tensordict)
+        out._non_tensordict.update(non_tensordict)
+        return out
     out = list_of_tdc[0]._from_tensordict(tensordict, non_tensordict)
     return out
 
@@ -1263,7 +1128,7 @@ def _cat(list_of_tdc: Sequence, dim: int = 0):
 
     """
     tensordict = torch.cat([tdc._tensordict for tdc in list_of_tdc], dim)
-    non_tensordict = _handle_list_non_tensor_dict(_cat, list_of_tdc, dim)
+    non_tensordict = list_of_tdc[0]._non_tensordict
     out = list_of_tdc[0]._from_tensordict(tensordict, non_tensordict)
     return out
 
@@ -1273,6 +1138,8 @@ def _get_typed_output(out, expected_type: str | type):
     # Otherwise, if the output is some TensorDictBase subclass, we check the type and if it
     # does not match, we map it. In all other cases, just return what has been gathered.
     if isinstance(expected_type, str) and expected_type in CLASSES_DICT:
+        if isinstance(out, CLASSES_DICT[expected_type]):
+            return out
         out = CLASSES_DICT[expected_type]._from_tensordict(out)
     elif (
         isinstance(expected_type, type)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -29,8 +29,8 @@ from typing import (
 from warnings import warn
 
 import numpy as np
-import torch
 
+import torch
 from tensordict.memmap import memmap_tensor_as_tensor, MemmapTensor
 from tensordict.utils import (
     _device,
@@ -111,11 +111,13 @@ _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-
 
 
 def is_tensordict(datatype: type | Any) -> bool:
+    from tensordict.prototype import is_tensorclass
+
     return (
         issubclass(datatype, TensorDictBase)
         if isinstance(datatype, type)
         else isinstance(datatype, TensorDictBase)
-    )
+    ) or is_tensorclass(datatype)
 
 
 def is_memmap(datatype: type | Any) -> bool:
@@ -180,7 +182,8 @@ class _TensorDictKeysView:
         for key, value in items_iter:
             full_key = self._combine_keys(prefix, key)
             if (
-                isinstance(value, (TensorDictBase, KeyedJaggedTensor))
+                is_tensordict(value)
+                or isinstance(value, (KeyedJaggedTensor,))
                 and self.include_nested
             ):
                 subkeys = tuple(
@@ -190,7 +193,7 @@ class _TensorDictKeysView:
                     )
                 )
                 yield from subkeys
-            if not (isinstance(value, TensorDictBase) and self.leaves_only):
+            if not (is_tensordict(value) and self.leaves_only):
                 yield full_key
 
     def _combine_keys(self, prefix: str | None, key: NestedKey) -> NestedKey:
@@ -206,9 +209,11 @@ class _TensorDictKeysView:
     def _items(
         self, tensordict: TensorDict | None = None
     ) -> Iterable[tuple[NestedKey, CompatibleType]]:
+        from tensordict.prototype import is_tensorclass
+
         if tensordict is None:
             tensordict = self.tensordict
-        if isinstance(tensordict, TensorDict):
+        if isinstance(tensordict, TensorDict) or is_tensorclass(tensordict):
             return tensordict._tensordict.items()
         elif isinstance(tensordict, LazyStackedTensorDict):
             return _iter_items_lazystack(tensordict)
@@ -421,9 +426,7 @@ class TensorDictBase(MutableMapping):
     def state_dict(self) -> OrderedDict[str, Any]:
         out = collections.OrderedDict()
         for key, item in self.apply(memmap_tensor_as_tensor).items():
-            out[key] = (
-                item if not isinstance(item, TensorDictBase) else item.state_dict()
-            )
+            out[key] = item if not is_tensordict(item) else item.state_dict()
         if "__batch_size" in out:
             raise KeyError(
                 "Cannot retrieve the state_dict of a TensorDict with `'__batch_size'` key"
@@ -445,7 +448,11 @@ class TensorDictBase(MutableMapping):
             self.to(device)
         for key, item in state_dict.items():
             if isinstance(item, dict):
-                self.set(key, TensorDict({}, []).load_state_dict(item), inplace=True)
+                self.set(
+                    key,
+                    self.get(key, default=TensorDict({}, [])).load_state_dict(item),
+                    inplace=True,
+                )
             else:
                 self.set(key, item, inplace=True)
         return self
@@ -683,7 +690,7 @@ class TensorDictBase(MutableMapping):
             value = self.get(key)
             if isinstance(value, Tensor):
                 pass
-            elif isinstance(value, TensorDictBase):
+            elif is_tensordict(value):
                 _tag = value._send(dst, _tag=_tag, pseudo_rand=pseudo_rand)
                 continue
             elif isinstance(value, MemmapTensor):
@@ -722,7 +729,7 @@ class TensorDictBase(MutableMapping):
             value = self.get(key)
             if isinstance(value, Tensor):
                 pass
-            elif isinstance(value, TensorDictBase):
+            elif is_tensordict(value):
                 _tag = value._recv(src, _tag=_tag, pseudo_rand=pseudo_rand)
                 continue
             elif isinstance(value, MemmapTensor):
@@ -831,7 +838,7 @@ class TensorDictBase(MutableMapping):
             _futures = []
         for key in self.sorted_keys:
             value = self.get(key)
-            if isinstance(value, TensorDictBase):
+            if is_tensordict(value):
                 _tag = value._isend(
                     dst, _tag=_tag, pseudo_rand=pseudo_rand, _futures=_futures
                 )
@@ -901,7 +908,7 @@ class TensorDictBase(MutableMapping):
 
         for key in self.sorted_keys:
             value = self.get(key)
-            if isinstance(value, TensorDictBase):
+            if is_tensordict(value):
                 _tag, _future_list = value._irecv(
                     src,
                     _tag=_tag,
@@ -1075,7 +1082,7 @@ class TensorDictBase(MutableMapping):
             out.unlock()
         for key, item in self.items():
             _others = [_other[key] for _other in others]
-            if isinstance(item, TensorDictBase):
+            if is_tensordict(item):
                 item_trsf = item.apply(
                     fn,
                     *_others,
@@ -1134,7 +1141,7 @@ class TensorDictBase(MutableMapping):
                     if len(subkey):
                         target.update({subkey: value})
                         continue
-                    elif isinstance(value, (dict, TensorDictBase)):
+                    elif isinstance(value, (dict,)) or is_tensordict(value):
                         target.update(value)
                         continue
             if len(subkey):
@@ -1246,7 +1253,7 @@ class TensorDictBase(MutableMapping):
     ) -> Tensor | MemmapTensor:
         if isinstance(input, dict):
             tensor = self._convert_to_tensordict(input)
-        elif not isinstance(input, _ACCEPTED_CLASSES):
+        elif not isinstance(input, tuple(_ACCEPTED_CLASSES)):
             tensor = self._convert_to_tensor(input)
         else:
             tensor = input
@@ -1258,7 +1265,7 @@ class TensorDictBase(MutableMapping):
         if check_tensor_shape and _shape(tensor)[: self.batch_dims] != self.batch_size:
             # if TensorDict, let's try to map it to the desired shape
             if (
-                isinstance(tensor, TensorDictBase)
+                is_tensordict(tensor)
                 and tensor.batch_size[: self.batch_dims] != self.batch_size
             ):
                 tensor = tensor.clone(recurse=False)
@@ -1390,7 +1397,7 @@ class TensorDictBase(MutableMapping):
 
         if is_tensorclass(other):
             return other != self
-        if isinstance(other, (dict, TensorDictBase)):
+        if isinstance(other, (dict,)) or is_tensordict(other):
             keys1 = set(self.keys())
             keys2 = set(other.keys())
             if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
@@ -1422,7 +1429,7 @@ class TensorDictBase(MutableMapping):
 
         if is_tensorclass(other):
             return other == self
-        if isinstance(other, (dict, TensorDictBase)):
+        if isinstance(other, (dict,)) or is_tensordict(other):
             keys1 = set(self.keys())
             keys2 = set(other.keys())
             if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
@@ -1608,7 +1615,7 @@ class TensorDictBase(MutableMapping):
             )
         tensordict = TensorDict({}, self.batch_size, device=self.device)
         for key, value in self.items():
-            if isinstance(value, TensorDictBase):
+            if is_tensordict(value):
                 if prefix is not None:
                     # ensure subdirectory exists
                     (prefix / key).mkdir(exist_ok=True)
@@ -1676,7 +1683,7 @@ class TensorDictBase(MutableMapping):
         return TensorDict(
             {
                 key: value.clone()
-                if not isinstance(value, TensorDictBase)
+                if not is_tensordict(value)
                 else value.to_tensordict()
                 for key, value in self.items()
             },
@@ -1909,7 +1916,7 @@ class TensorDictBase(MutableMapping):
     def to_dict(self) -> dict[str, Any]:
         """Returns a dictionary with key-value pairs matching those of the tensordict."""
         return {
-            key: value.to_dict() if isinstance(value, TensorDictBase) else value
+            key: value.to_dict() if is_tensordict(value) else value
             for key, value in self.items()
         }
 
@@ -2819,7 +2826,7 @@ class TensorDict(TensorDictBase):
                             _is_memmap=_is_memmap,
                         )
                     elif (
-                        isinstance(value, TensorDictBase)
+                        is_tensordict(value)
                         and value.batch_size[: self.batch_dims] != self.batch_size
                     ):
                         value = value.clone(False)
@@ -2944,12 +2951,10 @@ class TensorDict(TensorDictBase):
         return self_copy
 
     def pin_memory(self) -> TensorDictBase:
-        for key, value in self.items():
-            if isinstance(value, TensorDictBase) or (
-                value.dtype in (torch.half, torch.float, torch.double)
-            ):
-                self.set(key, value.pin_memory(), inplace=False)
-        return self
+        def pin_mem(tensor):
+            return tensor.pin_memory()
+
+        return self.apply(pin_mem)
 
     def expand(self, *shape: int) -> TensorDictBase:
         """Expands every tensor with `(*shape, *tensor.shape)` and returns the same tensordict with new tensors with expanded shapes.
@@ -3158,7 +3163,7 @@ class TensorDict(TensorDictBase):
         _nested_key_type_check(key)
         is_nested = isinstance(key, tuple)
         # do we need this?
-        if not isinstance(value, _ACCEPTED_CLASSES):
+        if not isinstance(value, tuple(_ACCEPTED_CLASSES)):
             value = self._process_input(
                 value, check_tensor_shape=False, check_device=False
             )
@@ -3212,7 +3217,7 @@ class TensorDict(TensorDictBase):
             if (
                 isinstance(value, Tensor)
                 and value.device.type == "cpu"
-                or isinstance(value, TensorDictBase)
+                or is_tensordict(value)
             ):
                 value.share_memory_()
         self._is_shared = True
@@ -3251,7 +3256,7 @@ class TensorDict(TensorDictBase):
                 raise Exception(
                     "memmap is not compatible with gradients, one of Tensors has requires_grad equals True"
                 )
-            if isinstance(value, TensorDictBase):
+            if is_tensordict(value):
                 if prefix is not None:
                     # ensure subdirectory exists
                     (prefix / key).mkdir(exist_ok=True)
@@ -3539,9 +3544,7 @@ def assert_allclose_td(
     msg: str = "",
 ) -> bool:
     """Compares two tensordicts and raise an exception if their content does not match exactly."""
-    if not isinstance(actual, TensorDictBase) or not isinstance(
-        expected, TensorDictBase
-    ):
+    if not is_tensordict(actual) or not is_tensordict(expected):
         raise TypeError("assert_allclose inputs must be of TensorDict type")
     set1 = set(actual.keys())
     set2 = set(expected.keys())
@@ -3555,7 +3558,7 @@ def assert_allclose_td(
     for key in keys:
         input1 = actual.get(key)
         input2 = expected.get(key)
-        if isinstance(input1, TensorDictBase):
+        if is_tensordict(input1):
             assert_allclose_td(input1, input2, rtol=rtol, atol=atol)
             continue
 
@@ -3927,7 +3930,7 @@ def pad(
         if len(pad_size) < len(_shape(tensor)) * 2:
             cur_pad = [0] * (len(_shape(tensor)) * 2 - len(pad_size)) + reverse_pad
 
-        if isinstance(tensor, TensorDictBase):
+        if is_tensordict(tensor):
             padded = pad(tensor, pad_size, value)
         else:
             padded = torch.nn.functional.pad(tensor, cur_pad, value=value)
@@ -4228,7 +4231,7 @@ torch.Size([3, 2])
     ) -> SubTensorDict:
         if not isinstance(idx, tuple):
             idx = (idx,)
-        if not isinstance(value, _ACCEPTED_CLASSES):
+        if not isinstance(value, tuple(_ACCEPTED_CLASSES)):
             value = self._process_input(
                 value, check_tensor_shape=False, check_device=False
             )
@@ -4317,7 +4320,7 @@ torch.Size([3, 2])
         clone: bool = False,
     ) -> SubTensorDict:
         for key, value in input_dict.items():
-            if not isinstance(value, _ACCEPTED_CLASSES):
+            if not isinstance(value, tuple(_ACCEPTED_CLASSES)):
                 raise TypeError(
                     f"Expected value to be one of types {_ACCEPTED_CLASSES} "
                     f"but got {type(value)}"
@@ -5221,7 +5224,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 td_dest.update_(td_source)
             return self
         for key, value in input_dict_or_td.items():
-            if not isinstance(value, _ACCEPTED_CLASSES):
+            if not isinstance(value, tuple(_ACCEPTED_CLASSES)):
                 raise TypeError(
                     f"Expected value to be one of types {_ACCEPTED_CLASSES} "
                     f"but got {type(value)}"
@@ -5507,7 +5510,7 @@ class _CustomOpTensorDict(TensorDictBase):
                 f"supported in this setting, consider calling "
                 f"`td.clone()` before `td.set_at_(...)`"
             )
-        if not isinstance(value, _ACCEPTED_CLASSES):
+        if not isinstance(value, tuple(_ACCEPTED_CLASSES)):
             value = self._process_input(
                 value, check_tensor_shape=False, check_device=False
             )
@@ -5916,13 +5919,13 @@ def _check_keys(
     return keys
 
 
-_ACCEPTED_CLASSES = (
+_ACCEPTED_CLASSES = [
     Tensor,
     MemmapTensor,
     TensorDictBase,
-)
+]
 if _has_torchrec:
-    _ACCEPTED_CLASSES = (*_ACCEPTED_CLASSES, KeyedJaggedTensor)
+    _ACCEPTED_CLASSES += [KeyedJaggedTensor]
 
 
 def _expand_to_match_shape(
@@ -6013,7 +6016,7 @@ def _iter_items_lazystack(
 def _clone_value(value: CompatibleType, recurse: bool) -> CompatibleType:
     if recurse:
         return value.clone()
-    elif isinstance(value, TensorDictBase):
+    elif is_tensordict(value):
         return value.clone(recurse=False)
     else:
         return value

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -111,6 +111,23 @@ _STR_MIXED_INDEX_ERROR = "Received a mixed string-non string index. Only string-
 
 
 def is_tensordict(datatype: type | Any) -> bool:
+    """Checks if a data object or a type is a tensor container from the tensordict lib.
+
+    Returns:
+        ``True`` if the input is a TensorDictBase subclass, a tensorclass or an istance of these.
+        ``False`` otherwise.
+
+    Examples:
+        >>> is_tensordict(TensorDictBase)  # True
+        >>> is_tensordict(TensorDict({}, []))  # True
+        >>> @tensorclass
+        ... class MyClass:
+        ...     pass
+        ...
+        >>> is_tensordict(MyClass)  # True
+        >>> is_tensordict(MyClass(batch_size=[]))  # True
+
+    """
     from tensordict.prototype import is_tensorclass
 
     return (

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -114,7 +114,7 @@ def is_tensordict(datatype: type | Any) -> bool:
     """Checks if a data object or a type is a tensor container from the tensordict lib.
 
     Returns:
-        ``True`` if the input is a TensorDictBase subclass, a tensorclass or an istance of these.
+        ``True`` if the input is a TensorDictBase subclass, a tensorclass or an instance of these.
         ``False`` otherwise.
 
     Examples:

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 from tensordict import TensorDict
+from tensordict.prototype import tensorclass
 from tensordict.tensordict import _stack as stack_td
 
 
@@ -25,6 +26,13 @@ def get_available_devices():
         for i in range(n_cuda):
             devices += [torch.device(f"cuda:{i}")]
     return devices
+
+
+@tensorclass
+class MyClass:
+    X: torch.Tensor
+    y: "MyClass"
+    z: str
 
 
 class TestTensorDictsBase:
@@ -48,6 +56,35 @@ class TestTensorDictsBase:
                 "my_nested_td": TensorDict(
                     {"inner": torch.randn(4, 3, 2, 1, 2)}, [4, 3, 2, 1]
                 ),
+            },
+            batch_size=[4, 3, 2, 1],
+            device=device,
+        )
+
+    def nested_tensorclass(self, device):
+
+        nested_class = MyClass(
+            X=torch.randn(4, 3, 2, 1),
+            y=MyClass(
+                X=torch.randn(
+                    4,
+                    3,
+                    2,
+                    1,
+                ),
+                y=None,
+                z=None,
+                batch_size=[4, 3, 2, 1],
+            ),
+            z="z",
+            batch_size=[4, 3, 2, 1],
+        )
+        return TensorDict(
+            source={
+                "a": torch.randn(4, 3, 2, 1, 5),
+                "b": torch.randn(4, 3, 2, 1, 10),
+                "c": torch.randint(10, (4, 3, 2, 1, 3)),
+                "my_nested_tc": nested_class,
             },
             batch_size=[4, 3, 2, 1],
             device=device,

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -615,9 +615,11 @@ def test_split():
     assert split_tcs[0].batch_size == torch.Size([3, 3])
     assert split_tcs[1].batch_size == torch.Size([3, 2])
     assert split_tcs[2].batch_size == torch.Size([3, 1])
-    assert split_tcs[0].y[0].batch_size == torch.Size([3, 3])
-    assert split_tcs[0].y[1].batch_size == torch.Size([3, 2])
-    assert split_tcs[0].y[2].batch_size == torch.Size([3, 1])
+
+    assert split_tcs[0].y.batch_size == torch.Size([3, 3])
+    assert split_tcs[1].y.batch_size == torch.Size([3, 2])
+    assert split_tcs[2].y.batch_size == torch.Size([3, 1])
+
     assert torch.all(torch.eq(split_tcs[0].X, torch.ones(3, 3, 5)))
     assert torch.all(torch.eq(split_tcs[0].y[0].X, torch.ones(3, 3, 5)))
     assert split_tcs[0].z == split_tcs[1].z == split_tcs[2].z == z
@@ -1164,7 +1166,7 @@ def test_statedict_errors():
     with pytest.raises(KeyError, match="Key 'a' wasn't expected in the state-dict"):
         tc.load_state_dict(sd)
     del sd["_non_tensordict"]["a"]
-    sd["_non_tensordict"]["y"]["_tensordict"]["a"] = None
+    sd["_tensordict"]["y"]["_tensordict"]["a"] = None
     with pytest.raises(KeyError, match="Key 'a' wasn't expected in the state-dict"):
         tc.load_state_dict(sd)
 


### PR DESCRIPTION
## Description

- Allows for tensorclass instances to be used as values for a TensorDict
- Adds a series of tests for this use case
- Removes the tensorclass instances from `tensorclass._non_tensordict`