### PR TITLE
[Feature] Add dispatch source and dest arguments

### DIFF
--- a/tensordict/nn/__init__.py
+++ b/tensordict/nn/__init__.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from tensordict.nn.common import (
-    dispatch_kwargs,
+    dispatch,
     make_tensordict,
     TensorDictModule,
     TensorDictModuleWrapper,
@@ -23,7 +23,7 @@ from tensordict.nn.sequence import TensorDictSequential
 from tensordict.nn.utils import biased_softplus, inv_softplus
 
 __all__ = [
-    "dispatch_kwargs",
+    "dispatch",
     "TensorDictModule",
     "TensorDictModuleWrapper",
     "get_functional",

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -72,6 +72,17 @@ class dispatch:
     :func:`dispatch` can be used either as a method or as a class when extra arguments
     need to be passed.
 
+    Args:
+        separator (str, optional): separator that combines sub-keys together
+            for ``in_keys`` that are tuples of strings.
+            Defaults to ``"_"``.
+        source (str, optional): the module attribute name that refers to the
+            list of input keys to be used.
+            Defaults to ``"in_keys"``.
+        dest (str, optional): the module attribute name that refers to the
+            list of output keys to be used.
+            Defaults to ``"out_keys"``.
+
     Examples:
         >>> class MyModule(nn.Module):
         ...     in_keys = ["a"]

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -269,7 +269,7 @@ class dispatch:
                                 f"but is expected to execute that function."
                             )
                 tensordict = make_tensordict(tensordict_values)
-                out = func(_self, tensordict, **kwargs)
+                out = func(_self, tensordict, *args, **kwargs)
                 out = tuple(out[key] for key in dest)
                 return out[0] if len(out) == 1 else out
             return func(_self, tensordict, *args, **kwargs)

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -241,6 +241,8 @@ class dispatch:
                     key in tensordict.keys(isinstance(key, tuple)) for key in source
                 ):
                     tensordict = None
+                else:
+                    args = args[1:]
             if tensordict is None:
                 tensordict_values = {}
                 dest = self.dest

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -167,9 +167,13 @@ class dispatch:
 
     .. note::
 
-        This can lead to unexpected behaviours when the first unnamed argument
-        is itself a tensordict instance with keys matching those specified
-        by the source.
+        If the first argument is a :class:`~.TensorDictBase` instance, it is
+        assumed that dispatch is __not__ being used and that this tensordict
+        contains all the necessary information to be run through the module.
+        In other words, one cannot decompose a tensordict with the first key
+        of the module inputs pointing to a tensordict instance.
+        In general, it is preferred to use :func:`dispatch` with tensordict
+        leaves only.
 
     Examples:
         >>> class MyModuleNest(nn.Module):
@@ -236,13 +240,10 @@ class dispatch:
                 source = getattr(_self, source)
             tensordict = None
             if len(args):
-                tensordict = args[0]
-                if not isinstance(tensordict, TensorDictBase) or not all(
-                    key in tensordict.keys(isinstance(key, tuple)) for key in source
-                ):
-                    tensordict = None
+                if not isinstance(args[0], TensorDictBase):
+                    pass
                 else:
-                    args = args[1:]
+                    tensordict, args = args[0], args[1:]
             if tensordict is None:
                 tensordict_values = {}
                 dest = self.dest

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -22,7 +22,7 @@ except ImportError:
     FUNCTORCH_ERROR = "functorch not installed. Consider installing functorch to use this functionality."
 
 
-from tensordict.nn.common import dispatch_kwargs, TensorDictModule
+from tensordict.nn.common import dispatch, TensorDictModule
 from tensordict.tensordict import LazyStackedTensorDict, TensorDictBase
 from tensordict.utils import _normalize_key, NestedKey
 from torch import nn
@@ -234,7 +234,7 @@ class TensorDictSequential(TensorDictModule):
             tensordict._update_valid_keys()
         return tensordict
 
-    @dispatch_kwargs
+    @dispatch
     def forward(
         self,
         tensordict: TensorDictBase,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -502,6 +502,21 @@ class TestTDModule:
         with pytest.raises(RuntimeError, match="Duplicated argument"):
             module(torch.zeros(1, 2), a_c=torch.ones(1, 2))
 
+    def test_dispatch_nested_extra_args(self):
+        class MyModuleNest(nn.Module):
+            in_keys = [("a", "c"), "d"]
+            out_keys = ["b"]
+
+            @dispatch(separator="_")
+            def forward(self, tensordict, other):
+                tensordict["b"] = tensordict["a", "c"] + tensordict["d"] + other
+                return tensordict
+
+        module = MyModuleNest()
+        other = 1
+        (b,) = module(torch.zeros(1, 2), torch.ones(1, 2), other)
+        assert (b == 2).all()
+
     def test_dispatch_nested_sep(self):
         class MyModuleNest(nn.Module):
             in_keys = [("a", "c")]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -500,12 +500,13 @@ class TestTDModule:
         (b,) = module(asepc=torch.zeros(1, 2))
         assert (b == 1).all()
 
-    def test_dispatch_kwargs_nested_source(self):
+    @pytest.mark.parametrize("source", ["keys_in", [("a", "c")]])
+    def test_dispatch_kwargs_nested_source(self, source):
         class MyModuleNest(nn.Module):
             keys_in = [("a", "c")]
             out_keys = ["b"]
 
-            @dispatch(separator="sep", source="keys_in")
+            @dispatch(separator="sep", source=source)
             def forward(self, tensordict):
                 tensordict["b"] = tensordict["a", "c"] + 1
                 return tensordict
@@ -514,12 +515,13 @@ class TestTDModule:
         (b,) = module(asepc=torch.zeros(1, 2))
         assert (b == 1).all()
 
-    def test_dispatch_kwargs_nested_dest(self):
+    @pytest.mark.parametrize("dest", ["other", ["b"]])
+    def test_dispatch_kwargs_nested_dest(self, dest):
         class MyModuleNest(nn.Module):
             in_keys = [("a", "c")]
             other = ["b"]
 
-            @dispatch(separator="sep", dest="other")
+            @dispatch(separator="sep", dest=dest)
             def forward(self, tensordict):
                 tensordict["b"] = tensordict["a", "c"] + 1
                 return tensordict


### PR DESCRIPTION
## Description

Adds a `source` and `dest` keyword arguments to `dispatch` (renamed from `dispatch_kwargs`).
One can also call the module with unnamed arguments.

Renames the `test_tensordictmodule.py` in `test_nn.py` which is clearer.