### PR TITLE
[Bugfix] fix getitem

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -517,6 +517,16 @@ class TensorDictModuleBase(nn.Module):
                 is_shared=False)
 
         """
+        if len(out_keys) == 1:
+            if out_keys[0] not in self.out_keys:
+                err_msg = f"Can't select non existent key: {out_keys[0]}. "
+                if (
+                    out_keys[0]
+                    and isinstance(out_keys[0], (tuple, list))
+                    and out_keys[0][0] in self.out_keys
+                ):
+                    err_msg += f"Are you passing the keys in a list? Try unpacking as: `{', '.join(out_keys[0])}`"
+                raise ValueError(err_msg)
         self.register_forward_hook(_OutKeysSelect(out_keys))
         for hook in self._forward_hooks.values():
             hook._init(self)


### PR DESCRIPTION
getitem is not working correctly paired with select_out_keys as the input is not a tuple but a list:
```python
mod = TensorDictModule(
    lambda x, y: (x + 2, y + 2, x), in_keys=["a", "b"], out_keys=["c", "d", "e"]
)
print(mod.out_keys)
mod.select_out_keys(["c", "d", "e"])
print(mod.out_keys)
mod.reset_out_keys()
print(mod.out_keys)
```
Results in:
```
['c', 'd', 'e']
[['c', 'd', 'e']]
['c', 'd', 'e']
```
then when dispatched [this](https://github.com/pytorch-labs/tensordict/blob/main/tensordict/nn/common.py#L271) raises
