### PR TITLE
[BugFix] add set/get and set_at,get_at methods to tensorclass

### DIFF
--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -625,6 +625,9 @@ def _get(self, key: NestedKey, default: Any = NO_DEFAULT):
             equivalent to chained calls of getattr.
         default: default value if the key is not found in the tensorclass.
 
+    Returns:
+        value stored with the input key
+
     """
     if isinstance(key, str):
         key = (key,)

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -25,12 +25,12 @@ from tensordict.memmap import MemmapTensor
 from tensordict.tensordict import (
     _get_repr,
     is_tensor_collection,
+    NO_DEFAULT,
     TD_HANDLED_FUNCTIONS,
     TensorDict,
     TensorDictBase,
-    NO_DEFAULT,
 )
-from tensordict.utils import DeviceType, NestedKey, IndexType
+from tensordict.utils import DeviceType, IndexType, NestedKey
 from torch import Tensor
 
 T = TypeVar("T", bound=TensorDictBase)
@@ -591,8 +591,8 @@ def _set(self, key: NestedKey, value: Any):
 
     Args:
         key (str, tuple of str): name of the key to be set.
-           If tuple of str it is equivalent to chained calls of getattr 
-           followed by a final setattr. 
+           If tuple of str it is equivalent to chained calls of getattr
+           followed by a final setattr.
         value (Any): value to be stored in the tensorclass
 
     Returns:
@@ -601,13 +601,15 @@ def _set(self, key: NestedKey, value: Any):
     """
 
     if isinstance(key, str):
-        key = (key, )
+        key = (key,)
 
     if key and isinstance(key, tuple):
         if len(key) > 1:
             return getattr(self, key[0]).set(key[1:], value)
         return setattr(self, key[0], value)
-    raise ValueError(f"Supported type for key are str and tuple, got {key} of type {type(key)}")
+    raise ValueError(
+        f"Supported type for key are str and tuple, got {key} of type {type(key)}"
+    )
 
 
 def _set_at_(self, key: NestedKey, value: Any, idx: IndexType):
@@ -626,7 +628,7 @@ def _get(self, key: NestedKey, default: Any = NO_DEFAULT):
 
     """
     if isinstance(key, str):
-        key = (key, )
+        key = (key,)
 
     if isinstance(key, tuple):
         try:

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -181,6 +181,8 @@ def tensorclass(cls: T) -> T:
     cls.__len__ = _len
     cls.__eq__ = __eq__
     cls.__ne__ = __ne__
+    cls.set = _set
+    cls.set_at_ = _set_at
     cls.state_dict = _state_dict
     cls.load_state_dict = _load_state_dict
 
@@ -585,6 +587,18 @@ def _device_setter(self, value: DeviceType) -> None:
         "tensorclass.to(new_device), which will return a new tensorclass "
         "on the new device."
     )
+
+
+def _set(self, key, value, *args, **kwargs):
+    if key in self._non_tensordict:
+        del self._non_tensordict[key]
+    return self._tensordict.set(key, value, *args, **kwargs)
+
+
+def _set_at(self, key, value, *args, **kwargs):
+    if key in self._non_tensordict:
+        del self._non_tensordict[key]
+    return self._tensordict.set_at_(key, value, *args, **kwargs)
 
 
 def _batch_size(self) -> torch.Size:

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -183,6 +183,8 @@ def tensorclass(cls: T) -> T:
     cls.__ne__ = __ne__
     cls.set = _set
     cls.set_at_ = _set_at
+    cls.get = _get
+    cls.get_at_ = _get_at
     cls.state_dict = _state_dict
     cls.load_state_dict = _load_state_dict
 
@@ -590,15 +592,19 @@ def _device_setter(self, value: DeviceType) -> None:
 
 
 def _set(self, key, value, *args, **kwargs):
-    if key in self._non_tensordict:
-        del self._non_tensordict[key]
-    return self._tensordict.set(key, value, *args, **kwargs)
+    return setattr(self, key, value)
 
 
 def _set_at(self, key, value, *args, **kwargs):
-    if key in self._non_tensordict:
-        del self._non_tensordict[key]
-    return self._tensordict.set_at_(key, value, *args, **kwargs)
+    return self._setitem(key, value, *args, **kwargs)
+
+
+def _get(self, key, *args, **kwargs):
+    return getattr(self, key)
+
+
+def _get_at(self, key, *args, **kwargs):
+    return self._getitem(key, *args, **kwargs)
 
 
 def _batch_size(self) -> torch.Size:

--- a/tensordict/prototype/tensorclass.py
+++ b/tensordict/prototype/tensorclass.py
@@ -599,7 +599,6 @@ def _set(self, key: NestedKey, value: Any):
         self
 
     """
