### PR TITLE
[CI] Added workflow to let contributors self-assign issues

### DIFF
--- a/.github/workflows/selfassign.yml
+++ b/.github/workflows/selfassign.yml
@@ -1,0 +1,24 @@
+# Allow users to automatically tag themselves to issues
+#
+# Usage:
+#  - a github user (a member of the repo) needs to comment
+#    with "#self-assign" on an issue to be assigned to them.
+#------------------------------------------------------------
+
+name: Self-assign
+on:
+  issue_comment:
+    types: created
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#take' ||
+       github.event.comment.body == '#self-assign')
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          echo "Done 🔥 "


### PR DESCRIPTION
## Description

Commenting `#self-assign` in any issue will let repository members to self-assign that issue to themselves.

:point_right: This reduces chores for repo-maintainer(s).

## Motivation and Context

**Why is this change required? What problem does it solve?**

- :tada: This reduces some administrative overhead and makes it quicker for any contributor to self-assign an issue and start working on it.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)
  - Closes #282 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:


- [x] New feature (non-breaking change which adds core functionality)
- [ ] Documentation (update in the documentation) `Not Sure`
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation. `Not Sure`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*). `NA`
- [ ] I have updated the documentation accordingly. `NA` (Needed??)



## 💡 **Question** 

*Will it be okay if the `CONTRIBUTING.md` file is updated with this feature for issue-self-assigning?*
