### PR TITLE
Deprecate interaction_mode with interaction_type

### DIFF
--- a/docs/source/reference/nn.rst
+++ b/docs/source/reference/nn.rst
@@ -296,6 +296,6 @@ Utils
 
     make_tensordict
     dispatch_kwargs
-    set_interaction_mode
+    set_interaction_type
     inv_softplus
     biased_softplus

--- a/tensordict/nn/__init__.py
+++ b/tensordict/nn/__init__.py
@@ -19,6 +19,7 @@ from tensordict.nn.probabilistic import (
     ProbabilisticTensorDictModule,
     ProbabilisticTensorDictSequential,
     set_interaction_mode,
+    set_interaction_type,
 )
 from tensordict.nn.sequence import TensorDictSequential
 from tensordict.nn.utils import biased_softplus, inv_softplus
@@ -33,6 +34,7 @@ __all__ = [
     "ProbabilisticTensorDictModule",
     "ProbabilisticTensorDictSequential",
     "set_interaction_mode",
+    "set_interaction_type",
     "TensorDictSequential",
     "make_tensordict",
     "biased_softplus",

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -446,7 +446,8 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
         **kwargs,
     ) -> tuple[D.Distribution, TensorDictBase]:
         tds = self.det_part
-        if type := interaction_type() is None:
+        type = interaction_type()
+        if type is None:
             type = self.module[-1].default_interaction_type
         with set_interaction_type(type):
             return tds(tensordict, tensordict_out, **kwargs)

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import re
 from textwrap import indent
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
+from warnings import warn
 
 import torch.nn as nn
 from tensordict.nn.common import TensorDictModule
@@ -21,22 +22,39 @@ from torch.autograd.grad_mode import _DecoratorContextManager
 __all__ = ["ProbabilisticTensorDictModule", "ProbabilisticTensorDictSequential"]
 
 