-
     if isinstance(key, str):
         key = (key,)
 

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -926,6 +926,7 @@ def test_setattr(any_to_td):
         z: TensorDictBase
         y: MyDataNest
         v: Any
+        k: Optional[Tensor] = None
 
     batch_size = [3, 4]
     if any_to_td:
@@ -973,6 +974,176 @@ def test_setattr(any_to_td):
     assert data.v == "test"
     assert "v" not in data._tensordict.keys()
     assert "v" in data._non_tensordict.keys()
+
+    # ensure optional fields are writable
+    data.k = torch.zeros(3, 4, 5)
+
+
+def test_set():
+    @tensorclass
+    class MyDataNest:
+        X: torch.Tensor
+        v: str
+
+    @tensorclass
+    class MyDataParent:
+        X: Tensor
+        z: TensorDictBase
+        y: MyDataNest
+        v: str
+        k: Optional[Tensor] = None
+        
+    batch_size = [3, 4]
+    X = torch.ones(3, 4, 5)
+    td = TensorDict({}, batch_size)
+    data_nest = MyDataNest(X=X, v="test_nested", batch_size=batch_size)
+    data = MyDataParent(
+        X=X, y=data_nest, z=td, v="test_tensorclass", batch_size=batch_size)
+
+    assert isinstance(data.y, type(data_nest))
+    assert data.y._tensordict is data_nest._tensordict
+    data.set("X", torch.zeros(3, 4, 5))
+    assert (data.X == torch.zeros(3, 4, 5)).all()
+    v_new = "test_bluff"
+    data.set("v", v_new)
+    assert data.v == v_new
+    # check that you can't mess up the batch_size
+    with pytest.raises(
+        RuntimeError, match=re.escape("the tensor smth has shape torch.Size([1]) which")
+    ):
+        data.set("z", TensorDict({"smth": torch.zeros(1)}, []))
+    # check that you can't write any attribute
+    with pytest.raises(AttributeError, match=re.escape("Cannot set the attribute")):
+        data.set("newattr", TensorDict({"smth": torch.zeros(1)}, []))
+
+    # Testing nested cases
+    data_nest.set("X", torch.zeros(3, 4, 5))
+    assert (data_nest.X == torch.zeros(3, 4, 5)).all()
+    assert (data.y.X == torch.zeros(3, 4, 5)).all()
+    assert data.y.v == "test_nested"
+    data.set(("y", "v"), "test_nested_new")
+    assert data.y.v == data_nest.v == "test_nested_new"
+    data_nest.set("v", "test_nested")
+    assert data_nest.v == data.y.v == "test_nested"
+
+    # Testing if user can override the type of the attribute
+    data.set("v", torch.ones(3, 4, 5))
+    assert (data.v == torch.ones(3, 4, 5)).all()
+    assert "v" in data._tensordict.keys()
+    assert "v" not in data._non_tensordict.keys()
+
+    data.set("v", "test")
+    assert data.v == "test"
+    assert "v" not in data._tensordict.keys()
+    assert "v" in data._non_tensordict.keys()
+    
+    # ensure optional fields are writable
+    data.set("k", torch.zeros(3, 4, 5))
+
+
+def test_get():
+    @tensorclass
+    class MyDataNest:
+        X: torch.Tensor
+        v: str
+
+    @tensorclass
+    class MyDataParent:
+        X: Tensor
+        z: TensorDictBase
+        y: MyDataNest
+        v: str
+        k: Optional[Tensor] = None
+
+    batch_size = [3, 4]
+    X = torch.ones(3, 4, 5)
+    td = TensorDict({}, batch_size)
+    data_nest = MyDataNest(X=X, v="test_nested", batch_size=batch_size)
+    v = "test_tensorclass"
+    data = MyDataParent(X=X, y=data_nest, z=td, v=v, batch_size=batch_size)
+    assert isinstance(data.y, type(data_nest))
+    assert (data.get("X") == X).all()
+    assert data.get("batch_size") == torch.Size(batch_size)
+    assert data.get("v") == v
+    assert (data.get("z") == td).all()
+
+    # Testing nested tensor class
+    assert data.get("y")._tensordict is data_nest._tensordict
+    assert (data.get("y").X == X).all()
+    assert (data.get(("y","X")) == X).all()
+    assert data.get("y").v == "test_nested"
+    assert data.get(("y", "v")) == "test_nested"
+    assert data.get("y").batch_size == torch.Size(batch_size)
+
+    # ensure optional fields are there
+    assert data.get("k") is None
+
+    # ensure default works
+    assert data.get("foo", "working") == "working"
+    assert data.get(("foo", "foo2"), "working") == "working"
+    assert data.get(("X", "foo2"), "working") == "working"
+
+    assert (data.get("X", "working") == X).all()
+    assert data.get("v", "working") == v
+
+def test_tensorclass_set_at_():
+    @tensorclass
+    class MyDataNest:
+        X: torch.Tensor
+        v: str
+
+    @tensorclass
+    class MyDataParent:
+        X: Tensor
+        z: TensorDictBase
+        y: MyDataNest
+        v: str
+        k: Optional[Tensor] = None
+
+    batch_size = [3, 4]
+    X = torch.ones(3, 4, 5)
+    td = TensorDict({}, batch_size)
+    data_nest = MyDataNest(X=X, v="test_nested", batch_size=batch_size)
+    v = "test_tensorclass"
+    data = MyDataParent(X=X, y=data_nest, z=td, v=v, batch_size=batch_size)
+
+    data.set_at_("X", 5, slice(2,3)) 
+    data.set_at_(("y", "X"), 5, slice(2,3))
+    assert (data.get_at("X", slice(2,3)) == 5).all()
+    assert (data.get_at(("y", "X"), slice(2,3)) == 5).all()
+    # assert other not changed
+    assert (data.get_at("X", slice(0,2)) == 1).all()
+    assert (data.get_at(("y", "X"), slice(0,2)) == 1).all()
+    assert (data.get_at("X", slice(3,5)) == 1).all()
+    assert (data.get_at(("y", "X"), slice(3,5)) == 1).all()
+
+def test_tensorclass_get_at():
+    @tensorclass
+    class MyDataNest:
+        X: torch.Tensor
+        v: str
+
+    @tensorclass
+    class MyDataParent:
+        X: Tensor
+        z: TensorDictBase
+        y: MyDataNest
+        v: str
+        k: Optional[Tensor] = None
+
+    batch_size = [3, 4]
+    X = torch.ones(3, 4, 5)
+    td = TensorDict({}, batch_size)
+    data_nest = MyDataNest(X=X, v="test_nested", batch_size=batch_size)
+    v = "test_tensorclass"
+    data = MyDataParent(X=X, y=data_nest, z=td, v=v, batch_size=batch_size)
+
+    assert (data.get("X")[2:3] == data.get_at("X", slice(2,3))).all()
+    assert (data.get(("y","X"))[2:3] == data.get_at(("y", "X"), slice(2,3))).all()
+    
+    # check default
+    assert data.get_at(("y", "foo"), slice(2,3), "working") == "working"
+    assert data.get_at("foo", slice(2,3), "working") == "working"
 
 
 def test_pre_allocate():

