### PR TITLE
[BugFix] Fix reshape with non-expanded sizes

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2060,7 +2060,7 @@ class TensorDictBase(MutableMapping):
 
         """
         if len(shape) == 0 and size is not None:
-            return self.view(*size)
+            return self.reshape(*size)
         elif len(shape) == 1 and isinstance(shape[0], (list, tuple, torch.Size)):
             return self.reshape(*shape[0])
         elif not isinstance(shape, torch.Size):

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2062,7 +2062,7 @@ class TensorDictBase(MutableMapping):
         if len(shape) == 0 and size is not None:
             return self.view(*size)
         elif len(shape) == 1 and isinstance(shape[0], (list, tuple, torch.Size)):
-            return self.view(*shape[0])
+            return self.reshape(*shape[0])
         elif not isinstance(shape, torch.Size):
             shape = torch.Size(shape)
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1183,15 +1183,27 @@ class TestTensorDicts(TestTensorDictsBase):
         td_reshape = td.reshape(td.shape)
         assert isinstance(td_reshape, TensorDict)
         assert td_reshape.shape.numel() == td.shape.numel()
+        assert td_reshape.shape == td.shape
         td_reshape = td.reshape(*td.shape)
         assert isinstance(td_reshape, TensorDict)
         assert td_reshape.shape.numel() == td.shape.numel()
+        assert td_reshape.shape == td.shape
+        td_reshape = td.reshape(size=td.shape)
+        assert isinstance(td_reshape, TensorDict)
+        assert td_reshape.shape.numel() == td.shape.numel()
+        assert td_reshape.shape == td.shape
         td_reshape = td.reshape(-1)
         assert isinstance(td_reshape, TensorDict)
         assert td_reshape.shape.numel() == td.shape.numel()
+        assert td_reshape.shape == torch.Size([td.shape.numel()])
         td_reshape = td.reshape((-1,))
         assert isinstance(td_reshape, TensorDict)
         assert td_reshape.shape.numel() == td.shape.numel()
+        assert td_reshape.shape == torch.Size([td.shape.numel()])
+        td_reshape = td.reshape(size=(-1,))
+        assert isinstance(td_reshape, TensorDict)
+        assert td_reshape.shape.numel() == td.shape.numel()
+        assert td_reshape.shape == torch.Size([td.shape.numel()])
 
     def test_view(self, td_name, device):
         if td_name in ("permute_td", "sub_td2"):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1178,6 +1178,21 @@ class TestTensorDicts(TestTensorDictsBase):
         with pytest.raises(RuntimeError):
             pad(td, [0])
 
+    def test_reshape(self, td_name, device):
+        td = getattr(self, td_name)(device)
+        td_reshape = td.reshape(td.shape)
+        assert isinstance(td_reshape, TensorDict)
+        assert td_reshape.shape.numel() == td.shape.numel()
+        td_reshape = td.reshape(*td.shape)
+        assert isinstance(td_reshape, TensorDict)
+        assert td_reshape.shape.numel() == td.shape.numel()
+        td_reshape = td.reshape(-1)
+        assert isinstance(td_reshape, TensorDict)
+        assert td_reshape.shape.numel() == td.shape.numel()
+        td_reshape = td.reshape((-1,))
+        assert isinstance(td_reshape, TensorDict)
+        assert td_reshape.shape.numel() == td.shape.numel()
+
     def test_view(self, td_name, device):
         if td_name in ("permute_td", "sub_td2"):
             pytest.skip("view incompatible with stride / permutation")


### PR DESCRIPTION
## Description

`TensorDict.reshape` calls `TensorDict.view` when the shape is not expanded.