### PR TITLE
[BugFix] Add dispatch decorator to probabilistic modules

### DIFF
--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -13,7 +13,7 @@ from warnings import warn
 
 from tensordict._contextlib import _DecoratorContextManager
 
-from tensordict.nn.common import TensorDictModule, TensorDictModuleBase
+from tensordict.nn.common import dispatch, TensorDictModule, TensorDictModuleBase
 from tensordict.nn.distributions import Delta, distributions_maps
 from tensordict.nn.sequence import TensorDictSequential
 
@@ -334,6 +334,7 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
                 raise err
         return dist
 
+    @dispatch(auto_batch_size=False)
     @set_skip_existing(None)
     def forward(
         self,
@@ -491,6 +492,7 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
         """Construct a distribution from the input parameters. Other modules in the sequence are not evaluated."""
         return self.module[-1].get_dist(tensordict)
 
+    @dispatch(auto_batch_size=False)
     @set_skip_existing(None)
     def forward(
         self,


### PR DESCRIPTION
## Description

This PR adds the `dispatch` decorator to probabilistic variants of `TensorDict{Module,Sequential}` in order that they may be used with positional / keyword tensor arguments as well as tensordicts.

Happy to add tests if you think they're needed.