--- a/test/test_tensorclass_nofuture.py
+++ b/test/test_tensorclass_nofuture.py
@@ -997,13 +997,14 @@ def test_set():
         y: MyDataNest
         v: str
         k: Optional[Tensor] = None
-        
+
     batch_size = [3, 4]
     X = torch.ones(3, 4, 5)
     td = TensorDict({}, batch_size)
     data_nest = MyDataNest(X=X, v="test_nested", batch_size=batch_size)
     data = MyDataParent(
-        X=X, y=data_nest, z=td, v="test_tensorclass", batch_size=batch_size)
+        X=X, y=data_nest, z=td, v="test_tensorclass", batch_size=batch_size
+    )
 
     assert isinstance(data.y, type(data_nest))
     assert data.y._tensordict is data_nest._tensordict
@@ -1041,7 +1042,7 @@ def test_set():
     assert data.v == "test"
     assert "v" not in data._tensordict.keys()
     assert "v" in data._non_tensordict.keys()
-    
+
     # ensure optional fields are writable
     data.set("k", torch.zeros(3, 4, 5))
 
@@ -1075,7 +1076,7 @@ def test_get():
     # Testing nested tensor class
     assert data.get("y")._tensordict is data_nest._tensordict
     assert (data.get("y").X == X).all()