-_INTERACTION_MODE = None
+_INTERACTION_TYPE = None
+
+
+def _insert_interaction_mode_deprecation_warning(
+    prefix: str = "",
+) -> Callable[[str, Warning, int], None]:
+    return warn(
+        f"{prefix}interaction_mode is deprecated for naming clarity. Please use {prefix}interaction_type instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+def interaction_type() -> str | None:
+    """Returns the current sampling type."""
+    return _INTERACTION_TYPE
 
 
 def interaction_mode() -> str | None:
-    """Returns the current sampling mode."""
-    return _INTERACTION_MODE
+    """*Deprecated* Returns the current sampling mode."""
+    _insert_interaction_mode_deprecation_warning()
+    return interaction_type()
 
 
 class set_interaction_mode(_DecoratorContextManager):
-    """Sets the sampling mode of all ProbabilisticTDModules to the desired mode.
+    """*Deprecated* Sets the sampling mode of all ProbabilisticTDModules to the desired mode.
 
     Args:
         mode (str): mode to use when the policy is being called.
     """
 
     def __init__(self, mode: str = "mode") -> None:
+        _insert_interaction_mode_deprecation_warning("set_")
         super().__init__()
         self.mode = mode
 
@@ -45,13 +63,38 @@ class set_interaction_mode(_DecoratorContextManager):
         return self.__class__(self.mode)
 
     def __enter__(self) -> None:
-        global _INTERACTION_MODE
-        self.prev = _INTERACTION_MODE
-        _INTERACTION_MODE = self.mode
+        global _INTERACTION_TYPE
+        self.prev = _INTERACTION_TYPE
+        _INTERACTION_TYPE = self.mode
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        global _INTERACTION_MODE
-        _INTERACTION_MODE = self.prev
+        global _INTERACTION_TYPE
+        _INTERACTION_TYPE = self.prev
+
+
+class set_interaction_type(_DecoratorContextManager):
+    """Sets all ProbabilisticTDModules sampling to the desired type.
+
+    Args:
+        type (str): sampling type to use when the policy is being called.
+    """
+
+    def __init__(self, type: str = "mode") -> None:
+        super().__init__()
+        self.type = type
+
+    def clone(self) -> set_interaction_type:
+        # override this method if your children class takes __init__ parameters
+        return self.__class__(self.type)
+
+    def __enter__(self) -> None:
+        global _INTERACTION_TYPE
+        self.prev = _INTERACTION_TYPE
+        _INTERACTION_TYPE = self.type
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        global _INTERACTION_TYPE
+        _INTERACTION_TYPE = self.prev
 
 
 class ProbabilisticTensorDictModule(nn.Module):
@@ -60,8 +103,8 @@ class ProbabilisticTensorDictModule(nn.Module):
     `ProbabilisticTensorDictModule` is a non-parametric module representing a
     probability distribution. It reads the distribution parameters from an input
     TensorDict using the specified `in_keys`. The output is sampled given some rule,
-    specified by the input :obj:`default_interaction_mode` argument and the
-    :obj:`interaction_mode()` global function.
+    specified by the input :obj:`default_interaction_type` argument and the
+    :obj:`interaction_type()` global function.
 
     :obj:`ProbabilisticTensorDictModule` can be used to construct the distribution
     (through the :obj:`get_dist()` method) and/or sampling from this distribution
@@ -92,16 +135,18 @@ class ProbabilisticTensorDictModule(nn.Module):
         out_keys (str or iterable of str): keys where the sampled values will be
             written. Importantly, if these keys are found in the input TensorDict, the
             sampling step will be skipped.
-        default_interaction_mode (str, optional): keyword-only argument.
+        default_interaction_mode (str, optional): *Deprecated* keyword-only argument.
+            Please use default_interaction_type instead.
+        default_interaction_type (str, optional): keyword-only argument.
             Default method to be used to retrieve
             the output value. Should be one of: 'mode', 'median', 'mean' or 'random'
             (in which case the value is sampled randomly from the distribution). Default
             is 'mode'.
             Note: When a sample is drawn, the :obj:`ProbabilisticTDModule` instance will
-            first look for the interaction mode dictated by the `interaction_mode()`
+            first look for the interaction mode dictated by the `interaction_type()`
             global function. If this returns `None` (its default value), then the
-            `default_interaction_mode` of the `ProbabilisticTDModule` instance will be
-            used. Note that DataCollector instances will use `set_interaction_mode` to
+            `default_interaction_type` of the `ProbabilisticTDModule` instance will be
+            used. Note that DataCollector instances will use `set_interaction_type` to
             `"random"` by default.
         distribution_class (Type, optional): keyword-only argument.
             A :class:`torch.distributions.Distribution` class to
@@ -197,7 +242,8 @@ class ProbabilisticTensorDictModule(nn.Module):
         in_keys: str | Sequence[str] | dict,
         out_keys: str | Sequence[str] | None = None,
         *,
-        default_interaction_mode: str = "mode",
+        default_interaction_mode: str | None = None,
+        default_interaction_type: str = "mode",
         distribution_class: type = Delta,
         distribution_kwargs: dict | None = None,
         return_log_prob: bool = False,
@@ -226,7 +272,12 @@ class ProbabilisticTensorDictModule(nn.Module):
         self.out_keys = out_keys
         self.in_keys = in_keys
 
-        self.default_interaction_mode = default_interaction_mode
+        if default_interaction_mode:
+            _insert_interaction_mode_deprecation_warning("default_")
+            self.default_interaction_type = default_interaction_mode
+        else:
+            self.default_interaction_type = default_interaction_type
+
         if isinstance(distribution_class, str):
             distribution_class = distributions_maps.get(distribution_class.lower())
         self.distribution_class = distribution_class
@@ -270,7 +321,7 @@ class ProbabilisticTensorDictModule(nn.Module):
 
         dist = self.get_dist(tensordict)
         if _requires_sample:
-            out_tensors = self._dist_sample(dist, interaction_mode=interaction_mode())
+            out_tensors = self._dist_sample(dist, interaction_type=interaction_type())
             if isinstance(out_tensors, Tensor):
                 out_tensors = (out_tensors,)
             tensordict_out.update(
@@ -294,12 +345,12 @@ class ProbabilisticTensorDictModule(nn.Module):
     def _dist_sample(
         self,
         dist: D.Distribution,
-        interaction_mode: bool = None,
+        interaction_type: str | None = None,
     ) -> tuple[Tensor, ...] | Tensor:
-        if interaction_mode is None or interaction_mode == "":
-            interaction_mode = self.default_interaction_mode
+        if interaction_type is None or interaction_type == "":
+            interaction_type = self.default_interaction_type
 
-        if interaction_mode == "mode":
+        if interaction_type == "mode":
             try:
                 return dist.mode
             except AttributeError:
@@ -307,7 +358,7 @@ class ProbabilisticTensorDictModule(nn.Module):
                     f"method {type(dist)}.mode is not implemented"
                 )
 
-        elif interaction_mode == "median":
+        elif interaction_type == "median":
             try:
                 return dist.median
             except AttributeError:
@@ -315,7 +366,7 @@ class ProbabilisticTensorDictModule(nn.Module):
                     f"method {type(dist)}.median is not implemented"
                 )
 
-        elif interaction_mode == "mean":
+        elif interaction_type == "mean":
             try:
                 return dist.mean
             except (AttributeError, NotImplementedError):
@@ -324,13 +375,13 @@ class ProbabilisticTensorDictModule(nn.Module):
                 else:
                     return dist.sample((self.n_empirical_estimate,)).mean(0)
 
-        elif interaction_mode == "random":
+        elif interaction_type == "random":
             if dist.has_rsample:
                 return dist.rsample()
             else:
                 return dist.sample()
         else:
-            raise NotImplementedError(f"unknown interaction_mode {interaction_mode}")
+            raise NotImplementedError(f"unknown interaction_type {interaction_type}")
 
 
 class ProbabilisticTensorDictSequential(TensorDictSequential):
@@ -395,10 +446,9 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
         **kwargs,
     ) -> tuple[D.Distribution, TensorDictBase]:
         tds = self.det_part
-        mode = interaction_mode()
-        if mode is None:
-            mode = self.module[-1].default_interaction_mode
-        with set_interaction_mode(mode):
+        if type := interaction_type() is None:
+            type = self.module[-1].default_interaction_type
+        with set_interaction_type(type):
             return tds(tensordict, tensordict_out, **kwargs)
 
     def get_dist(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -19,7 +19,7 @@ from tensordict.nn import (
 )
 from tensordict.nn.distributions import NormalParamExtractor, NormalParamWrapper
 from tensordict.nn.functional_modules import is_functional, make_functional
-from tensordict.nn.probabilistic import set_interaction_mode
+from tensordict.nn.probabilistic import set_interaction_type
 from torch import nn
 from torch.distributions import Normal
 
@@ -81,8 +81,8 @@ class TestTDModule:
 
     @pytest.mark.parametrize("out_keys", [["loc", "scale"], ["loc_1", "scale_1"]])
     @pytest.mark.parametrize("lazy", [True, False])
-    @pytest.mark.parametrize("interaction_mode", ["mode", "random", None])
-    def test_stateful_probabilistic_deprec(self, lazy, interaction_mode, out_keys):
+    @pytest.mark.parametrize("interaction_type", ["mode", "random", None])
+    def test_stateful_probabilistic_deprec(self, lazy, interaction_type, out_keys):
         torch.manual_seed(0)
         param_multiplier = 2
         if lazy:
@@ -110,7 +110,7 @@ class TestTDModule:
         tensordict_module = ProbabilisticTensorDictSequential(net, prob_module)
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
-        with set_interaction_mode(interaction_mode):
+        with set_interaction_type(interaction_type):
             tensordict_module(td)
         assert td.shape == torch.Size([3])
         assert td.get("out").shape == torch.Size([3, 4])
@@ -118,9 +118,9 @@ class TestTDModule:
     @pytest.mark.parametrize("out_keys", [["low"], ["low1"], [("stuff", "low1")]])
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("max_dist", [1.0, 2.0])
-    @pytest.mark.parametrize("interaction_mode", ["mode", "random", None])
+    @pytest.mark.parametrize("interaction_type", ["mode", "random", None])
     def test_stateful_probabilistic_kwargs(
-        self, lazy, interaction_mode, out_keys, max_dist
+        self, lazy, interaction_type, out_keys, max_dist
     ):
         torch.manual_seed(0)
         if lazy:
@@ -147,7 +147,7 @@ class TestTDModule:
         tensordict_module = ProbabilisticTensorDictSequential(net, prob_module)
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
-        with set_interaction_mode(interaction_mode):
+        with set_interaction_type(interaction_type):
             tensordict_module(td)
         assert td.shape == torch.Size([3])
         assert td.get("out").shape == torch.Size([3, 4])
@@ -161,8 +161,8 @@ class TestTDModule:
         ],
     )
     @pytest.mark.parametrize("lazy", [True, False])
-    @pytest.mark.parametrize("interaction_mode", ["mode", "random", None])
-    def test_stateful_probabilistic(self, lazy, interaction_mode, out_keys):
+    @pytest.mark.parametrize("interaction_type", ["mode", "random", None])
+    def test_stateful_probabilistic(self, lazy, interaction_type, out_keys):
         torch.manual_seed(0)
         param_multiplier = 2
         if lazy:
@@ -191,7 +191,7 @@ class TestTDModule:
         )
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
-        with set_interaction_mode(interaction_mode):
+        with set_interaction_type(interaction_type):
             tensordict_module(td)
         assert td.shape == torch.Size([3])
         assert td.get("out").shape == torch.Size([3, 4])
@@ -1521,16 +1521,16 @@ class TestTDSequence:
         assert torch.allclose(td_module[0].module.weight, sub_seq_1[0].module.weight)
 
 
-@pytest.mark.parametrize("mode", ["random", "mode"])
+@pytest.mark.parametrize("interaction_type", ["random", "mode"])
 class TestSIM:
-    def test_cm(self, mode):
-        with set_interaction_mode(mode):
-            assert nn_probabilistic._INTERACTION_MODE == mode
+    def test_cm(self, interaction_type):
+        with set_interaction_type(interaction_type):
+            assert nn_probabilistic._INTERACTION_TYPE == interaction_type
 
-    def test_dec(self, mode):
-        @set_interaction_mode(mode)
+    def test_dec(self, interaction_type):
+        @set_interaction_type(interaction_type)
         def dummy():
-            assert nn_probabilistic._INTERACTION_MODE == mode
+            assert nn_probabilistic._INTERACTION_TYPE == interaction_type
 
         dummy()
 

--- a/tutorials/sphinx_tuto/tensordict_module.py
+++ b/tutorials/sphinx_tuto/tensordict_module.py
@@ -167,7 +167,7 @@ assert split_and_merge_linear(tensordict)["output"].shape == torch.Size([5, 13])
 # ``ProbabilisticTensorDictModule`` is a non-parametric module representing a
 # probability distribution. Distribution parameters are read from tensordict
 # input, and the output is written to an output tensordict. The output is
-# sampled given some rule, specified by the input ``default_interaction_mode``
+# sampled given some rule, specified by the input ``default_interaction_type``
 # argument and the ``exploration_mode()`` global function. If they conflict,
 # the context manager precedes.
 #


### PR DESCRIPTION
## Description

Replaced `<*>interaction_mode` class/fcn/args with `<*>interaction_type` for better naming clarity. Added depreciated warnings to existing usage of `interaction_mode` for backward compatibility.

## Motivation and Context

Why is this change required? What problem does it solve?
This is to address https://github.com/pytorch/rl/issues/1016 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.

## Tests
* `pytest test/`
