### PR TITLE
[Quality] More informative error message when an argument is None in TensorDictModule

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3179,7 +3179,7 @@ class TensorDict(TensorDictBase):
                         if "has no attribute" in str(err):
                             raise ValueError(
                                 f"Expected a TensorDictBase instance but got {type(first_lev)} instead"
-                                f" for key '{key[0]}' in tensordict:\n{self}."
+                                f" for key '{key[0]}' and subkeys {key[1:]} in tensordict:\n{self}."
                             )
                 return self.get(key[0])
             return self._tensordict[key]

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3173,7 +3173,14 @@ class TensorDict(TensorDictBase):
                     first_lev = self.get(key[0])
                     if len(key) == 2 and isinstance(first_lev, KeyedJaggedTensor):
                         return first_lev[key[1]]
-                    return first_lev.get(key[1:])
+                    try:
+                        return first_lev.get(key[1:])
+                    except AttributeError as err:
+                        if "has no attribute" in str(err):
+                            raise ValueError(
+                                f"Expected a TensorDictBase instance but got {type(first_lev)} instead"
+                                f" for key {key[0]} in tensordict:\n{self}."
+                            )
                 return self.get(key[0])
             return self._tensordict[key]
         except KeyError:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3005,7 +3005,12 @@ class TensorDict(TensorDictBase):
         else:
             td, subkey = self, key
         if inplace:
-            td.get(subkey).copy_(value)
+            try:
+                td.get(subkey).copy_(value)
+            except Exception as err:
+                raise ValueError(
+                    f"Failed to update '{subkey}' in tensordict {td}"
+                ) from err
         else:
             if td._tensordict.get(subkey, None) is not value:
                 td._tensordict[subkey] = value

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3179,7 +3179,7 @@ class TensorDict(TensorDictBase):
                         if "has no attribute" in str(err):
                             raise ValueError(
                                 f"Expected a TensorDictBase instance but got {type(first_lev)} instead"
-                                f" for key {key[0]} in tensordict:\n{self}."
+                                f" for key '{key[0]}' in tensordict:\n{self}."
                             )
                 return self.get(key[0])
             return self._tensordict[key]

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3007,6 +3007,8 @@ class TensorDict(TensorDictBase):
         if inplace:
             try:
                 td.get(subkey).copy_(value)
+            except KeyError as err:
+                raise err
             except Exception as err:
                 raise ValueError(
                     f"Failed to update '{subkey}' in tensordict {td}"

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1491,6 +1491,14 @@ def test_probabilistic_sequential_type_checks():
         ProbabilisticTensorDictSequential(td_module_1, td_module_2)
 
 
+def test_keyerr_msg():
+    module = TensorDictModule(nn.Linear(2, 3), in_keys=["a"], out_keys=["b"])
+    with pytest.raises(
+        KeyError, match="Some tensors that are necessary for the module call"
+    ):
+        module(TensorDict({"c": torch.randn(())}, []))
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3872,6 +3872,12 @@ def test_save_load_memmap_stacked_td(
         assert (d2[:, 0] == a).all()
 
 
+def test_err_msg_missing_nested():
+    td = TensorDict({"a": torch.zeros(())}, [])
+    with pytest.raises(ValueError, match="Expected a TensorDictBase instance"):
+        td["a", "b"]
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1443,7 +1443,12 @@ class TestTensorDicts(TestTensorDictsBase):
         val2 = np.zeros(shape=(4, 3, 2, 1, 10))
         td.set_("key1", val2)
         assert (td.get("key1") == 0).all()
-        with pytest.raises((KeyError, AttributeError, ValueError)):
+        if td_name not in ("stacked_td", "nested_stacked_td"):
+            err_msg = 'key "smartypants" not found in '
+        else:
+            err_msg = "setting a value in-place on a stack of TensorDict"
+
+        with pytest.raises(KeyError, match=err_msg):
             td.set_("smartypants", np.ones(shape=(4, 3, 2, 1, 5)))
 
         # test set_at_
@@ -1469,8 +1474,14 @@ class TestTensorDicts(TestTensorDictsBase):
         val2 = {"subkey1": torch.zeros(4, 3, 2, 1, 10)}
         td.set_("key1", val2)
         assert (td.get("key1").get("subkey1") == 0).all()
-        with pytest.raises((KeyError, AttributeError, ValueError)):
-            td.set_("smartypants", torch.ones(4, 3, 2, 1, 5))
+
+        if td_name not in ("stacked_td", "nested_stacked_td"):
+            err_msg = 'key "smartypants" not found in '
+        else:
+            err_msg = "setting a value in-place on a stack of TensorDict"
+
+        with pytest.raises(KeyError, match=err_msg):
+            td.set_("smartypants", np.ones(shape=(4, 3, 2, 1, 5)))
 
     def test_delitem(self, td_name, device):
         torch.manual_seed(1)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3872,10 +3872,18 @@ def test_save_load_memmap_stacked_td(
         assert (d2[:, 0] == a).all()
 
 
-def test_err_msg_missing_nested():
-    td = TensorDict({"a": torch.zeros(())}, [])
-    with pytest.raises(ValueError, match="Expected a TensorDictBase instance"):
-        td["a", "b"]
+class TestErrorMessage:
+    @staticmethod
+    def test_err_msg_missing_nested():
+        td = TensorDict({"a": torch.zeros(())}, [])
+        with pytest.raises(ValueError, match="Expected a TensorDictBase instance"):
+            td["a", "b"]
+
+    @staticmethod
+    def test_inplace_error():
+        td = TensorDict({"a": torch.rand(())}, [])
+        with pytest.raises(ValueError, match="Failed to update 'a'"):
+            td.set_("a", torch.randn(2))
 
 
 if __name__ == "__main__":

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1443,7 +1443,7 @@ class TestTensorDicts(TestTensorDictsBase):
         val2 = np.zeros(shape=(4, 3, 2, 1, 10))
         td.set_("key1", val2)
         assert (td.get("key1") == 0).all()
-        with pytest.raises((KeyError, AttributeError)):
+        with pytest.raises((KeyError, AttributeError, ValueError)):
             td.set_("smartypants", np.ones(shape=(4, 3, 2, 1, 5)))
 
         # test set_at_
@@ -1469,7 +1469,7 @@ class TestTensorDicts(TestTensorDictsBase):
         val2 = {"subkey1": torch.zeros(4, 3, 2, 1, 10)}
         td.set_("key1", val2)
         assert (td.get("key1").get("subkey1") == 0).all()
-        with pytest.raises((KeyError, AttributeError)):
+        with pytest.raises((KeyError, AttributeError, ValueError)):
             td.set_("smartypants", torch.ones(4, 3, 2, 1, 5))
 
     def test_delitem(self, td_name, device):


### PR DESCRIPTION
## Description

`TensorDictModule` allows some arguments to be missing in the input tensordict, in which case a `None` value is used.
The error message that occurs if that value is actually necessary is misleading, always being something like "NoneType has no attribute shape" or similar.

We now capture errors, check if any input is None and if the error contains None, and turn the error message to something more indicative of what is going on.

Similarly, we capture errors like
```python
td = TensorDict({"a": torch.zeros(())}, [])
td["a", "b"]
```
to let users know what is going on with the wrongful indexing.

Suggestions are welcome!