-    assert (data.get(("y","X")) == X).all()
+    assert (data.get(("y", "X")) == X).all()
     assert data.get("y").v == "test_nested"
     assert data.get(("y", "v")) == "test_nested"
     assert data.get("y").batch_size == torch.Size(batch_size)
@@ -1090,6 +1091,7 @@ def test_get():
 
     assert (data.get("X", "working") == X).all()
     assert data.get("v", "working") == v
+
 
 def test_tensorclass_set_at_():
     @tensorclass
@@ -1112,15 +1114,16 @@ def test_tensorclass_set_at_():
     v = "test_tensorclass"
     data = MyDataParent(X=X, y=data_nest, z=td, v=v, batch_size=batch_size)
 
-    data.set_at_("X", 5, slice(2,3)) 
-    data.set_at_(("y", "X"), 5, slice(2,3))
-    assert (data.get_at("X", slice(2,3)) == 5).all()
-    assert (data.get_at(("y", "X"), slice(2,3)) == 5).all()
+    data.set_at_("X", 5, slice(2, 3))
+    data.set_at_(("y", "X"), 5, slice(2, 3))
+    assert (data.get_at("X", slice(2, 3)) == 5).all()
+    assert (data.get_at(("y", "X"), slice(2, 3)) == 5).all()
     # assert other not changed
-    assert (data.get_at("X", slice(0,2)) == 1).all()
-    assert (data.get_at(("y", "X"), slice(0,2)) == 1).all()
-    assert (data.get_at("X", slice(3,5)) == 1).all()
-    assert (data.get_at(("y", "X"), slice(3,5)) == 1).all()
+    assert (data.get_at("X", slice(0, 2)) == 1).all()
+    assert (data.get_at(("y", "X"), slice(0, 2)) == 1).all()
+    assert (data.get_at("X", slice(3, 5)) == 1).all()
+    assert (data.get_at(("y", "X"), slice(3, 5)) == 1).all()
+
 
 def test_tensorclass_get_at():
     @tensorclass
@@ -1143,12 +1146,12 @@ def test_tensorclass_get_at():
     v = "test_tensorclass"
     data = MyDataParent(X=X, y=data_nest, z=td, v=v, batch_size=batch_size)
 
-    assert (data.get("X")[2:3] == data.get_at("X", slice(2,3))).all()
-    assert (data.get(("y","X"))[2:3] == data.get_at(("y", "X"), slice(2,3))).all()
-    
+    assert (data.get("X")[2:3] == data.get_at("X", slice(2, 3))).all()
+    assert (data.get(("y", "X"))[2:3] == data.get_at(("y", "X"), slice(2, 3))).all()
+
     # check default
-    assert data.get_at(("y", "foo"), slice(2,3), "working") == "working"
-    assert data.get_at("foo", slice(2,3), "working") == "working"
+    assert data.get_at(("y", "foo"), slice(2, 3), "working") == "working"
+    assert data.get_at("foo", slice(2, 3), "working") == "working"
 
 
 def test_pre_allocate():


### PR DESCRIPTION
## Description
set and set_at_ are broken for non-tensor / optional fields. This PR solves this.

Example code:

```python
from __future__ import annotations

import torch
from tensordict.prototype import tensorclass
@tensorclass
class Data:
    opt0: torch.Tensor | str | None = None
    opt1: torch.Tensor | str | None = None

d = Data(opt0=torch.randn([3,5]), batch_size=[3])
d.set("opt1", torch.randn([3,3]))

d = Data(batch_size=[3])
d[0] = Data(opt0=torch.randn(()), opt1=torch.randn(()), batch_size=[])
print(d[0].opt0)
print(d.opt1)
```