### PR TITLE
[BugFix] Select misses nested keys if missing nested are present

### DIFF
--- a/benchmarks/common/common_ops_test.py
+++ b/benchmarks/common/common_ops_test.py
@@ -113,6 +113,14 @@ def test_set_nested_new(benchmark, td, c):
     benchmark.pedantic(exec_set_nested_new, iterations=10000)
 
 
+def test_select(benchmark, td, c):
+    def exec_select():
+        tdc = td.clone()
+        tdc["c", "c", "c"] = c
+        tdc.select("a", "z", ("c", "c", "c"), strict=False)
+
+    benchmark.pedantic(exec_select, iterations=10000)
+
 def main():
     # creation
     td = TensorDict({}, [3, 4])
@@ -183,6 +191,14 @@ def main():
     tdc["b", "b1"] = b
 
     # set nested new
+    a = torch.zeros(3, 4, 5)
+    b = torch.zeros(3, 4, 5)
+    c = torch.zeros(3, 4, 5)
+    td = TensorDict({"a": a, "b": {"b1": b}}, [3, 4])
+    tdc = td.clone()
+    tdc["c", "c", "c"] = c
+
+    # select
     a = torch.zeros(3, 4, 5)
     b = torch.zeros(3, 4, 5)
     c = torch.zeros(3, 4, 5)

--- a/benchmarks/common/common_ops_test.py
+++ b/benchmarks/common/common_ops_test.py
@@ -121,6 +121,7 @@ def test_select(benchmark, td, c):
 
     benchmark.pedantic(exec_select, iterations=10000)
 
+
 def main():
     # creation
     td = TensorDict({}, [3, 4])

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3010,6 +3010,14 @@ def test_select_nested(inplace):
         }
 
 
+def test_select_nested_missing():
+    # checks that we keep a nested key even if missing nested keys are present
+    td = TensorDict({"a": {"b": [1], "c": [2]}}, [])
+
+    td_select = td.select(("a", "b"), "r", ("a", "z"), strict=False)
+    assert ("a", "b") in td_select.keys(True, True)
+
+
 @pytest.mark.parametrize("inplace", [True, False])
 def test_exclude_nested(inplace):
     tensor_1 = torch.rand(4, 5, 6, 7)


### PR DESCRIPTION
## Description

`select` currently misses the nested `("a", "b")` in this case:
```python
    # checks that we keep a nested key even if missing nested keys are present
    td = TensorDict({"a": {"b": [1], "c": [2]}}, [])

    td_select = td.select(("a", "b"), "r", ("a", "z"), strict=False)
    assert ("a", "b") in td_select.keys(True, True)
```