### PR TITLE
[BugFix] Add sample_log_prob to out_keys when return_log_prob=True

### DIFF
--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -312,6 +312,8 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
         self._dist = None
         self.cache_dist = cache_dist if hasattr(distribution_class, "update") else False
         self.return_log_prob = return_log_prob
+        if self.return_log_prob:
+            self.out_keys.append("sample_log_prob")
 
     def get_dist(self, tensordict: TensorDictBase) -> D.Distribution:
         try:


### PR DESCRIPTION
## Description

This PR adds `sample_log_prob` to the `out_keys` of a `ProbabilisticTensorDictModule` when `return_log_prob=True`. 

The primary motivation is so that sample_log_prob is returned as part of the tuple of tensors when a probabilistic module is used with tensor arguments via the dispatch decorator (cf. #345)