### PR TITLE
[Refactor] Speedup construction

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2866,12 +2866,10 @@ class TensorDict(TensorDictBase):
         source: TensorDictBase | dict,
         batch_size: Sequence[int] | torch.Size | int | None = None,
     ) -> torch.Size:
-        if isinstance(batch_size, (Number, Sequence)):
-            if not isinstance(batch_size, torch.Size):
-                if isinstance(batch_size, int):
-                    return torch.Size([batch_size])
-                return torch.Size(batch_size)
-            return batch_size
+        if isinstance(batch_size, Sequence):
+            return torch.Size(batch_size)
+        elif isinstance(batch_size, Number):
+            return torch.Size([batch_size])
         elif isinstance(source, TensorDictBase):
             return source.batch_size
         raise ValueError(

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3509,14 +3509,13 @@ def _dict_to_nested_keys(
 
 
 def _default_hook(td: TensorDictBase, k: tuple[str, ...]) -> None:
-    try:
-        return td.get(k[0])
-    except KeyError:
+    out = td.get(k[0], None)
+    if out is None:
         out = td.select()
         if td.is_locked:
             raise RuntimeError(TensorDictBase.LOCK_ERROR)
         td._set(k[0], out)
-        return out
+    return out
 
 
 def _get_leaf_tensordict(


### PR DESCRIPTION
## Description

Some changes in tensordict construction aimed at speeding it up.

Some benchmarks:
```python
import timeit

import torch

from tensordict import TensorDict

make_td1 = """
TensorDict({
    'a': {'1': {'2': {'3': torch.zeros(())}}},
    'b': {'1': {'2': {'3': torch.zeros(())}}},
    'c': {'1': {'2': {'3': torch.zeros(())}}},
    'd': {'1': {'2': {'3': torch.zeros(())}}},
    'e': {'1': {'2': {'3': torch.zeros(())}}},
    'f': {'1': {'2': {'3': torch.zeros(())}}},
    'g': {'1': {'2': {'3': torch.zeros(())}}},
    'h': {'1': {'2': {'3': torch.zeros(())}}},
    'i': {'1': {'2': {'3': torch.zeros(())}}},
    'j': {'1': {'2': {'3': torch.zeros(())}}},
    'k': {'1': {'2': {'3': torch.zeros(())}}},
    'l': {'1': {'2': {'3': torch.zeros(())}}},
    'm': {'1': {'2': {'3': torch.zeros(())}}},
    'n': {'1': {'2': {'3': torch.zeros(())}}},
}, [])
"""

make_td2 = """
TensorDict({
    ('a', '1', '2', '3'): torch.zeros(()),
    ('b', '1', '2', '3'): torch.zeros(()),
    ('c', '1', '2', '3'): torch.zeros(()),
    ('d', '1', '2', '3'): torch.zeros(()),
    ('e', '1', '2', '3'): torch.zeros(()),
    ('f', '1', '2', '3'): torch.zeros(()),
    ('g', '1', '2', '3'): torch.zeros(()),
    ('h', '1', '2', '3'): torch.zeros(()),
    ('i', '1', '2', '3'): torch.zeros(()),
    ('j', '1', '2', '3'): torch.zeros(()),
    ('k', '1', '2', '3'): torch.zeros(()),
    ('l', '1', '2', '3'): torch.zeros(()),
    ('m', '1', '2', '3'): torch.zeros(()),
    ('n', '1', '2', '3'): torch.zeros(()),
    }, []
)
"""

print(exec(make_td1))
print(exec(make_td2))

print(timeit.repeat(make_td1, number=10_000, globals={"TensorDict": TensorDict, "torch": torch}))
print(timeit.repeat(make_td2, number=10_000, globals={"TensorDict": TensorDict, "torch": torch}))
```

## Before

```
[3.272523496998474, 3.2705835989909247, 3.2683338769711554, 3.268758771009743, 3.2690370980417356]
[4.023852066020481, 4.021149920066819, 4.020547269959934, 4.021907583926804, 4.018796102027409]
```

## After
```
[3.386114652035758, 3.3847680549370125, 3.381894279969856, 3.381631589960307, 3.380491119925864]
[2.8363861240213737, 2.82888167607598, 2.837151632993482, 2.829621796030551, 2.8261794140562415]
```

We get a 1.5 speedup on setting nested keys using tuples. Using nested dicts we don't observe much. In that case the bottleneck is in the creation of tensordicts repeatedly, which I don't see how to improve atm.