### PR TITLE
[BugFix] Key checks in TensorDictSequential

### DIFF
--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -399,15 +399,15 @@ class TensorDictSequential(TensorDictModule):
         tensordict: TensorDictBase,
         **kwargs: Any,
     ) -> Any:
-        tensordict_keys = set(tensordict.keys(include_nested=True))
         if not self.partial_tolerant or all(
-            key in tensordict_keys for key in module.in_keys
+            key in tensordict.keys(include_nested=True) for key in module.in_keys
         ):
             tensordict = module(tensordict, **kwargs)
         elif self.partial_tolerant and isinstance(tensordict, LazyStackedTensorDict):
             for sub_td in tensordict.tensordicts:
-                tensordict_keys = set(sub_td.keys(include_nested=True))
-                if all(key in tensordict_keys for key in module.in_keys):
+                if all(
+                    key in sub_td.keys(include_nested=True) for key in module.in_keys
+                ):
                     module(sub_td, **kwargs)
             tensordict._update_valid_keys()
         return tensordict


### PR DESCRIPTION
## Description

Use `key in tensordict.keys()` inside `TensorDictSequential` instead of collecting keys into a `set`.

The old way of doing things causes problems when using `TensorDictSequential` on a `LazyStackedTensorDict` with some entries that can't be stacked, even if they are not used by the sequential module. See example below

```python
import torch
import torch.nn as nn
from tensordict import TensorDict
from tensordict.nn import TensorDictModule, TensorDictSequential

tds = [
    TensorDict({"in": torch.rand(10, 3), "other": torch.rand(10, 2)}, batch_size=[10]),
    TensorDict({"in": torch.rand(10, 3), "other": torch.rand(10, 5)}, batch_size=[10]),
]
td = torch.stack(tds, 0)

module1 = TensorDictModule(nn.Linear(3, 5), ["in"], ["intermediate"])
module2 = TensorDictModule(nn.Linear(5, 1), ["intermediate"], ["out"])
module = TensorDictSequential(module1, module2)

module(td)  # fails on main
```