### PR TITLE
[BugFix] make_tensordict batch-size with tuple keys

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2949,13 +2949,14 @@ class TensorDict(TensorDictBase):
                 is_shared=False)
 
         """
+        batch_size_set = [] if batch_size is None else batch_size
         for key, value in list(input_dict.items()):
             if isinstance(value, (dict,)):
-                input_dict[key] = TensorDict(value, [], device=device)
+                input_dict[key] = TensorDict(value, batch_size_set, device=device)
         # _run_checks=False breaks because a tensor may have the same batch-size as the tensordict
         out = cls(
             input_dict,
-            batch_size=[],
+            batch_size=batch_size_set,
             device=device,
         )
         if batch_size is None:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2950,16 +2950,19 @@ class TensorDict(TensorDictBase):
 
         """
         for key, value in list(input_dict.items()):
-            if isinstance(value, (dict, TensorDictBase)):
-                input_dict[key] = TensorDict.from_dict(value)
-        if batch_size is None:
-            batch_size = _find_max_batch_size(input_dict)
+            if isinstance(value, (dict,)):
+                input_dict[key] = TensorDict(value, [], device=device)
         # _run_checks=False breaks because a tensor may have the same batch-size as the tensordict
-        return cls(
+        out = cls(
             input_dict,
-            batch_size=batch_size,
+            batch_size=[],
             device=device,
         )
+        if batch_size is None:
+            _find_max_batch_size(out)
+        else:
+            out.batch_size = batch_size
+        return out
 
     @staticmethod
     def _parse_batch_size(
@@ -4108,14 +4111,17 @@ def pad_sequence(
     if out is None:
         out = TensorDict({}, shape, device=device, _run_checks=False)
         for key in keys:
-            out.set(
-                key,
-                torch.nn.utils.rnn.pad_sequence(
-                    [td.get(key) for td in list_of_tensordicts],
-                    batch_first=batch_first,
-                    padding_value=padding_value,
-                ),
-            )
+            try:
+                out.set(
+                    key,
+                    torch.nn.utils.rnn.pad_sequence(
+                        [td.get(key) for td in list_of_tensordicts],
+                        batch_first=batch_first,
+                        padding_value=padding_value,
+                    ),
+                )
+            except Exception as err:
+                raise RuntimeError(f"pad_sequence failed for key {key}") from err
         return out
     else:
         for key in keys:
@@ -6230,20 +6236,27 @@ def make_tensordict(
     return TensorDict.from_dict(kwargs, batch_size=batch_size, device=device)
 
 
-def _find_max_batch_size(source: TensorDictBase | dict) -> list[int]:
+def _find_max_batch_size(source: TensorDictBase):
+    """Updates a tensordict with its maximium batch size."""
     tensor_data = list(source.values())
+    for val in tensor_data:
+        if is_tensor_collection(val):
+            _find_max_batch_size(val)
     batch_size = []
     if not tensor_data:  # when source is empty
-        return batch_size
+        source.batch_size = batch_size
+        return
     curr_dim = 0
     while True:
         if tensor_data[0].dim() > curr_dim:
             curr_dim_size = tensor_data[0].size(curr_dim)
         else:
-            return batch_size
+            source.batch_size = batch_size
+            return
         for tensor in tensor_data[1:]:
             if tensor.dim() <= curr_dim or tensor.size(curr_dim) != curr_dim_size:
-                return batch_size
+                source.batch_size = batch_size
+                return
         batch_size.append(curr_dim_size)
         curr_dim += 1
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3292,6 +3292,24 @@ class TestMakeTensorDict:
         tensordict = make_tensordict(input_dict)
         assert tensordict.shape == torch.Size([3])
         assert tensordict["a"].shape == torch.Size([3, 4])
+        input_tensordict = TensorDict(
+            {
+                "a": {"b": torch.randn(3, 4), "c": torch.randn(3, 4, 5)},
+                "d": torch.randn(3),
+            },
+            [],
+        )
+        tensordict = make_tensordict(input_tensordict)
+        assert tensordict.shape == torch.Size([3])
+        assert tensordict["a"].shape == torch.Size([3, 4])
+        input_dict = {
+            ("a", "b"): torch.randn(3, 4),
+            ("a", "c"): torch.randn(3, 4, 5),
+            "d": torch.randn(3),
+        }
+        tensordict = make_tensordict(input_dict)
+        assert tensordict.shape == torch.Size([3])
+        assert tensordict["a"].shape == torch.Size([3, 4])
 
 
 def test_update_nested_dict():

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3284,6 +3284,15 @@ class TestMakeTensorDict:
         assert tensordict["b"].device == device
         assert tensordict["c"].device == device
 
+    def test_nested(self):
+        input_dict = {
+            "a": {"b": torch.randn(3, 4), "c": torch.randn(3, 4, 5)},
+            "d": torch.randn(3),
+        }
+        tensordict = make_tensordict(input_dict)
+        assert tensordict.shape == torch.Size([3])
+        assert tensordict["a"].shape == torch.Size([3, 4])
+
 
 def test_update_nested_dict():
     t = TensorDict({"a": {"d": [[[0]] * 3] * 2}}, [2, 3])
@@ -3945,26 +3954,30 @@ class TestErrorMessage:
 
 
 @pytest.mark.parametrize("batch_first", [True, False])
-def test_pad_sequence(
-    batch_first,
-):
+@pytest.mark.parametrize("make_mask", [True, False])
+def test_pad_sequence(batch_first, make_mask):
     list_td = [
-        TensorDict({"a": torch.ones((3,)), ("b", "c"): torch.ones((2, 3))}, []),
-        TensorDict({"a": torch.ones((4,)), ("b", "c"): torch.ones((4, 3))}, []),
+        TensorDict({"a": torch.ones((2,)), ("b", "c"): torch.ones((2, 3))}, [2]),
+        TensorDict({"a": torch.ones((4,)), ("b", "c"): torch.ones((4, 3))}, [4]),
     ]
-    padded_td = pad_sequence(list_td, batch_first=batch_first)
+    padded_td = pad_sequence(list_td, batch_first=batch_first, return_mask=make_mask)
     if batch_first:
-        assert padded_td.shape == torch.Size([2])
+        assert padded_td.shape == torch.Size([2, 4])
         assert padded_td["a"].shape == torch.Size([2, 4])
         assert padded_td["a"][0, -1] == 0
         assert padded_td["b", "c"].shape == torch.Size([2, 4, 3])
         assert padded_td["b", "c"][0, -1, 0] == 0
     else:
-        assert padded_td.shape == torch.Size([])
+        assert padded_td.shape == torch.Size([4, 2])
         assert padded_td["a"].shape == torch.Size([4, 2])
         assert padded_td["a"][-1, 0] == 0
         assert padded_td["b", "c"].shape == torch.Size([4, 2, 3])
         assert padded_td["b", "c"][-1, 0, 0] == 0
+    if make_mask:
+        assert "mask" in padded_td.keys()
+        assert not padded_td["mask"].all()
+    else:
+        assert "mask" not in padded_td.keys()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Ensures that the following methods work the same way:
```python
        input_dict = {
            "a": {"b": torch.randn(3, 4), "c": torch.randn(3, 4, 5)},
            "d": torch.randn(3),
        }
        tensordict = make_tensordict(input_dict)
        input_dict = {
            ("a", "b"): torch.randn(3, 4),
            ("a", "c"): torch.randn(3, 4, 5),
            "d": torch.randn(3),
        }
        tensordict = make_tensordict(input_dict)
```