### PR TITLE
[Docs] Remove unneeded __len__ definition in tutorial

### DIFF
--- a/tutorials/sphinx_tuto/tensorclass_fashion.py
+++ b/tutorials/sphinx_tuto/tensorclass_fashion.py
@@ -79,10 +79,6 @@ class FashionMNISTData:
             data[i] = cls(images=image, targets=torch.tensor(target), batch_size=[])
         return data
 
-    def __len__(self):
-        # need to define explicitly for `len()` to work
-        return self.batch_size[0] if self.batch_dims else 0
-
 
 ###############################################################################
 # We will create two tensorclasses, one each for the training and test data. Note that


### PR DESCRIPTION
## Description

As of #150 this is not needed, so removing from tutorial to avoid confusion.