### PR TITLE
[Refactor] Reduce boilerplate in tensorclass methods

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -15,9 +15,8 @@ import typing
 import warnings
 from copy import copy
 from dataclasses import dataclass
-from pathlib import Path
 from textwrap import indent
-from typing import Any, Callable, Sequence, TypeVar, Union
+from typing import Any, Callable, Protocol, Sequence, TypeVar, Union
 
 import tensordict as tensordict_lib
 
@@ -25,6 +24,7 @@ import torch
 from tensordict.tensordict import (
     get_repr,
     is_tensor_collection,
+    TD_HANDLED_FUNCTIONS,
     TensorDict,
     TensorDictBase,
 )
@@ -34,12 +34,37 @@ from torch import Tensor
 T = TypeVar("T", bound=TensorDictBase)
 PY37 = sys.version_info < (3, 8)
 
+
+class TensorClassProtocol(Protocol):
+    _tensordict: TensorDictBase
+    _non_tensordict: dict[str, Any]
+
+
 # We keep a dict of str -> class to call the class based on the string
 CLASSES_DICT: dict[str, type] = {}
 
 # Regex precompiled patterns
 OPTIONAL_PATTERN = re.compile(r"Optional\[(.*?)\]")
 UNION_PATTERN = re.compile(r"Union\[(.*?)\]")
+
+# methods where non_tensordict data should be cleared in the return value
+_CLEAR_METADATA = {"all", "any"}
+# torch functions where we can wrap the corresponding TensorDict version
+_TD_PASS_THROUGH = {
+    torch.unbind,
+    torch.full_like,
+    torch.zeros_like,
+    torch.ones_like,
+    torch.clone,
+    torch.squeeze,
+    torch.unsqueeze,
+    torch.split,
+    torch.permute,
+    torch.split,
+    torch.stack,
+    torch.cat,
+    torch.gather,
+}
 
 
 def is_tensorclass(obj: type | Any) -> bool:
@@ -104,14 +129,14 @@ def tensorclass(cls: T) -> T:
 
 
     """
-    td_handled_functions: dict[Callable, Callable] = {}
+    tc_handled_functions: dict[Callable, Callable] = {}
 
     def implements_for_tdc(torch_function: Callable) -> Callable:
         """Register a torch function override for _TensorClass."""
 
         @functools.wraps(torch_function)
         def decorator(func: Callable) -> Callable:
-            td_handled_functions[torch_function] = func
+            tc_handled_functions[torch_function] = func
             return func
 
         return decorator
@@ -123,14 +148,34 @@ def tensorclass(cls: T) -> T:
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
     ) -> Callable:
+        if (
+            func not in tc_handled_functions and func not in _TD_PASS_THROUGH
+        ) or not all(issubclass(t, (Tensor, cls)) for t in types):
+            return NotImplemented
         if kwargs is None:
             kwargs = {}
-        if func not in td_handled_functions or not all(
-            issubclass(t, (Tensor, cls)) for t in types
-        ):
-            return NotImplemented
+        if func in _TD_PASS_THROUGH:
+            if len(args) > 0:
+                input_ = args[0]
+            else:
+                input_ = kwargs["input"] if "input" in kwargs else kwargs["tensors"]
+            if isinstance(input_, (list, tuple)):
+                tc = input_[0]
+                input_ = input_.__class__(tc._tensordict for tc in input_)
+            else:
+                tc = input_
+                input_ = input_._tensordict
 
-        return td_handled_functions[func](*args, **kwargs)
+            out = kwargs.get("out")
+            if out is not None:
+                kwargs["out"] = out._tensordict
+
+            res = TD_HANDLED_FUNCTIONS[func](input_, *args[1:], **kwargs)
+            if isinstance(res, (list, tuple)):
+                return res.__class__(_from_tensordict_with_copy(tc, td) for td in res)
+            return _from_tensordict_with_copy(tc, res)
+
+        return tc_handled_functions[func](*args, **kwargs)
 
     cls = dataclass(cls)
     expected_keys = set(cls.__dataclass_fields__)
@@ -155,30 +200,13 @@ def tensorclass(cls: T) -> T:
     cls.__len__ = _len
     cls.__eq__ = __eq__
     cls.__ne__ = __ne__
-    cls.any = _any
-    cls.all = _all
     cls.state_dict = _state_dict
     cls.load_state_dict = _load_state_dict
     cls.gather = _gather
 
     cls.to_tensordict = _to_tensordict
-    cls.memmap_ = _memmap_
-    cls.memmap_like = _memmap_like
     cls.device = property(_device, _device_setter)
     cls.batch_size = property(_batch_size, _batch_size_setter)
-
-    implements_for_tdc(torch.unbind)(_unbind)
-    implements_for_tdc(torch.full_like)(_full_like)
-    implements_for_tdc(torch.zeros_like)(_zeros_like)
-    implements_for_tdc(torch.zeros_like)(_ones_like)
-    implements_for_tdc(torch.clone)(_clone)
-    implements_for_tdc(torch.squeeze)(_squeeze)
-    implements_for_tdc(torch.unsqueeze)(_unsqueeze)
-    implements_for_tdc(torch.permute)(_permute)
-    implements_for_tdc(torch.split)(_split)
-    implements_for_tdc(torch.stack)(_stack)
-    implements_for_tdc(torch.cat)(_cat)
-    implements_for_tdc(torch.gather)(_gather)
 
     cls.__doc__ = f"{cls.__name__}{inspect.signature(cls)}"
 
@@ -352,7 +380,7 @@ def _getattribute_wrapper(getattribute: Callable) -> Callable:
                 return out
             elif (
                 "_non_tensordict" in self.__dict__
-                and item in self.__dict__["_non_tensordict"].keys()
+                and item in self.__dict__["_non_tensordict"]
             ):
                 out = self._non_tensordict[item]
                 return out
@@ -417,23 +445,19 @@ def _getattr(self, attr: str) -> Any:
     @functools.wraps(func)
     def wrapped_func(*args, **kwargs):
         res = func(*args, **kwargs)
-        # Handling nested tensor class
-        non_tensor_dict = {}
-        for key, value in self._non_tensordict.items():
-            if is_tensorclass(value):
-                temp = getattr(value, attr)
-                if callable(temp):
-                    # Recursively calling for nested tensor classes
-                    non_tensor_dict[key] = temp(*args, **kwargs)
-                else:
-                    non_tensor_dict[key] = temp
-            else:
-                non_tensor_dict[key] = value
         if isinstance(res, TensorDictBase):
-            new = self._from_tensordict(res, non_tensor_dict)
-            return new
-        else:
-            return res
+            if attr.endswith("_"):
+                # in-place operation, return the current object
+                return self
+            elif attr in _CLEAR_METADATA:
+                # this is an attribute where copying the metadata makes no sense, e.g.
+                # .all or .any, so we replace all values with None
+                return self._from_tensordict(
+                    res, {k: None for k in self._non_tensordict}
+                )
+            # create a new tensorclass from res and copy the metadata from self
+            return self._from_tensordict(res, copy(self._non_tensordict))
+        return res
 
     return wrapped_func
 
@@ -544,60 +568,6 @@ def _to_tensordict(self) -> TensorDict:
     return td
 
 
-def _memmap_(self, prefix: str | None = None, copy_existing: bool = False):
-    """Writes all tensors onto a MemmapTensor.
-
-    Args:
-        prefix (str): directory prefix where the memmap tensors will have to
-            be stored.
-        copy_existing (bool): If False (default), an exception will be raised if an
-            entry in the tensorclass is already a MemmapTensor but is not saved in
-            the correct location according to prefix. If True, any MemmapTensors
-            that are not in the correct location are copied to the new location.
-
-    The tensorclass is then locked, meaning that the only writing operations that
-    can be executed must be done in-place.
-    Once the tensordict is unlocked, the memmap attribute is turned to False,
-    because cross-process identity is not guaranteed anymore.
-
-    Returns:
-        self.
-
-    Note:
-        Serialising in this fashion might be slow with deeply nested tensordicts, so
-        we do not recommend calling this method inside a training loop.
-    """
-    if prefix is not None:
-        prefix = Path(prefix)
-    self._tensordict.memmap_(prefix=prefix, copy_existing=copy_existing)
-    return self
-
-
-def _memmap_like(
-    self,
-    prefix: str | None = None,
-):
-    """Creates an empty Memory-mapped tensorclass with the same content shape as the current one.
-
-    Args:
-        prefix (str): directory prefix where the memmap tensors will have to
-            be stored.
-
-    The resulting tensorclass will be locked and ``is_memmap() = True``,
-    meaning that the only writing operations that can be executed must be done in-place.
-    Once the tensorclass is unlocked, the memmap attribute is turned to False,
-    because cross-process identity is not guaranteed anymore.
-
-    Returns:
-        a new tensorclass instance with data stored as memory-mapped tensors.
-
-    """
-    if prefix is not None:
-        prefix = Path(prefix)
-    out_td = self._tensordict.memmap_like(prefix=prefix)
-    return _from_tensordict_with_copy(self, out_td)
-
-
 def _device(self) -> torch.device:
     """Retrieves the device type of tensor class"""
     return self._tensordict.device
@@ -677,117 +647,11 @@ def _load_state_dict(self, state_dict: dict[str, Any]):
     return self
 
 
-def _any(self, dim: int | None = None) -> bool:
-    """A recursive implementation of `any()` over the tensorclass leaves.
-
-    If the `dim` arg is passed, the resulting tensorclass will have
-    this dimension removed.
-
-    Args:
-        dim (int, optional): if provided, ``any`` will run over that dimension and reduce it.
-            When traversing the tensorclass leaves,  negative dims will be turned to positive
-            ones compared with the root tensorclass' batch-size to avoid any clash
-            of dimensions.
-            Defaults to None, i.e., full reduction in a single boolean value.
-
-    Returns:
-        A boolean if ``dim`` is ``None``, a tensorclass of the same class as the
-        parent otherwise (with the target dimension reduced).
-
-    Examples:
-        >>> @tensorclass
-        ... class MyClass:
-        ...      X: Tensor
-        ...      y: "MyClass"
-        ...
-        >>> c = MyClass(
-        ...     torch.randn(3, 4),
-        ...     MyClass(torch.randn(3, 4, 1), None, batch_size=[3, 4, 1]),
-        ...     batch_size=[3, 4])
-        >>> c_any = c.any()  # bool
-        >>> assert isinstance(c_any, bool)
-        >>> print(c.any(dim=0))
-        MyClass(
-            X=Tensor(shape=torch.Size([4]), device=cpu, dtype=torch.bool, is_shared=False),
-            y=MyClass(
-                X=Tensor(shape=torch.Size([4, 1]), device=cpu, dtype=torch.bool, is_shared=False),
-                y=None,
-                batch_size=torch.Size([4, 1]),
-                device=None,
-                is_shared=False),
-            batch_size=torch.Size([4]),
-            device=None,
-            is_shared=False)
-        >>> # one can work with negative dimensions, which will be converted to positive dims for the root tensorclass
-        >>> assert (c.any(-1) == c.any(1)).all()
-        >>> assert c.any(-1).y.batch_size == c.any(1).y.batch_size
-
-    """
-    if dim is None:
-        return self._tensordict.any()
-
-    if dim < 0:
-        dim = self.batch_dims + dim
-
-    return _from_tensordict_with_none(self, self._tensordict.any(dim=dim))
-
-
-def _all(self, dim: int | None = None) -> bool:
-    """A recursive implementation of `all()` over the tensorclass leaves.
-
-    If the `dim` arg is passed, the resulting tensorclass will have
-    this dimension removed.
-
-    Args:
-        dim (int, optional): if provided, ``all`` will run over that dimension and reduce it.
-            When traversing the tensorclass leaves,  negative dims will be turned to positive
-            ones compared with the root tensorclass' batch-size to avoid any clash
-            of dimensions.
-            Defaults to None, i.e., full reduction in a single boolean value.
-
-    Returns:
-        A boolean if ``dim`` is ``None``, a tensorclass of the same class as the
-        parent otherwise (with the target dimension reduced).
-
-    Examples:
-        >>> @tensorclass
-        ... class MyClass:
-        ...      X: Tensor
-        ...      y: "MyClass"
-        ...
-        >>> c = MyClass(
-        ...     torch.randn(3, 4),
-        ...     MyClass(torch.randn(3, 4, 1), None, batch_size=[3, 4, 1]),
-        ...     batch_size=[3, 4])
-        >>> c_all = c.all()  # bool
-        >>> assert isinstance(c_all, bool)
-        >>> print(c.all(dim=0))
-        MyClass(
-            X=Tensor(shape=torch.Size([4]), device=cpu, dtype=torch.bool, is_shared=False),
-            y=MyClass(
-                X=Tensor(shape=torch.Size([4, 1]), device=cpu, dtype=torch.bool, is_shared=False),
-                y=None,
-                batch_size=torch.Size([4, 1]),
-                device=None,
-                is_shared=False),
-            batch_size=torch.Size([4]),
-            device=None,
-            is_shared=False)
-        >>> # one can work with negative dimensions, which will be converted to positive dims for the root tensorclass
-        >>> assert (c.all(-1) == c.all(1)).all()
-        >>> assert c.all(-1).y.batch_size == c.all(1).y.batch_size
-
-    """
-    if dim is None:
-        return self._tensordict.all()
-
-    if dim < 0:
-        dim = self.batch_dims + dim
-
-    return _from_tensordict_with_none(self, self._tensordict.all(dim=dim))
-
-
-def _gather(self, dim: int, index: torch.Tensor, out: TensorDictBase | None = None):
+# this function appears to be required even though we fall back on `TensorDict.gather`
+# because it's not clear how to deal with methods with an `out` argument generically
+def _gather(
+    self, dim: int, index: torch.Tensor, out: TensorClassProtocol | None = None
+):
     """Gathers values along an axis specified by `dim`.
 
     Args:
@@ -816,16 +680,11 @@ def _gather(self, dim: int, index: torch.Tensor, out: TensorDictBase | None = No
     if dim < 0:
         dim = self.batch_dims + dim
 
-    def _get_out(key, nontensor):
-        if out is None:
-            return None
-        if nontensor:
-            return out._non_tensordict[key]
-        else:
-            return out._tensordict
-
     return _from_tensordict_with_copy(
-        self, self._tensordict.gather(dim=dim, index=index, out=_get_out(None, False))
+        self,
+        self._tensordict.gather(
+            dim=dim, index=index, out=out._tensordict if out is not None else None
+        ),
     )
 
 
@@ -945,172 +804,6 @@ def __ne__(self, other: object) -> bool:
     else:
         tensor = self._tensordict != other
     return _from_tensordict_with_none(self, tensor)
-
-
-def _unbind(tdc, dim: int = 0) -> list:
-    """Unbind the tensor class object along a given dimension, the behavior is extended to nested tensor classes as well.(no impact to non-tensor data)
-
-    Args:
-        tdc: tensor class object
-        dim (int): the dimension along which to unbind the tensor (default is 0)
-
-    Returns:
-        out (list): list of tensor class objects representing the unbound parts of the original tensor class object
-
-    """
-    tensordicts = torch.unbind(tdc._tensordict, dim)
-    non_tensor_dict = tdc._non_tensordict
-    out = [tdc._from_tensordict(td, non_tensor_dict) for td in tensordicts]
-    return out
-
-
-def _full_like(tdc, fill_value: float):
-    """Fill the tensor types of tensor class object with the fill value, the behavior is extended to nested tensor classes as well (no impact to non-tensor data)
-
-    Args:
-        tdc: tensor class object
-        fill_value (float): The value with which the filling happen
-
-    Returns:
-        out: the filled tensor class object
-
-    """
-    return _from_tensordict_with_copy(tdc, torch.full_like(tdc._tensordict, fill_value))
-
-
-def _zeros_like(tdc):
-    """Fill the tensor types of tensor class object including nested tensor classes with zeros (no impact to non-tensor data)
-
-    Args:
-        tdc: tensor class object
-
-    Returns:
-        out: tensor class object filled with zeros
-
-    """
-    return _full_like(tdc, 0.0)
-
-
-def _ones_like(tdc):
-    """Fill the tensor types of tensor class object including nested tensor classes with ones (no impact to non-tensor data)
-
-    Args:
-        tdc: tensor class object
-
-    Returns:
-        out: tensor class object filled with ones
-
-    """
-    return _full_like(tdc, 1.0)
-
-
-def _clone(tdc):
-    """Create a shallow copy of the tensor class object, the behavior is extended to nested tensor classes as well
-
-    Args:
-        tdc: tensor class object
-
-    Returns:
-        out: a shallow copy of the tensor class object
-
-    """
-    return _from_tensordict_with_copy(tdc, torch.clone(tdc._tensordict))
-
-
-def _squeeze(tdc):
-    """Remove single-dimensional entries from the shape of a tensors for the tensor class objects including nested tensor classes (no impact on non-tensor data)
-
-    Args:
-        tdc: tensor class object
-
-    Returns:
-        out: squeezed tensor class object
-
-    """
-    return _from_tensordict_with_copy(tdc, torch.squeeze(tdc._tensordict))
-
-
-def _unsqueeze(tdc, dim: int = 0):
-    """Insert a single-dimensional entry at the specified position in the shape of a tensor for tensor class objects including the nested tensor classes (no impact on non-tensor data)
-
-    Args:
-        tdc: tensor class object
-        dim (int, optional): the position at which to insert the single-dimensional entry
-
-    Returns:
-        out: tensor class object with the single-dimensional entry inserted
-
-    """
-    return _from_tensordict_with_copy(tdc, torch.unsqueeze(tdc._tensordict, dim))
-
-
-def _permute(tdc, dims: int | Sequence[int]):
-    """Permute the dimensions of a tensor class object including nested tensor classes (no impact on non-tensor data)
-
-    Args:
-        tdc: tensor class object
-        dims (int or tuple of ints): the desired order of the dimensions
-
-    Returns:
-        out: permuted tensor class object
-
-    """
-    return _from_tensordict_with_copy(tdc, torch.permute(tdc._tensordict, dims))
-
-
-def _split(tdc, split_size_or_sections: int | Sequence[int], dim: int = 0):
-    """
-    Split a tensor class object into smaller tensor class objects along a given dimension.
-
-    It extends the behavior to nested tensor classes (no impact on non-tensor data)
-
-    Args:
-       tdc: tensor class object
-       split_size_or_sections (int or list): the size of each split
-       dim (int, optional): the dimension along which to split the tensor (default is 0)
-
-    Returns:
-        out[list]: list of smaller tensor class objects
-
-
-    """
-    tensordicts = torch.split(tdc._tensordict, split_size_or_sections, dim)
-    return [_from_tensordict_with_copy(tdc, td) for td in tensordicts]
-
-
-def _stack(list_of_tdc: Sequence[Any], dim: int = 0, out: Any = None):
-    """Stack tensor class objects along a given dimension, the behavior is extended to nested tensor classes. (no impact on non-tensor data)
-
-    Args:
-        list_of_tdc (list): list of  tensor class objects to stack
-        dim (int, optional): the position of the new dimension (default is 0)
-
-    Returns:
-        out: stacked tensor class object
-
-    """
-    tensordict = torch.stack([tdc._tensordict for tdc in list_of_tdc], dim)
-    if out is not None:
-        out.update_(tensordict)
-        out._non_tensordict.update(list_of_tdc[0]._non_tensordict)
-        return out
-    return _from_tensordict_with_copy(list_of_tdc[0], tensordict)
-
-
-def _cat(list_of_tdc: Sequence, dim: int = 0):
-    """Concatenate tensor class objects along a given dimension, the behavior is extended to nested tensor classes as well.(no impact on non-tensor data)
-
-    Args:
-        list_of_tdc (list): list of  tensor class objects to concatenate
-        dim (int, optional): the position of the new dimension (default is 0)
-
-    Returns:
-        out: concatenated tensor class object
-
-    """
-    return _from_tensordict_with_copy(
-        list_of_tdc[0], torch.cat([tdc._tensordict for tdc in list_of_tdc], dim)
-    )
 
 
 def _get_typed_output(out, expected_type: str | type):

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2289,10 +2289,10 @@ class TensorDictBase(MutableMapping):
                 shape.
 
         """
-        if dim is not None and (dim >= self.batch_dims or dim <= -self.batch_dims):
+        if dim is not None and (dim >= self.batch_dims or dim < -self.batch_dims):
             raise RuntimeError(
-                "dim must be greater than -tensordict.batch_dims and smaller "
-                "than tensordict.batchdims"
+                "dim must be greater than or equal to -tensordict.batch_dims and "
+                "smaller than tensordict.batch_dims"
             )
         if dim is not None:
             if dim < 0:
@@ -2315,10 +2315,10 @@ class TensorDictBase(MutableMapping):
                 the tensordict shape.
 
         """
-        if dim is not None and (dim >= self.batch_dims or dim <= -self.batch_dims):
+        if dim is not None and (dim >= self.batch_dims or dim < -self.batch_dims):
             raise RuntimeError(
-                "dim must be greater than -tensordict.batch_dims and smaller "
-                "than tensordict.batchdims"
+                "dim must be greater than or equal to -tensordict.batch_dims and "
+                "smaller than tensordict.batch_dims"
             )
         if dim is not None:
             if dim < 0:


### PR DESCRIPTION
## Description

This PR reduces boilerplate in tensorclass methods. Many of them copy the metadata or replace entries with `None`. Here we create two helper functions that can be called from inside the methods to streamline the code.