### PR TITLE
[Refactor] Faster functional module

### DIFF
--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -253,7 +253,9 @@ def _swap_state(
     return_old_tensordict: bool = False,
     old_tensordict: dict[str, torch.Tensor] | TensorDict | None = None,
 ) -> dict[str, torch.Tensor] | TensorDict | None:
+    was_stateless = model.__dict__["_is_stateless"]
     model.__dict__["_is_stateless"] = is_stateless
+    return_old_tensordict = return_old_tensordict and not was_stateless
     if return_old_tensordict and old_tensordict is None:
         old_tensordict = {}
     keys = set(tensordict.keys())
@@ -438,9 +440,7 @@ def _assign_params(
 ) -> TensorDict | None:
     if params is not None:
         out = _swap_state(module, params, make_stateless, return_old_tensordict)
-        if out is not None:
-            return TensorDict(out, [], _run_checks=False)
-        return None
+        return out
     return None
 
 

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -19,7 +19,7 @@ from torch import nn
 
 
 def set_tensor(module: "torch.nn.Module", name: str, tensor: torch.Tensor) -> None:
-    """Simplified version of torch.nn.utils._named_member_accessor"""
+    """Simplified version of torch.nn.utils._named_member_accessor."""
     if name in module._parameters:
         module._parameters[name] = tensor  # type: ignore[assignment]
     elif name in module._buffers:

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -339,7 +339,7 @@ def make_functional(
     _decorate_funs(
         module,
         funs_to_decorate=funs_to_decorate,
-        make_stateless=return_params and not keep_params,
+        make_stateless=not keep_params,
     )
     if return_params:
         params = extract_weights_and_buffers(
@@ -348,6 +348,8 @@ def make_functional(
         if keep_params:
             repopulate_module(module, params)
         return params
+    elif not keep_params:
+        extract_weights_and_buffers(module)
 
 
 def get_functional(

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -17,6 +17,17 @@ from tensordict import TensorDict
 from tensordict.tensordict import TensorDictBase
 from torch import nn
 
+
+def set_tensor(module: "torch.nn.Module", name: str, tensor: torch.Tensor) -> None:
+    """Simplified version of torch.nn.utils._named_member_accessor"""
+    if name in module._parameters:
+        module._parameters[name] = tensor  # type: ignore[assignment]
+    elif name in module._buffers:
+        module._buffers[name] = tensor
+    else:
+        setattr(module, name, tensor)
+
+
 _RESET_OLD_TENSORDICT = True
 try:
     import torch._functorch.vmap as vmap_src
@@ -293,7 +304,7 @@ def _swap_state(
             old_tensordict[key] = old_attr
         if is_param:
             delattr(model, key)
-        setattr(model, key, value)
+        set_tensor(model, key, value)
     if return_old_tensordict:
         return old_tensordict
     return None

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2911,10 +2911,7 @@ class TensorDict(TensorDictBase):
         self._device = device
 
         if not _run_checks:
-            if isinstance(source, dict):
-                self._tensordict: dict = copy(source)
-            else:
-                self._tensordict: dict = dict(source)
+            self._tensordict: dict = dict(source)
             self._batch_size = torch.Size(batch_size)
             upd_dict = {}
             for key, value in self._tensordict.items():

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1541,7 +1541,17 @@ def test_make_functional(return_params, keep_params):
     else:
         assert params is None
     if keep_params:
+        for m in module.modules():
+            assert not m._is_stateless, m
         assert module(torch.randn(3)).shape == torch.Size([3])
+        for m in module.modules():
+            assert not m._is_stateless, m
+    else:
+        for m in module.modules():
+            assert m._is_stateless, m
+        assert module(torch.randn(3), params=td).shape == torch.Size([3])
+        for m in module.modules():
+            assert m._is_stateless, m
 
     assert module(torch.randn(3), params=td).shape == torch.Size([3])
 


### PR DESCRIPTION
## Description

Our implementation is now 1.3s vs 2s previously.
torch functional call is still at 0.8s on my mcbook, so there is room for improvement.

```python
import timeit

import torch
from torch import nn
from tensordict.nn import make_functional

def make_module():
    module = torch.nn.Sequential(
        nn.Linear(4, 4),
        nn.ReLU(),
        nn.Linear(4, 4),
        nn.ReLU(),
    )
    return module
x = torch.randn(4)
module = make_module()
parameter_and_buffer_dicts = module.state_dict()
v1 = torch.func.functional_call(module, parameter_and_buffer_dicts, (x,))
t0=timeit.timeit("torch.func.functional_call(module, parameter_and_buffer_dicts, (x,)), ", globals={
    "module": module,
    "parameter_and_buffer_dicts": parameter_and_buffer_dicts,
    "x": x,
    "torch": torch,
}, number=10_000)

# module = make_module()
params = make_functional(module)
v2 = module(x, params)
t1=timeit.timeit("module(x, params=params)", globals={
    "module": module,
    "x": x,
    "params": params,
}, number=10_000)

torch.testing.assert_close(v1, v2)
print(t0, t1)
```



Sharing the profiling of swap-state for record
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   248                                           @profile
   249                                           def _swap_state(
   250                                               model: nn.Module,
   251                                               tensordict: TensorDict,
   252                                               is_stateless: bool,
   253                                               return_old_tensordict: bool = False,
   254                                               old_tensordict: dict[str, torch.Tensor] | TensorDict | None = None,
   255                                           ) -> dict[str, torch.Tensor] | TensorDict | None:
   256    100005      34818.0      0.3      1.7      was_stateless = model.__dict__["_is_stateless"]
   257    100005      31352.0      0.3      1.5      model.__dict__["_is_stateless"] = is_stateless
   258    100005      25253.0      0.3      1.2      return_old_tensordict = return_old_tensordict and not was_stateless
   259    100000      25017.0      0.3      1.2      if return_old_tensordict and old_tensordict is None:
   260    100000      21751.0      0.2      1.1          old_tensordict = {}
   261    100005     192412.0      1.9      9.4      keys = set(tensordict.keys())
   262    100005      22420.0      0.2      1.1      children = []
   263    100005     125360.0      1.3      6.1      for key, child in model.named_children():
   264     80004      16096.0      0.2      0.8          try:
   265     80004      31110.0      0.4      1.5              keys.remove(key)
   266                                                   except KeyError:
   267                                                       # if params are built externally, this could lead to a KeyError as some
   268                                                       # modules do not have params
   269                                                       pass
   270     80004      26613.0      0.3      1.3          children.append(key)
   271     80004      81196.0      1.0      3.9          value = tensordict.get(key, None)
   272     80004      19955.0      0.2      1.0          if value is None:
   273                                                       # faster than get(key, Tensordict(...))
   274                                                       value = {}
   275
   276     80004      32263.0      0.4      1.6          _old_value = old_tensordict.get(key, None) if return_old_tensordict else None
   277     80004     104161.0      1.3      5.1          _old_value = _swap_state(
   278     80004      16898.0      0.2      0.8              child,
   279     80004      17530.0      0.2      0.9              value,
   280     80004      17340.0      0.2      0.8              return_old_tensordict=return_old_tensordict,
   281     80004      17622.0      0.2      0.9              old_tensordict=_old_value,
   282     80004      16981.0      0.2      0.8              is_stateless=is_stateless,
   283                                                   )
   284     80000      21035.0      0.3      1.0          if old_tensordict is not None:
   285     80000      23254.0      0.3      1.1              old_tensordict[key] = _old_value
   286    100005      35709.0      0.4      1.7      for key in keys:
   287     80004      76070.0      1.0      3.7          value = tensordict.get(key)
   288     80004      41061.0      0.5      2.0          is_param = key in model.__dict__.get("_parameters")
   289     80000      20294.0      0.3      1.0          if return_old_tensordict:
   290     80000     118880.0      1.5      5.8              old_attr = getattr(model, key)
   291     80000      22227.0      0.3      1.1              if old_attr is None:
   292                                                           old_attr = torch.zeros(*value.shape, 0)
   293     80000      25619.0      0.3      1.2              old_tensordict[key] = old_attr
   294     80004      22963.0      0.3      1.1          if is_param:
   295     80004      76933.0      1.0      3.7              delattr(model, key)
   296     80004     649581.0      8.1     31.6          setattr(model, key, value)
   297    100000      25603.0      0.3      1.2      if return_old_tensordict:
   298    100000      21945.0      0.2      1.1          return old_tensordict
   299         5          0.0      0.0      0.0      return None
```

We could probably hack our way through the module `setattr` to make things faster

See https://github.com/pytorch/pytorch/pull/92536