### PR TITLE
[BugFix] tensorclass.set and set_at_

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -181,6 +181,8 @@ def tensorclass(cls: T) -> T:
     cls.__len__ = _len
     cls.__eq__ = __eq__
     cls.__ne__ = __ne__
+    cls.set = _set
+    cls.set_at_ = _set_at
     cls.state_dict = _state_dict
     cls.load_state_dict = _load_state_dict
 
@@ -585,6 +587,18 @@ def _device_setter(self, value: DeviceType) -> None:
         "tensorclass.to(new_device), which will return a new tensorclass "
         "on the new device."
     )
+
+
+def _set(self, key, value, *args, **kwargs):
+    if key in self._non_tensordict:
+        del self._non_tensordict[key]
+    return self._tensordict.set(key, value, *args, **kwargs)
+
+
+def _set_at(self, key, value, *args, **kwargs):
+    if key in self._non_tensordict:
+        del self._non_tensordict[key]
+    return self._tensordict.set_at_(key, value, *args, **kwargs)
 
 
 def _batch_size(self) -> torch.Size:


### PR DESCRIPTION
## Description

set and set_at_ are broken for non-tensor / optional fields.
This PR solves this.

Example code:
```python
from __future__ import annotations

import torch
from tensordict.prototype import tensorclass
@tensorclass
class Data:
    opt0: torch.Tensor | str | None = None
    opt1: torch.Tensor | str | None = None

d = Data(opt0=torch.randn([3,5]), batch_size=[3])
d.set("opt1", torch.randn([3,3]))

d = Data(batch_size=[3])
d[0] = Data(opt0=torch.randn(()), opt1=torch.randn(()), batch_size=[])
print(d[0].opt0)
print(d.opt1)

```