### PR TITLE
[Feature] h5 compatibility

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - pytest-rerunfailures
     - expecttest
     - coverage
+    - h5py

--- a/.circleci/unittest/linux_stable/scripts/environment.yml
+++ b/.circleci/unittest/linux_stable/scripts/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - pytest-rerunfailures
     - expecttest
     - coverage
+    - h5py

--- a/.circleci/unittest/linux_torchrec/scripts/environment.yml
+++ b/.circleci/unittest/linux_torchrec/scripts/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - pytest-rerunfailures
     - expecttest
     - coverage
+    - h5py

--- a/docs/source/reference/tensordict.rst
+++ b/docs/source/reference/tensordict.rst
@@ -15,6 +15,7 @@ regular pytorch tensors.
     TensorDict
     SubTensorDict
     LazyStackedTensorDict
+    PersistentTensorDict
 
 Memory-mapped tensors
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ def _main(argv):
         extras_require={
             "tests": ["pytest", "pyyaml", "pytest-instafail", "pytest-rerunfailures"],
             "checkpointing": ["torchsnapshot-nightly"],
+            "h5": ["h5py>=3.8"],
         },
         zip_safe=False,
         classifiers=[

--- a/tensordict/__init__.py
+++ b/tensordict/__init__.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from tensordict.memmap import MemmapTensor, set_transfer_ownership
+from tensordict.persistent import PersistentTensorDict
 from tensordict.tensordict import (
     is_batchedtensor,
     is_memmap,
@@ -36,4 +37,5 @@ __all__ = [
     "is_batchedtensor",
     "is_tensor_collection",
     "pad",
+    "PersistentTensorDict",
 ]

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -547,7 +547,11 @@ MemmapTensor of shape {self.shape}."""
         if not hasattr(self, "file"):
             return
         # for some reason Memmap keeps 2 refs to the file
-        if HAS_OWNERSHIP.get(self.filename, False) and getrefcount(self.file) <= 2:
+        if (
+            HAS_OWNERSHIP
+            and HAS_OWNERSHIP.get(self.filename, False)
+            and getrefcount(self.file) <= 2
+        ):
             if isinstance(self.file, tempfile._TemporaryFileWrapper) and os.path.isfile(
                 self.filename
             ):

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Persistent tensordicts (H5 and others)."""
+
+import h5py
+import torch
+from tensordict.tensordict import NO_DEFAULT, TensorDictBase
+
+
+class PersistentTensorDict(TensorDictBase):
+    """Persistent TensorDict implementation.
+
+    Args:
+        batch_size (torch.Size or compatible): the tensordict batch size.
+        filename (str, optional):
+        group (h5py.Group, optional):
+        mode (str, optional):
+        backend (str, optional):
+        device (torch.device or compatible, optional):
+
+    """
+
+    def __init__(
+        self,
+        *,
+        batch_size,
+        filename=None,
+        group=None,
+        mode="r",
+        backend="h5",
+        device=None,
+    ):
+        super().__init__()
+        if backend != "h5":
+            raise NotImplementedError
+        if filename is not None and group is None:
+            self.file = h5py.File(filename, mode)
+        elif group is not None:
+            self.file = group
+        else:
+            raise RuntimeError
+        self._batch_size = torch.Size(batch_size)
+        self._device = device
+        self._is_shared = False
+        self._check_batch_size(self._batch_size)
+
+    def _check_batch_size(self, batch_size) -> None:
+        for key in self.keys(True, True):
+            if isinstance(key, str):
+                pass
+            elif len(key) == 1:
+                key = key[0]
+            else:
+                key = "/".join(key)
+            size = self.file[key].shape
+            if torch.Size(size[: len(batch_size)]) != batch_size:
+                raise RuntimeError(
+                    f"batch size and array size mismatch: array.shape={size}, batch_size={batch_size}."
+                )
+
+    def get(self, key, default=NO_DEFAULT):
+        if isinstance(key, tuple):
+            key = "/".join(key)
+        array = self.file[key]
+        print(key)
+        if isinstance(array, (h5py.Dataset,)):
+            if self.device is not None:
+                device = self.device
+            else:
+                device = torch.device("cpu")
+            return torch.as_tensor(array, device=device)
+        else:
+            return PersistentTensorDict(group=array, batch_size=self.batch_size)
+
+    def __getitem__(self, item):
+        if isinstance(item, str) or (
+            isinstance(item, tuple) and all(isinstance(val, str) for val in item)
+        ):
+            return self.get(item)
+        return self.get_sub_tensordict(item)
+
+    def keys(self, include_nested=False, leaves_only=False):
+        if include_nested:
+            if leaves_only:
+                for key in self.file.visit(lambda key: key.split("/")):
+                    if isinstance(self.file[key], (h5py.Dataset,)):
+                        yield key
+            else:
+                yield from self.file.visit(lambda key: key.split("/"))
+        else:
+            yield from self.file.keys()
+
+    def _change_batch_size(self):
+        raise NotImplementedError
+
+    def _stack_onto_(self):
+        raise NotImplementedError
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    def contiguous(self):
+        raise NotImplementedError
+
+    def del_(self):
+        raise NotImplementedError
+
+    def detach_(self):
+        raise NotImplementedError
+
+    @property
+    def device(self):
+        return self._device
+
+    def entry_class(self):
+        raise NotImplementedError
+
+    def is_contiguous(self):
+        raise NotImplementedError
+
+    def masked_fill(self):
+        raise NotImplementedError
+
+    def masked_fill_(self):
+        raise NotImplementedError
+
+    def memmap_(self):
+        raise NotImplementedError
+
+    def pin_memory(self):
+        raise NotImplementedError
+
+    def rename_key(self):
+        raise NotImplementedError
+
+    def select(self):
+        raise NotImplementedError
+
+    def set_(self):
+        raise NotImplementedError
+
+    def set_at_(self):
+        raise NotImplementedError
+
+    def share_memory_(self):
+        raise NotImplementedError
+
+    def to(self):
+        raise NotImplementedError

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -370,7 +370,7 @@ class PersistentTensorDict(TensorDictBase):
 
     def _stack_onto_(
         self, key: str, list_item: list[CompatibleType], dim: int
-    ) -> TensorDict:
+    ) -> PersistentTensorDict:
         stacked = torch.stack(list_item, dim=dim)
         self.set_(key, stacked)
         return self
@@ -425,7 +425,7 @@ class PersistentTensorDict(TensorDictBase):
 
     def memmap_(
         self, prefix: str | None = None, copy_existing: bool = False
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
         raise RuntimeError(
             "Cannot build a memmap TensorDict in-place from a PersistentTensorDict. Use `td.memmap()` instead."
         )
@@ -507,7 +507,7 @@ class PersistentTensorDict(TensorDictBase):
 
     def rename_key_(
         self, old_key: str, new_key: str, safe: bool = False
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
         old_key = self._process_key(old_key)
         new_key = self._process_key(new_key)
         try:
@@ -539,13 +539,13 @@ class PersistentTensorDict(TensorDictBase):
 
     def select(
         self, *keys: str, inplace: bool = False, strict: bool = True
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
         raise NotImplementedError(
             "Cannot call select on a PersistentTensorDict. "
             "Create a regular tensordict first using the `to_tensordict` method."
         )
 
-    def exclude(self, *keys: str, inplace: bool = False) -> TensorDictBase:
+    def exclude(self, *keys: str, inplace: bool = False) -> PersistentTensorDict:
         raise NotImplementedError(
             "Cannot call exclude on a PersistentTensorDict. "
             "Create a regular tensordict first using the `to_tensordict` method."
@@ -557,7 +557,7 @@ class PersistentTensorDict(TensorDictBase):
             "Create a regular tensordict first using the `to_tensordict` method."
         )
 
-    def to(self, dest: DeviceType | torch.Size | type, **kwargs: Any) -> TensorDictBase:
+    def to(self, dest: DeviceType | torch.Size | type, **kwargs: Any) -> PersistentTensorDict:
         if isinstance(dest, type) and issubclass(dest, TensorDictBase):
             if isinstance(self, dest):
                 return self
@@ -614,7 +614,7 @@ class PersistentTensorDict(TensorDictBase):
 
     def _set(
         self, key: str, value, inplace: bool = False, idx=None, check_shape=True
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
         # although it is expected that _set will run as few tests as possible,
         # we must do the value transformation here as _set can be called by other
         # methods from TensorDictBase.

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -4,11 +4,88 @@
 # LICENSE file in the root directory of this source tree.
 
 """Persistent tensordicts (H5 and others)."""
+from __future__ import annotations
+
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any
 
 import h5py
+import numpy as np
 import torch
-from tensordict.tensordict import CompatibleType, NO_DEFAULT, TensorDictBase
-from tensordict.utils import IndexType
+
+from tensordict import MemmapTensor
+from tensordict.tensordict import (
+    _get_leaf_tensordict,
+    _TensorDictKeysView,
+    CompatibleType,
+    is_tensor_collection,
+    NO_DEFAULT,
+    TensorDict,
+    TensorDictBase,
+)
+from tensordict.utils import (
+    _shape,
+    DeviceType,
+    expand_right,
+    IndexType,
+    NestedKey,
+    NUMPY_TO_TORCH_DTYPE_DICT,
+)
+
+
+class _Visitor:
+    def __init__(self, fun=None):
+        self.elts = []
+        self.fun = fun
+
+    def __call__(self, name):
+        self.elts.append(name)
+
+    def __iter__(self):
+        if self.fun is None:
+            yield from self.elts
+        else:
+            for elt in self.elts:
+                yield self.fun(elt)
+
+
+class _PersistentTDKeysView(_TensorDictKeysView):
+    def __init__(self, persistent_td, include_nested, leaves_only):
+        self.include_nested = include_nested
+        self.leaves_only = leaves_only
+        self.persistent_td = persistent_td
+
+    def __iter__(self):
+        if self.include_nested:
+            visitor = _Visitor(lambda key: tuple(key.split("/")))
+            self.persistent_td.file.visit(visitor)
+            if self.leaves_only:
+                for key in visitor:
+                    if self.persistent_td._get_metadata(key)["array"]:
+                        yield key
+            else:
+                yield from visitor
+        else:
+            yield from self.persistent_td.file.keys()
+
+    def __len__(self):
+        counter = 0
+        for _ in self:
+            counter += 1
+        return counter
+
+    def __contains__(self, key):
+        if isinstance(key, tuple) and len(key) == 1:
+            key = key[0]
+        for a_key in self:
+            if isinstance(a_key, tuple) and len(a_key) == 1:
+                a_key = a_key[0]
+            if key == a_key:
+                return True
+        else:
+            return False
 
 
 class PersistentTensorDict(TensorDictBase):
@@ -16,11 +93,12 @@ class PersistentTensorDict(TensorDictBase):
 
     Args:
         batch_size (torch.Size or compatible): the tensordict batch size.
-        filename (str, optional):
-        group (h5py.Group, optional):
-        mode (str, optional):
-        backend (str, optional):
-        device (torch.device or compatible, optional):
+        filename (str, optional): the path to the h5 file. Exclusive with ``group``.
+        group (h5py.Group, optional): a file or a group that contains data. Exclusive with ``filename``.
+        mode (str, optional): Reading mode. Defaults to ``"r"``.
+        backend (str, optional): storage backend. Currently only ``"h5"`` is supported.
+        device (torch.device or compatible, optional): device of the tensordict.
+            Defaults to ``None`` (ie. default PyTorch device).
 
     """
 
@@ -35,6 +113,8 @@ class PersistentTensorDict(TensorDictBase):
         device=None,
     ):
         super().__init__()
+        self.filename = filename
+        self.mode = mode
         if backend != "h5":
             raise NotImplementedError
         if filename is not None and group is None:
@@ -42,131 +122,637 @@ class PersistentTensorDict(TensorDictBase):
         elif group is not None:
             self.file = group
         else:
-            raise RuntimeError
+            raise RuntimeError(
+                f"Either group or filename must be provided, and not both. Got group={group} and filename={filename}."
+            )
         self._batch_size = torch.Size(batch_size)
         self._device = device
         self._is_shared = False
+        self._is_memmap = False
+
+        # we use this to allow nested tensordicts to have a different batch-size
+        self._nested_tensordicts = {}
+
+        # this must be kept last
         self._check_batch_size(self._batch_size)
+
+    @classmethod
+    def from_h5(cls, filename, mode="r"):
+        """Creates a PersistentTensorDict from a h5 file.
+
+        This function will automatically determine the batch-size for each nested
+        tensordict.
+
+        Args:
+            filename (str): the path to the h5 file.
+            mode (str, optional): reading mode. Defaults to ``"r"``.
+        """
+        out = cls(filename=filename, mode=mode, batch_size=[])
+        # determine batch size
+        _find_max_batch_size(out)
+        return out
+
+    @classmethod
+    def from_dict(cls, input_dict, filename, batch_size=None, device=None):
+        """Converts a dictionary or a TensorDict to a h5 file.
+
+        Args:
+            input_dict (dict, TensorDict or compatible): data to be stored as h5.
+            filename (str or path): path to the h5 file.
+            batch_size (tensordict batch-size, optional): if provided, batch size
+                of the tensordict. If not, the batch size will be gathered from the
+                input structure (if present) or determined automatically.
+            device (torch.device or compatible, optional): the device where to
+                expect the tensor once they are returned. Defaults to ``None``
+                (on cpu by default).
+
+        Returns:
+            A :class:`PersitentTensorDict` instance linked to the newly created file.
+
+        """
+        file = h5py.File(filename, "w")
+        _has_batch_size = True
+        if batch_size is None:
+            if is_tensor_collection(input_dict):
+                batch_size = input_dict.batch_size
+            else:
+                _has_batch_size = False
+                batch_size = torch.Size([])
+
+        # let's make a tensordict first
+        out = cls(group=file, batch_size=batch_size, device=device)
+        if is_tensor_collection(input_dict):
+            out.update(input_dict)
+        else:
+            out.update(TensorDict(input_dict, batch_size=batch_size))
+        if not _has_batch_size:
+            _find_max_batch_size(out)
+        return out
+
+    def _process_key(self, key):
+        if isinstance(key, str):
+            return key
+        else:
+            return "/".join(key)
 
     def _check_batch_size(self, batch_size) -> None:
         for key in self.keys(True, True):
-            if isinstance(key, str):
-                pass
-            elif len(key) == 1:
-                key = key[0]
-            else:
-                key = "/".join(key)
+            key = self._process_key(key)
             size = self.file[key].shape
             if torch.Size(size[: len(batch_size)]) != batch_size:
-                raise RuntimeError(
+                raise ValueError(
                     f"batch size and array size mismatch: array.shape={size}, batch_size={batch_size}."
                 )
 
+    def _get_array(self, key, default=NO_DEFAULT):
+        try:
+            key = self._process_key(key)
+            array = self.file[key]
+            return array
+        except KeyError:
+            if default is not NO_DEFAULT:
+                return default
+            raise KeyError(f"key {key} not found in PersistentTensorDict {self}")
+
     def get(self, key, default=NO_DEFAULT):
-        if isinstance(key, tuple):
-            key = "/".join(key)
-        array = self.file[key]
+        array = self._get_array(key, default)
         if isinstance(array, (h5py.Dataset,)):
             if self.device is not None:
                 device = self.device
             else:
                 device = torch.device("cpu")
+            # we convert to an array first to avoid "Creating a tensor from a list of numpy.ndarrays is extremely slow."
+            array = array[:]
             return torch.as_tensor(array, device=device)
+        elif array is not default:
+            out = self._nested_tensordicts.get(key, None)
+            if out is None:
+                out = self._nested_tensordicts[key] = PersistentTensorDict(
+                    group=array, batch_size=self.batch_size
+                )
+            return out
         else:
-            return PersistentTensorDict(group=array, batch_size=self.batch_size)
+            return default
 
     def get_at(
         self, key: str, idx: IndexType, default: CompatibleType = NO_DEFAULT
     ) -> CompatibleType:
-        if isinstance(key, tuple):
-            key = "/".join(key)
-        array = self.file[key]
+        array = self._get_array(key, default)
         if isinstance(array, (h5py.Dataset,)):
             if self.device is not None:
                 device = self.device
             else:
                 device = torch.device("cpu")
             # indexing must be done before converting to tensor.
+            idx = self._process_index(idx, array)
             # `get_at` is there to save us.
-            return torch.as_tensor(array[idx], device=device)
+            try:
+                return torch.as_tensor(array[idx], device=device)
+            except TypeError as err:
+                if "Boolean indexing array has incompatible shape" in str(err):
+                    # Known bug in h5py: cannot broadcast boolean mask on the right as
+                    # done in np and torch. Therefore we put a performance warning
+                    # and convert to torch tensor first.
+                    warnings.warn(
+                        "Indexing an h5py.Dataset object with a boolean mask "
+                        "that needs broadcasting does not work directly. "
+                        "tensordict will cast the entire array in memory and index it using the mask. "
+                        "This is suboptimal and may lead to performance issue."
+                    )
+                    return torch.as_tensor(array, device=device)[idx]
+                else:
+                    raise err
         else:
-            return PersistentTensorDict(
-                group=array, batch_size=self.batch_size
-            ).get_sub_tensordict(idx)
+            out = self._nested_tensordicts.get(key, None)
+            if out is None:
+                out = self._nested_tensordicts[key] = PersistentTensorDict(
+                    group=array, batch_size=self.batch_size
+                )
+            return out.get_sub_tensordict(idx)
+
+    def _get_metadata(self, key):
+        """Gets the metadata for an entry.
+
+        This method avoids creating a tensor from scratch, and just reads the metadata of the array.
+        """
+        key = self._process_key(key)
+        array = self.file[key]
+        if isinstance(array, (h5py.Dataset,)):
+            shape = torch.Size(array.shape)
+            return {
+                "dtype": NUMPY_TO_TORCH_DTYPE_DICT[array.dtype],
+                "shape": shape,
+                "dim": len(shape),
+                "array": True,
+            }
+        else:
+            shape = self.get(key).shape
+            return {
+                "dtype": None,
+                "shape": shape,
+                "dim": len(shape),
+                "array": False,
+            }
+
+    @classmethod
+    def _process_index(cls, idx, array=None):
+        if isinstance(idx, tuple):
+            return tuple(cls._process_index(_idx, array) for _idx in idx)
+        if isinstance(idx, torch.Tensor):
+            # if idx.dtype == torch.bool:
+            #     # expand to the right
+            #     print(idx.shape, array.shape, idx.sum())
+            #     idx = expand_right(idx, array.shape)
+            return idx.cpu().detach().numpy()
+        if isinstance(idx, list):
+            return np.asarray(idx)
+        return idx
 
     def __getitem__(self, item):
         if isinstance(item, str) or (
             isinstance(item, tuple) and all(isinstance(val, str) for val in item)
         ):
             return self.get(item)
+        if isinstance(item, list):
+            # convert to tensor
+            item = torch.tensor(item)
         return self.get_sub_tensordict(item)
 
-    def keys(self, include_nested=False, leaves_only=False):
-        if include_nested:
-            if leaves_only:
-                for key in self.file.visit(lambda key: key.split("/")):
-                    if isinstance(self.file[key], (h5py.Dataset,)):
-                        yield key
-            else:
-                yield from self.file.visit(lambda key: key.split("/"))
-        else:
-            yield from self.file.keys()
+    __getitems__ = __getitem__
 
-    def _change_batch_size(self):
+    def __setitem__(self, item, value):
+        if isinstance(item, str) or (
+            isinstance(item, tuple) and all(isinstance(val, str) for val in item)
+        ):
+            return self.set(item, value, inplace=True)
+
+        if isinstance(item, list):
+            # convert to tensor
+            item = torch.tensor(item)
+        return self.get_sub_tensordict(item).update(value, inplace=True)
+
+    def keys(
+        self, include_nested: bool = False, leaves_only: bool = False
+    ) -> _PersistentTDKeysView:
+        return _PersistentTDKeysView(
+            persistent_td=self,
+            include_nested=include_nested,
+            leaves_only=leaves_only,
+        )
+
+    def _items_metadata(self, include_nested=False, leaves_only=False):
+        """Iterates over the metadata of the PersistentTensorDict."""
+        for key in self.keys(include_nested, leaves_only):
+            yield (key, self._get_metadata(key))
+
+    def _values_metadata(self, include_nested=False, leaves_only=False):
+        """Iterates over the metadata of the PersistentTensorDict."""
+        for key in self.keys(include_nested, leaves_only):
+            yield self._get_metadata(key)
+
+    def _change_batch_size(self, value):
         raise NotImplementedError
 
-    def _stack_onto_(self):
-        raise NotImplementedError
+    def _stack_onto_(
+        self, key: str, list_item: list[CompatibleType], dim: int
+    ) -> TensorDict:
+        stacked = torch.stack(list_item, dim=dim)
+        self.set_(key, stacked)
+        return self
 
     @property
     def batch_size(self):
         return self._batch_size
 
-    def contiguous(self):
-        raise NotImplementedError
+    @batch_size.setter
+    def batch_size(self, value):
+        _batch_size = self._batch_size
+        try:
+            self._batch_size = torch.Size(value)
+            self._check_batch_size(self._batch_size)
+        except ValueError:
+            self._batch_size = _batch_size
 
-    def del_(self):
-        raise NotImplementedError
+    def contiguous(self):
+        """Materializes a PersistentTensorDict on a regular TensorDict."""
+        return self.to_tensordict()
+
+    def del_(self, key):
+        del self.file[key]
+        return self
 
     def detach_(self):
-        raise NotImplementedError
+        # PersistentTensorDict do not carry gradients. This is a no-op
+        return self
 
     @property
     def device(self):
         return self._device
 
-    def entry_class(self):
-        raise NotImplementedError
+    def entry_class(self, key: NestedKey) -> type:
+        entry_class = self._get_metadata(key)
+        if entry_class["array"]:
+            return torch.Tensor
+        else:
+            return PersistentTensorDict
 
     def is_contiguous(self):
-        raise NotImplementedError
+        return False
 
-    def masked_fill(self):
-        raise NotImplementedError
+    def masked_fill(self, mask, value):
+        return self.to_tensordict().masked_fill(mask, value)
 
-    def masked_fill_(self):
-        raise NotImplementedError
+    def masked_fill_(self, mask, value):
+        for key in self.keys(True, True):
+            array = self._get_array(key)
+            array[expand_right(mask, array.shape).cpu().numpy()] = value
+        return self
 
-    def memmap_(self):
-        raise NotImplementedError
+    def memmap_(
+        self, prefix: str | None = None, copy_existing: bool = False
+    ) -> TensorDictBase:
+        raise RuntimeError(
+            "Cannot build a memmap TensorDict in-place from a PersistentTensorDict. Use `td.memmap()` instead."
+        )
+
+    def memmap(
+        self,
+        prefix: str | None = None,
+    ) -> TensorDict:
+        """Converts the PersistentTensorDict to a memmap equivalent."""
+        mm_like = self.memmap_like(prefix)
+        for key in self.keys(True, True):
+            mm_val = mm_like[key]
+            mm_val._memmap_array[:] = self._get_array(key)
+        return mm_like
+
+    def memmap_like(self, prefix: str | None = None) -> TensorDictBase:
+        # re-implements this to make it faster using the meta-data
+        if prefix is not None:
+            prefix = Path(prefix)
+            if not prefix.exists():
+                prefix.mkdir(exist_ok=True)
+            torch.save(
+                {"batch_size": self.batch_size, "device": self.device},
+                prefix / "meta.pt",
+            )
+        if not self.keys():
+            raise Exception(
+                "memmap_like() must be called when the TensorDict is (partially) "
+                "populated. Set a tensor first."
+            )
+        tensordict = TensorDict({}, self.batch_size, device=self.device)
+        for key, value in self._items_metadata():
+            if not value["array"]:
+                value = self.get(key)
+                if prefix is not None:
+                    # ensure subdirectory exists
+                    (prefix / key).mkdir(exist_ok=True)
+                    tensordict[key] = value.memmap_like(
+                        prefix=prefix / key,
+                    )
+                    torch.save(
+                        {"batch_size": value.batch_size, "device": value.device},
+                        prefix / key / "meta.pt",
+                    )
+                else:
+                    tensordict[key] = value.memmap_like()
+                continue
+            else:
+                tensordict[key] = MemmapTensor(
+                    value["shape"],
+                    device="cpu",
+                    dtype=value["dtype"],
+                    filename=str(prefix / f"{key}.memmap")
+                    if prefix is not None
+                    else None,
+                )
+            if prefix is not None:
+                torch.save(
+                    {
+                        "shape": value["shape"],
+                        "device": torch.device("cpu"),
+                        "dtype": value["dtype"],
+                    },
+                    prefix / f"{key}.meta.pt",
+                )
+        tensordict._is_memmap = True
+        tensordict.lock_()
+        return tensordict
 
     def pin_memory(self):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"cannot call pin_memory on {self.__class__.__name__}."
+        )
 
-    def rename_key(self):
-        raise NotImplementedError
+    def rename_key_(
+        self, old_key: str, new_key: str, safe: bool = False
+    ) -> TensorDictBase:
+        old_key = self._process_key(old_key)
+        new_key = self._process_key(new_key)
+        try:
+            self.file.move(old_key, new_key)
+        except ValueError as err:
+            raise KeyError(f"key {new_key} already present in TensorDict.") from err
+        return self
 
-    def select(self):
-        raise NotImplementedError
+    def select(
+        self, *keys: str, inplace: bool = False, strict: bool = True
+    ) -> TensorDictBase:
+        raise NotImplementedError(
+            "Cannot call select on a PersistentTensorDict. "
+            "Create a regular tensordict first using the `to_tensordict` method."
+        )
 
-    def set_(self):
-        raise NotImplementedError
-
-    def set_at_(self):
-        raise NotImplementedError
+    def exclude(self, *keys: str, inplace: bool = False) -> TensorDictBase:
+        raise NotImplementedError(
+            "Cannot call exclude on a PersistentTensorDict. "
+            "Create a regular tensordict first using the `to_tensordict` method."
+        )
 
     def share_memory_(self):
-        raise NotImplementedError
+        raise NotImplementedError(
+            "Cannot call share_memory_ on a PersistentTensorDict. "
+            "Create a regular tensordict first using the `to_tensordict` method."
+        )
 
-    def to(self):
-        raise NotImplementedError
+    def to(self, dest: DeviceType | torch.Size | type, **kwargs: Any) -> TensorDictBase:
+        if isinstance(dest, type) and issubclass(dest, TensorDictBase):
+            if isinstance(self, dest):
+                return self
+            td = dest(source=self, **kwargs)
+            return td
+        elif isinstance(dest, (torch.device, str, int)):
+            # must be device
+            dest = torch.device(dest)
+            if self.device is not None and dest == self.device:
+                return self
+            self._device = dest
+            return self
+        elif isinstance(dest, torch.Size):
+            self.batch_size = dest
+            return self
+        else:
+            raise NotImplementedError(
+                f"dest must be a string, torch.device or a TensorDict "
+                f"instance, {dest} not allowed"
+            )
+
+    def _validate_value(self, value, check_shape=True):
+        if hasattr(value, "requires_grad") and value.requires_grad:
+            raise RuntimeError("Cannot set a tensor that has requires_grad=True.")
+        if isinstance(value, torch.Tensor):
+            out = value.cpu().detach().numpy()
+        elif isinstance(value, MemmapTensor):
+            out = value._memmap_array
+        elif isinstance(value, dict):
+            out = TensorDict(value, [])
+        elif is_tensor_collection(value):
+            out = value
+        elif isinstance(value, (np.ndarray,)):
+            out = value
+        else:
+            raise NotImplementedError(
+                f"Cannot set values of type {value} in a PersistentTensorDict."
+            )
+        if check_shape and _shape(out)[: self.batch_dims] != self.batch_size:
+            # if TensorDict, let's try to map it to the desired shape
+            if is_tensor_collection(out):
+                out = out.clone(recurse=False)
+                out.batch_size = self.batch_size
+            else:
+                raise RuntimeError(
+                    f"batch dimension mismatch, got self.batch_size"
+                    f"={self.batch_size} and value.shape[:self.batch_dims]"
+                    f"={_shape(out)[: self.batch_dims]} with value {out}"
+                )
+        return out
+
+    def _set(self, key: str, value, inplace: bool = False, idx=None) -> TensorDictBase:
+        if not inplace and idx is not None:
+            raise RuntimeError("Cannot pass an index to _set when inplace=False.")
+        # shortcut set if we're placing a tensordict
+        if is_tensor_collection(value):
+            if isinstance(key, tuple):
+                key, subkey = key[0], key[1:]
+            else:
+                key, subkey = key, []
+            target_td = self.get(key, default=None)
+            if target_td is None:
+                self.file.create_group(key)
+                target_td = self.get(key)
+            elif not is_tensor_collection(target_td):
+                raise RuntimeError(
+                    f"cannot set a tensor collection in place of a non-tensor collection in {self.__class__.__name__}. "
+                    f"Got self.get({key})={target_td} and value={value}."
+                )
+            if idx is None:
+                if len(subkey):
+                    target_td.set(subkey, value, inplace=inplace)
+                else:
+                    target_td.update(value, inplace=inplace)
+            else:
+                if len(subkey):
+                    target_td.set_at_(subkey, value, idx=idx)
+                else:
+                    target_td.update_at_(value, idx=idx)
+
+            return self
+
+        if inplace:
+            array = self.file[key]
+            if idx is None:
+                idx = ()
+            else:
+                idx = self._process_index(idx, array)
+
+            try:
+                array[idx] = value
+            except TypeError as err:
+                if "Boolean indexing array has incompatible shape" in str(err):
+                    # Known bug in h5py: cannot broadcast boolean mask on the right as
+                    # done in np and torch. Therefore we put a performance warning
+                    # and convert to torch tensor first.
+                    warnings.warn(
+                        "Indexing an h5py.Dataset object with a boolean mask "
+                        "that needs broadcasting does not work directly. "
+                        "tensordict will cast the entire array in memory and index it using the mask. "
+                        "This is suboptimal and may lead to performance issue."
+                    )
+                    idx = tuple(
+                        expand_right(torch.as_tensor(_idx), array.shape).numpy()
+                        if _idx.dtype == np.dtype("bool")
+                        else _idx
+                        for _idx in idx
+                    )
+                    array[idx] = torch.as_tensor(value)
+                else:
+                    raise err
+
+        else:
+            try:
+                self.file[key] = value
+            except OSError as err:
+                if "name already exists" in str(err):
+                    warnings.warn(
+                        "Replacing an array with another one is inefficient. Consider using different names or populating in-place using `inplace=True`."
+                    )
+                    del self.file[key]
+                    self.file[key] = value
+        return self
+
+    def set(
+        self,
+        key: NestedKey,
+        value: dict[str, CompatibleType] | CompatibleType,
+        inplace: bool = False,
+    ) -> TensorDictBase:
+        value = self._validate_value(value)
+
+        key = self._process_key(key)
+
+        visitor = _Visitor()
+        self.file.visit(visitor)
+        inplace = inplace and key in visitor
+        if self.is_locked and not inplace:
+            raise RuntimeError(TensorDictBase.LOCK_ERROR)
+
+        # not calling set_ to avoid re-validate key
+        return self._set(key, value, inplace=inplace)
+
+    def set_(
+        self, key: str, value: dict[str, CompatibleType] | CompatibleType
+    ) -> TensorDictBase:
+        visitor = _Visitor()
+        self.file.visit(visitor)
+        key = self._process_key(key)
+        if key not in visitor:
+            raise KeyError(f'key "{key}" not found in h5.')
+        # we don't need to check shape as the modification will be done
+        # in-place and an error will be thrown anyway if shapes don't match
+        value = self._validate_value(value, check_shape=False)
+        return self._set(key, value, inplace=True)
+
+    def set_at_(
+        self,
+        key: NestedKey,
+        value: dict[str, CompatibleType] | CompatibleType,
+        idx: IndexType,
+    ) -> TensorDictBase:
+        visitor = _Visitor()
+        self.file.visit(visitor)
+        key = self._process_key(key)
+        if key not in visitor:
+            raise KeyError(f'key "{key}" not found in h5.')
+        # we don't need to check shape as the modification will be done
+        # in-place and an error will be thrown anyway if shapes don't match
+        value = self._validate_value(value, check_shape=False)
+        return self._set(key, value, inplace=True, idx=idx)
+
+    def clone(self, recurse: bool = True, newfile=None) -> TensorDictBase:
+        if recurse:
+            # this should clone the h5 to a new location indicated by newfile
+            if newfile is None:
+                warnings.warn(
+                    "A destination should be provided when cloning a "
+                    "PersistentTensorDict. A temporary file will be used "
+                    "instead. Use `recurse=False` to keep track of the original data "
+                    "with a new PersistentTensorDict instance."
+                )
+                tmpfile = tempfile.NamedTemporaryFile()
+                newfile = tmpfile.name
+            f_dest = h5py.File(newfile, "w")
+            f_src = self.file
+            for key in self.keys(True, True):
+                key = self._process_key(key)
+                f_dest.create_dataset(key, data=f_src[key])
+                # f_src.copy(f_src[key],  f_dest[key], "DataSet")
+            # create a non-recursive copy and update the file
+            clone = self.clone(False)
+            clone.file = f_src
+            clone.filename = newfile
+            return clone
+        else:
+            nested_tds = {
+                key: td.clone(False) for key, td in self._nested_tensordicts.items()
+            }
+            filename = self.filename
+            file = self.file if filename is None else None
+            clone = PersistentTensorDict(
+                filename=filename,
+                group=file,
+                mode=self.mode,
+                backend="h5",
+                device=self.device,
+                batch_size=self.batch_size,
+            )
+            clone._nested_tensordicts = nested_tds
+            return clone
+
+
+def _find_max_batch_size(source: PersistentTensorDict):
+    """Updates a tensordict with its maximium batch size."""
+    tensor_data = list(source._items_metadata())
+    for key, val in tensor_data:
+        if not val["array"]:
+            _find_max_batch_size(source.get(key))
+
+    batch_size = []
+    if not tensor_data:  # when source is empty
+        source.batch_size = batch_size
+        return
+
+    curr_dim = 0
+    tensor_data = list(source._values_metadata())
+    while True:
+        if tensor_data[0]["dim"] > curr_dim:
+            curr_dim_size = tensor_data[0]["shape"][curr_dim]
+        else:
+            source.batch_size = batch_size
+            return
+        for tensor in tensor_data[1:]:
+            if tensor["dim"] <= curr_dim or tensor["shape"][curr_dim] != curr_dim_size:
+                source.batch_size = batch_size
+                return
+        batch_size.append(curr_dim_size)
+        curr_dim += 1

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -497,7 +497,7 @@ class PersistentTensorDict(TensorDictBase):
 
     def pin_memory(self):
         if self.device.type == "cuda":
-            raise RuntimeError("Cannot call pin_memory on tensordict stored on cuda.")
+            raise RuntimeError("cannot pin memory on a tensordict stored on cuda.")
         out = self.clone(False)
         out._pin_mem = True
         out._nested_tensordicts = {

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -299,8 +299,7 @@ class PersistentTensorDict(TensorDictBase):
 
         This method avoids creating a tensor from scratch, and just reads the metadata of the array.
         """
-        key = self._process_key(key)
-        array = self.file[key]
+        array = self._get_array(key)
         if isinstance(array, (h5py.Dataset,)):
             shape = torch.Size(array.shape)
             return {
@@ -704,7 +703,7 @@ class PersistentTensorDict(TensorDictBase):
                         "Replacing an array with another one is inefficient. Consider using different names or populating in-place using `inplace=True`."
                     )
                     del self.file[key]
-                    self.file[key] = value
+                    self.file.create_dataset(key, data=value, **self.kwargs)
         return self
 
     def set(

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -570,6 +570,8 @@ class PersistentTensorDict(TensorDictBase):
                 return self
             out = self.clone(False)
             out._device = dest
+            for key, nested in list(out._nested_tensordicts.items()):
+                out._nested_tensordicts[key] = nested.to(dest)
             return out
         elif isinstance(dest, torch.Size):
             self.batch_size = dest
@@ -694,7 +696,7 @@ class PersistentTensorDict(TensorDictBase):
         key: NestedKey,
         value: dict[str, CompatibleType] | CompatibleType,
         inplace: bool = False,
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
 
         key = self._process_key(key)
 
@@ -709,7 +711,7 @@ class PersistentTensorDict(TensorDictBase):
 
     def set_(
         self, key: str, value: dict[str, CompatibleType] | CompatibleType
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
         visitor = _Visitor()
         self.file.visit(visitor)
         key = self._process_key(key)
@@ -724,7 +726,7 @@ class PersistentTensorDict(TensorDictBase):
         key: NestedKey,
         value: dict[str, CompatibleType] | CompatibleType,
         idx: IndexType,
-    ) -> TensorDictBase:
+    ) -> PersistentTensorDict:
         visitor = _Visitor()
         self.file.visit(visitor)
         key = self._process_key(key)
@@ -734,7 +736,7 @@ class PersistentTensorDict(TensorDictBase):
         # in-place and an error will be thrown anyway if shapes don't match
         return self._set(key, value, inplace=True, idx=idx, check_shape=False)
 
-    def clone(self, recurse: bool = True, newfile=None) -> TensorDictBase:
+    def clone(self, recurse: bool = True, newfile=None) -> PersistentTensorDict:
         if recurse:
             # this should clone the h5 to a new location indicated by newfile
             if newfile is None:

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -513,14 +513,9 @@ class PersistentTensorDict(TensorDictBase):
             self
 
         """
-        target_class = self.entry_class(key)
-        if is_tensor_collection(target_class):
-            tensordict = self.get(key)
-            tensordict.apply_(lambda x: x.fill_(value))
-            self._set(key, tensordict, inplace=True)
-        else:
-            tensor = torch.full_like(self.get(key), value).cpu().numpy()
-            self._set(key, tensor, inplace=True)
+        for key in self.keys(True, True):
+            array = self._get_array(key)
+            array[:] = 0
         return self
 
     def select(

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -230,7 +230,9 @@ class PersistentTensorDict(TensorDictBase):
             out = self._nested_tensordicts.get(key, None)
             if out is None:
                 out = self._nested_tensordicts[key] = PersistentTensorDict(
-                    group=array, batch_size=self.batch_size
+                    group=array,
+                    batch_size=self.batch_size,
+                    device=self.device,
                 )
             return out
         else:
@@ -268,7 +270,9 @@ class PersistentTensorDict(TensorDictBase):
             out = self._nested_tensordicts.get(key, None)
             if out is None:
                 out = self._nested_tensordicts[key] = PersistentTensorDict(
-                    group=array, batch_size=self.batch_size
+                    group=array,
+                    batch_size=self.batch_size,
+                    device=self.device,
                 )
             return out.get_sub_tensordict(idx)
 

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -591,7 +591,7 @@ class PersistentTensorDict(TensorDictBase):
         return out
 
     def _set(self, key: str, value, inplace: bool = False, idx=None, check_shape=True) -> TensorDictBase:
-        value = self._validate_value(value, check_shape=False)
+        value = self._validate_value(value, check_shape=check_shape)
         if not inplace and idx is not None:
             raise RuntimeError("Cannot pass an index to _set when inplace=False.")
         # shortcut set if we're placing a tensordict

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -568,8 +568,9 @@ class PersistentTensorDict(TensorDictBase):
             dest = torch.device(dest)
             if self.device is not None and dest == self.device:
                 return self
-            self._device = dest
-            return self
+            out = self.clone(False)
+            out._device = dest
+            return out
         elif isinstance(dest, torch.Size):
             self.batch_size = dest
             return self

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -516,11 +516,11 @@ class PersistentTensorDict(TensorDictBase):
         md = self._get_metadata(key)
         if md["array"]:
             array = self._get_array(key)
-            array[:] = 0
+            array[:] = value
         else:
-            val = self.get(key)
-            for subkey in val.keys():
-                val.fill_(subkey, value)
+            nested = self.get(key)
+            for subkey in nested.keys():
+                nested.fill_(subkey, value)
         return self
 
     def select(

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -17,7 +17,6 @@ import torch
 
 from tensordict import MemmapTensor
 from tensordict.tensordict import (
-    _get_leaf_tensordict,
     _TensorDictKeysView,
     CompatibleType,
     is_tensor_collection,

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -595,7 +595,9 @@ class PersistentTensorDict(TensorDictBase):
                 )
         return out
 
-    def _set(self, key: str, value, inplace: bool = False, idx=None, check_shape=True) -> TensorDictBase:
+    def _set(
+        self, key: str, value, inplace: bool = False, idx=None, check_shape=True
+    ) -> TensorDictBase:
         # although it is expected that _set will run as few tests as possible,
         # we must do the value transformation here as _set can be called by other
         # methods from TensorDictBase.

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -519,7 +519,7 @@ class PersistentTensorDict(TensorDictBase):
             tensordict.apply_(lambda x: x.fill_(value))
             self._set(key, tensordict, inplace=True)
         else:
-            tensor = torch.full_like(self.get(key), value).numpy()
+            tensor = torch.full_like(self.get(key), value).cpu().numpy()
             self._set(key, tensor, inplace=True)
         return self
 

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -752,12 +752,14 @@ class PersistentTensorDict(TensorDictBase):
                 f_dest.create_dataset(key, data=f_src[key], **self.kwargs)
                 # f_src.copy(f_src[key],  f_dest[key], "DataSet")
             # create a non-recursive copy and update the file
+            # this way, we can keep the batch-size of every nested tensordict
             clone = self.clone(False)
             clone.file = f_src
             clone.filename = newfile
             clone._pin_mem = False
             return clone
         else:
+            # we need to keep the batch-size of nested tds, which we do manually
             nested_tds = {
                 key: td.clone(False) for key, td in self._nested_tensordicts.items()
             }

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -502,6 +502,27 @@ class PersistentTensorDict(TensorDictBase):
             raise KeyError(f"key {new_key} already present in TensorDict.") from err
         return self
 
+    def fill_(self, key: str, value: float | bool) -> TensorDictBase:
+        """Fills a tensor pointed by the key with the a given value.
+
+        Args:
+            key (str): key to be remaned
+            value (Number, bool): value to use for the filling
+
+        Returns:
+            self
+
+        """
+        target_class = self.entry_class(key)
+        if is_tensor_collection(target_class):
+            tensordict = self.get(key)
+            tensordict.apply_(lambda x: x.fill_(value))
+            self._set(key, tensordict, inplace=True)
+        else:
+            tensor = torch.full_like(self.get(key), value).numpy()
+            self._set(key, tensor, inplace=True)
+        return self
+
     def select(
         self, *keys: str, inplace: bool = False, strict: bool = True
     ) -> TensorDictBase:

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -590,7 +590,8 @@ class PersistentTensorDict(TensorDictBase):
                 )
         return out
 
-    def _set(self, key: str, value, inplace: bool = False, idx=None) -> TensorDictBase:
+    def _set(self, key: str, value, inplace: bool = False, idx=None, check_shape=True) -> TensorDictBase:
+        value = self._validate_value(value, check_shape=False)
         if not inplace and idx is not None:
             raise RuntimeError("Cannot pass an index to _set when inplace=False.")
         # shortcut set if we're placing a tensordict
@@ -669,7 +670,6 @@ class PersistentTensorDict(TensorDictBase):
         value: dict[str, CompatibleType] | CompatibleType,
         inplace: bool = False,
     ) -> TensorDictBase:
-        value = self._validate_value(value)
 
         key = self._process_key(key)
 
@@ -692,8 +692,7 @@ class PersistentTensorDict(TensorDictBase):
             raise KeyError(f'key "{key}" not found in h5.')
         # we don't need to check shape as the modification will be done
         # in-place and an error will be thrown anyway if shapes don't match
-        value = self._validate_value(value, check_shape=False)
-        return self._set(key, value, inplace=True)
+        return self._set(key, value, inplace=True, check_shape=False)
 
     def set_at_(
         self,
@@ -708,8 +707,7 @@ class PersistentTensorDict(TensorDictBase):
             raise KeyError(f'key "{key}" not found in h5.')
         # we don't need to check shape as the modification will be done
         # in-place and an error will be thrown anyway if shapes don't match
-        value = self._validate_value(value, check_shape=False)
-        return self._set(key, value, inplace=True, idx=idx)
+        return self._set(key, value, inplace=True, idx=idx, check_shape=False)
 
     def clone(self, recurse: bool = True, newfile=None) -> TensorDictBase:
         if recurse:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1735,6 +1735,7 @@ class TensorDictBase(MutableMapping):
     def to_h5(
         self,
         filename,
+        **kwargs,
     ):
         """Converts a tensordict to a PersistentTensorDict with the h5 backend.
 
@@ -1743,9 +1744,36 @@ class TensorDictBase(MutableMapping):
             device (torch.device or compatible, optional): the device where to
                 expect the tensor once they are returned. Defaults to ``None``
                 (on cpu by default).
+            **kwargs: kwargs to be passed to :meth:`h5py.File.create_dataset`.
 
         Returns:
             A :class:`PersitentTensorDict` instance linked to the newly created file.
+
+        Examples:
+            >>> import tempfile
+            >>> import timeit
+            >>>
+            >>> from tensordict import TensorDict, MemmapTensor
+            >>> td = TensorDict({
+            ...     "a": MemmapTensor(1_000_000),
+            ...     "b": {"c": MemmapTensor(1_000_000, 3)},
+            ... }, [1_000_000])
+            >>>
+            >>> file = tempfile.NamedTemporaryFile()
+            >>> td_h5 = td.to_h5(file.name, compression="gzip", compression_opts=9)
+            >>> print(td_h5)
+            PersistentTensorDict(
+                fields={
+                    a: Tensor(shape=torch.Size([1000000]), device=cpu, dtype=torch.float32, is_shared=False),
+                    b: PersistentTensorDict(
+                        fields={
+                            c: Tensor(shape=torch.Size([1000000, 3]), device=cpu, dtype=torch.float32, is_shared=False)},
+                        batch_size=torch.Size([1000000]),
+                        device=None,
+                        is_shared=False)},
+                batch_size=torch.Size([1000000]),
+                device=None,
+                is_shared=False)
 
 
         """
@@ -1754,6 +1782,7 @@ class TensorDictBase(MutableMapping):
         return PersistentTensorDict.from_dict(
             self,
             filename=filename,
+            **kwargs,
         )
 
     def to_tensordict(self):

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1732,6 +1732,30 @@ class TensorDictBase(MutableMapping):
             _run_checks=False,
         )
 
+    def to_h5(
+        self,
+        filename,
+    ):
+        """Converts a tensordict to a PersistentTensorDict with the h5 backend.
+
+        Args:
+            filename (str or path): path to the h5 file.
+            device (torch.device or compatible, optional): the device where to
+                expect the tensor once they are returned. Defaults to ``None``
+                (on cpu by default).
+
+        Returns:
+            A :class:`PersitentTensorDict` instance linked to the newly created file.
+
+
+        """
+        from .persistent import PersistentTensorDict
+
+        return PersistentTensorDict.from_dict(
+            self,
+            filename=filename,
+        )
+
     def to_tensordict(self):
         """Returns a regular TensorDict instance from the TensorDictBase.
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1580,7 +1580,7 @@ class TensorDictBase(MutableMapping):
         return self.update_at_(tensordict, idx)
 
     def get_at(
-        self, key: str, idx: IndexType, default: CompatibleType = "_no_default_"
+        self, key: str, idx: IndexType, default: CompatibleType = NO_DEFAULT
     ) -> CompatibleType:
         """Get the value of a tensordict from the key `key` at the index `idx`.
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3007,7 +3007,7 @@ class TensorDict(TensorDictBase):
             device=device,
         )
         if batch_size is None:
-            _find_max_batch_size(out)
+            _set_max_batch_size(out)
         else:
             out.batch_size = batch_size
         return out
@@ -6490,12 +6490,12 @@ def make_tensordict(
     return TensorDict.from_dict(kwargs, batch_size=batch_size, device=device)
 
 
-def _find_max_batch_size(source: TensorDictBase):
+def _set_max_batch_size(source: TensorDictBase):
     """Updates a tensordict with its maximium batch size."""
     tensor_data = list(source.values())
     for val in tensor_data:
         if is_tensor_collection(val):
-            _find_max_batch_size(val)
+            _set_max_batch_size(val)
     batch_size = []
     if not tensor_data:  # when source is empty
         source.batch_size = batch_size

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 import math
 import tempfile
-from fileinput import filename
 
 import numpy as np
 import torch

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -3,11 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import math
+import tempfile
+from fileinput import filename
 
 import numpy as np
 import torch
 
-from tensordict import TensorDict
+from tensordict import PersistentTensorDict, TensorDict
 from tensordict.prototype import tensorclass
 from tensordict.tensordict import _stack as stack_td
 
@@ -212,6 +214,17 @@ class TestTensorDictsBase:
         )
         td.batch_size = torch.Size([4, 3, 2, 1])
         return td
+
+    def td_h5(
+        self,
+        device,
+    ):
+        file = tempfile.NamedTemporaryFile()
+        filename = file.name
+        td_h5 = PersistentTensorDict.from_dict(
+            self.nested_td(device), filename=filename, device=device
+        )
+        return td_h5
 
 
 def expand_list(list_of_tensors, *dims):

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import abc
 import argparse
 

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import argparse
 
 import pytest

--- a/test/test_h5.py
+++ b/test/test_h5.py
@@ -12,7 +12,7 @@ import torch
 
 from tensordict import PersistentTensorDict
 from torch import multiprocessing as mp
-
+TIMEOUT=100
 
 class TestH5Serialization:
     @classmethod
@@ -41,9 +41,9 @@ class TestH5Serialization:
         p = mp.Process(target=self.flummoxydoodle, args=(cyberbliptronics, q))
         p.start()
         try:
-            val = q.get(1)
+            val = q.get(timeout=TIMEOUT)
             assert (torch.tensor(arr) == val["default"]).all()
-            val = q.get(1)
+            val = q.get(timeout=TIMEOUT)
             assert (torch.tensor(arr) + 1 == val).all()
         finally:
             p.join()

--- a/test/test_h5.py
+++ b/test/test_h5.py
@@ -27,8 +27,11 @@ class TestH5Serialization:
             ]
         )
         assert q2.get(timeout=TIMEOUT) == "checked"
-        q1.put(cyberbliptronics["Base_Group", "Sub_Group", "default"] + 1)
+        val = cyberbliptronics["Base_Group", "Sub_Group", "default"] + 1
+        q1.put(val)
+        assert q2.get(timeout=TIMEOUT) == "checked"
         q1.close()
+        q2.close()
 
     def test_h5_serialization(self, tmp_path):
         arr = np.random.randn(1000)
@@ -51,6 +54,7 @@ class TestH5Serialization:
             q2.put("checked")
             val = q1.get(timeout=TIMEOUT)
             assert (torch.tensor(arr) + 1 == val).all()
+            q2.put("checked")
             q1.close()
             q2.close()
         finally:

--- a/test/test_h5.py
+++ b/test/test_h5.py
@@ -12,7 +12,9 @@ import torch
 
 from tensordict import PersistentTensorDict
 from torch import multiprocessing as mp
-TIMEOUT=100
+
+TIMEOUT = 100
+
 
 class TestH5Serialization:
     @classmethod

--- a/test/test_h5.py
+++ b/test/test_h5.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import argparse
+
+import h5py
+
+import numpy as np
+import pytest
+import torch
+
+from tensordict import PersistentTensorDict
+from torch import multiprocessing as mp
+
+
+class TestH5Serialization:
+    @classmethod
+    def flummoxydoodle(cls, cyberbliptronics, queue):
+        assert isinstance(cyberbliptronics, PersistentTensorDict)
+        assert cyberbliptronics.file.filename.endswith("groups.hdf5")
+        queue.put(
+            cyberbliptronics["Base_Group"][
+                "Sub_Group",
+            ]
+        )
+        queue.put(cyberbliptronics["Base_Group", "Sub_Group", "default"] + 1)
+
+    def test_h5_serialization(self, tmp_path):
+        arr = np.random.randn(1000)
+        fn = tmp_path / "groups.hdf5"
+        with h5py.File(fn, "w") as f:
+            g = f.create_group("Base_Group")
+            gg = g.create_group("Sub_Group")
+
+            _ = g.create_dataset("default", data=arr)
+            _ = gg.create_dataset("default", data=arr)
+
+        cyberbliptronics = PersistentTensorDict(filename=fn, batch_size=[])
+        q = mp.Queue(1)
+        p = mp.Process(target=self.flummoxydoodle, args=(cyberbliptronics, q))
+        p.start()
+        try:
+            val = q.get(1)
+            assert (torch.tensor(arr) == val["default"]).all()
+            val = q.get(1)
+            assert (torch.tensor(arr) + 1 == val).all()
+        finally:
+            p.join()
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import argparse
 import dataclasses
 import inspect

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -524,6 +524,7 @@ TD_BATCH_SIZE = 4
         "nested_tensorclass",
         "permute_td",
         "nested_stacked_td",
+        "td_h5",
     ],
 )
 @pytest.mark.parametrize("device", get_available_devices())
@@ -552,6 +553,11 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         keys = ["a"]
+        if td_name == "td_h5":
+            with pytest.raises(NotImplementedError, match="Cannot call select"):
+                td.select(*keys, strict=strict, inplace=inplace)
+            return
+
         if td_name in ("nested_stacked_td", "nested_td"):
             keys += [("my_nested_td", "inner")]
 
@@ -577,6 +583,11 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_select_exception(self, td_name, device, strict):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
+        if td_name == "td_h5":
+            with pytest.raises(NotImplementedError, match="Cannot call select"):
+                _ = td.select("tada", strict=strict)
+            return
+
         if strict:
             with pytest.raises(KeyError):
                 _ = td.select("tada", strict=strict)
@@ -588,6 +599,10 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_exclude(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
+        if td_name == "td_h5":
+            with pytest.raises(NotImplementedError, match="Cannot call exclude"):
+                _ = td.exclude("a")
+            return
         td2 = td.exclude("a")
         assert td2 is not td
         assert (
@@ -713,7 +728,13 @@ class TestTensorDicts(TestTensorDictsBase):
         td_clone = td.to_tensordict()
         assert not td_clone.is_locked
         assert td.is_locked
-        td = td.select(inplace=True)
+        if td_name == "td_h5":
+            td.unlock_()
+            for key in list(td.keys()):
+                del td[key]
+            td.lock_()
+        else:
+            td = td.select(inplace=True)
         for key, item in td_clone.items(True):
             with pytest.raises(RuntimeError, match="Cannot modify locked TensorDict"):
                 td.set(key, item)
@@ -731,7 +752,10 @@ class TestTensorDicts(TestTensorDictsBase):
         td = getattr(self, td_name)(device)
         td.unlock_()
         assert not td.is_locked
-        assert td.device.type == "cuda" or not td.is_shared()
+        if td.device is not None:
+            assert td.device.type == "cuda" or not td.is_shared()
+        else:
+            assert not td.is_shared()
         assert not td.is_memmap()
 
     def test_sorted_keys(self, td_name, device):
@@ -812,9 +836,12 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_masking(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
-        mask = torch.zeros(td.batch_size, dtype=torch.bool, device=device).bernoulli_(
-            0.8
-        )
+        while True:
+            mask = torch.zeros(
+                td.batch_size, dtype=torch.bool, device=device
+            ).bernoulli_(0.8)
+            if not mask.all() and mask.any():
+                break
         td_masked = td[mask]
         td_masked2 = torch.masked_select(td, mask)
         assert_allclose_td(td_masked, td_masked2)
@@ -1047,6 +1074,8 @@ class TestTensorDicts(TestTensorDictsBase):
 
     @pytest.mark.parametrize("nested", [True, False])
     def test_exclude_missing(self, td_name, device, nested):
+        if td_name == "td_h5":
+            raise pytest.skip("exclude not implemented for PersitentTensorDict")
         td = getattr(self, td_name)(device)
         if nested:
             td2 = td.exclude("this key is missing", ("this one too",))
@@ -1058,6 +1087,8 @@ class TestTensorDicts(TestTensorDictsBase):
 
     @pytest.mark.parametrize("nested", [True, False])
     def test_exclude_nested(self, td_name, device, nested):
+        if td_name == "td_h5":
+            raise pytest.skip("exclude not implemented for PersitentTensorDict")
         td = getattr(self, td_name)(device)
         td.unlock_()  # make sure that the td is not locked
         if td_name == "stacked_td":
@@ -1293,11 +1324,18 @@ class TestTensorDicts(TestTensorDictsBase):
         # cloning is type-preserving: we can do that operation
         td_stack.clone()
 
-    def test_clone_td(self, td_name, device):
+    def test_clone_td(self, td_name, device, tmp_path):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
-        assert (torch.clone(td) == td).all()
-        assert td.batch_size == torch.clone(td).batch_size
+        if td_name == "td_h5":
+            # need a new file
+            newfile = tmp_path / "file.h5"
+            clone = td.clone(newfile=newfile)
+        else:
+            clone = torch.clone(td)
+        assert (clone == td).all()
+        assert td.batch_size == clone.batch_size
+        assert type(td.clone(recurse=False)) is type(td)
         if td_name in (
             "stacked_td",
             "nested_stacked_td",
@@ -1307,9 +1345,9 @@ class TestTensorDicts(TestTensorDictsBase):
             "sub_td",
             "sub_td2",
             "permute_td",
+            "td_h5",
         ):
-            with pytest.raises(AssertionError):
-                assert td.clone(recurse=False).get("a") is td.get("a")
+            assert td.clone(recurse=False).get("a") is not td.get("a")
         else:
             assert td.clone(recurse=False).get("a") is td.get("a")
 
@@ -1422,7 +1460,10 @@ class TestTensorDicts(TestTensorDictsBase):
         assert (td[idx].get("a") == 0).all()
 
         td_clone = torch.cat([td_clone, td_clone], 0)
-        with pytest.raises(RuntimeError, match="differs from the source batch size"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"differs from the source batch size|batch dimension mismatch",
+        ):
             td[idx] = td_clone
 
     def test_setitem_string(self, td_name, device):
@@ -1441,7 +1482,9 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         assert_allclose_td(td[range(2)], td[[0, 1]])
-        assert_allclose_td(td[range(1), range(1)], td[[0], [0]])
+        if td_name not in ("td_h5",):
+            # for h5, we can't use a double list index
+            assert_allclose_td(td[range(1), range(1)], td[[0], [0]])
         assert_allclose_td(td[:, range(2)], td[:, [0, 1]])
         assert_allclose_td(td[..., range(1)], td[..., [0]])
 
@@ -1667,10 +1710,17 @@ class TestTensorDicts(TestTensorDictsBase):
         td = getattr(self, td_name)(device)
         td.unlock_()
         assert not td.get("a").requires_grad
+        if td_name in ("td_h5",):
+            with pytest.raises(
+                RuntimeError, match="Cannot set a tensor that has requires_grad=True"
+            ):
+                td.set("a", torch.randn_like(td.get("a")).requires_grad_())
+            return
         if td_name in ("sub_td", "sub_td2"):
             td.set_("a", torch.randn_like(td.get("a")).requires_grad_())
         else:
             td.set("a", torch.randn_like(td.get("a")).requires_grad_())
+
         assert td.get("a").requires_grad
 
     def test_nested_td_emptyshape(self, td_name, device):
@@ -1834,6 +1884,12 @@ class TestTensorDicts(TestTensorDictsBase):
                 match="Converting a sub-tensordict values to memmap cannot be done",
             ):
                 td.memmap_()
+        elif td_name in ("td_h5",):
+            with pytest.raises(
+                RuntimeError,
+                match="Cannot build a memmap TensorDict in-place",
+            ):
+                td.memmap_()
         else:
             td.memmap_()
             assert td.is_memmap()
@@ -1860,6 +1916,13 @@ class TestTensorDicts(TestTensorDictsBase):
             ):
                 td.memmap_(tmp_path / "tensordict")
             return
+        elif td_name in ("td_h5",):
+            with pytest.raises(
+                RuntimeError,
+                match="Cannot build a memmap TensorDict in-place",
+            ):
+                td.memmap_(tmp_path / "tensordict")
+            return
         else:
             td.memmap_(tmp_path / "tensordict")
 
@@ -1883,9 +1946,9 @@ class TestTensorDicts(TestTensorDictsBase):
             pytest.skip(
                 "Memmap case is redundant, functionality checked by other cases"
             )
-        elif td_name in ("sub_td", "sub_td2"):
+        elif td_name in ("sub_td", "sub_td2", "td_h5"):
             pytest.skip(
-                "SubTensorDict and memmap_ incompatibility is checked elsewhere"
+                "SubTensorDict/H5 and memmap_ incompatibility is checked elsewhere"
             )
 
         td = getattr(self, td_name)(device).memmap_(prefix=tmp_path / "tensordict")
@@ -1972,7 +2035,8 @@ class TestTensorDicts(TestTensorDictsBase):
         sub_tensordict = TensorDict(
             {"b": sub_sub_tensordict}, [4, 3, 2, 1], device=device
         )
-
+        if td_name == "td_h5":
+            del td["a"]
         if td_name == "sub_td":
             td = td._source.set(
                 "a", sub_tensordict.expand(2, *sub_tensordict.shape)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -24,6 +24,7 @@ from tensordict.utils import _getitem_batch_size
         np.arange(2),
         torch.arange(2),
         [True, True],
+        Ellipsis,
     ],
 )
 @pytest.mark.parametrize(
@@ -38,6 +39,7 @@ from tensordict.utils import _getitem_batch_size
         np.arange(0, 1),
         torch.arange(2),
         [True, False, True],
+        Ellipsis,
     ],
 )
 @pytest.mark.parametrize(
@@ -52,6 +54,7 @@ from tensordict.utils import _getitem_batch_size
         np.arange(1, 3),
         torch.arange(2),
         [True, False, True, False],
+        Ellipsis,
     ],
 )
 @pytest.mark.parametrize(
@@ -66,11 +69,21 @@ from tensordict.utils import _getitem_batch_size
         np.arange(0, 4, 2),
         torch.arange(2),
         [True, False, False, False, True],
+        Ellipsis,
     ],
 )
 def test_getitem_batch_size(tensor, index1, index2, index3, index4):
+    # cannot have 2 ellipsis
+    if (index1 is Ellipsis) + (index2 is Ellipsis) + (index3 is Ellipsis) + (
+        index4 is Ellipsis
+    ) > 1:
+        pytest.skip("cannot have more than one ellipsis in an index.")
+    if (index1 is Ellipsis) + (index2 is Ellipsis) + (index3 is Ellipsis) + (
+        index4 is Ellipsis
+    ) == 1 and tensor.ndim == 5:
+        pytest.skip("index possibly incompatible with tensor shape.")
     index = (index1, index2, index3, index4)
-    assert tensor[index].shape == _getitem_batch_size(tensor.shape, index)
+    assert tensor[index].shape == _getitem_batch_size(tensor.shape, index), index
 
 
 @pytest.mark.parametrize("tensor", [torch.rand(2, 3, 4, 5), torch.rand(2, 3, 4, 5, 6)])


### PR DESCRIPTION
## Description

Test:
```python
import numpy as np
import h5py
from tensordict import PersistentTensorDict

arr = np.random.randn(1000)

with h5py.File('groups.hdf5', 'w') as f:
    g = f.create_group('Base_Group')
    gg = g.create_group('Sub_Group')

    d = g.create_dataset('default', data=arr)
    dd = gg.create_dataset('default', data=arr)

td = PersistentTensorDict(filename='groups.hdf5', batch_size=[1000])
print(td.get(("Base_Group", "Sub_Group", "default"))[:2])
print(td[:2]["Base_Group", "Sub_Group", "default"])
print(td[:2]["Base_Group", "Sub_Group"]["default"])
print(td["Base_Group"])
print(td)
td = PersistentTensorDict(filename='groups.hdf5', batch_size=[3])
print(td)  # raises an exception
```

Follow up:
- [ ] Test repr
- [ ] Benchmarks
- [ ] kwargs (e.g. `compression="gzip", compression_opts=9`)