### PR TITLE
[Refactor] Faster creation on device

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1545,9 +1545,6 @@ class TensorDictBase(MutableMapping):
                     f" numeric scalars and tensors. Got {type(value)}"
                 )
 
-        if self.device is not None:
-            value = value.to(self.device)
-
         if check_shape and _shape(value)[: self.batch_dims] != self.batch_size:
             # if TensorDict, let's try to map it to the desired shape
             if is_tensor_collection(value):
@@ -1559,6 +1556,10 @@ class TensorDictBase(MutableMapping):
                     f"={self.batch_size} and value.shape[:self.batch_dims]"
                     f"={_shape(value)[: self.batch_dims]} with value {value}"
                 )
+
+        if self.device is not None:
+            value = value.to(self.device, non_blocking=True)
+
         if (
             self._names is not None
             and is_tensor_collection(value)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1557,7 +1557,9 @@ class TensorDictBase(MutableMapping):
                     f"={_shape(value)[: self.batch_dims]} with value {value}"
                 )
 
-        if self.device is not None:
+        if self.device is not None and self.device.type == "cuda" and value.device == torch.device("cpu"):
+            value = value.pin_memory().to(self.device, non_blocking=True)
+        else:
             value = value.to(self.device, non_blocking=True)
 
         if (

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1557,9 +1557,7 @@ class TensorDictBase(MutableMapping):
                     f"={_shape(value)[: self.batch_dims]} with value {value}"
                 )
 
-        if self.device is not None and self.device.type == "cuda" and value.device == torch.device("cpu"):
-            value = value.pin_memory().to(self.device, non_blocking=True)
-        else:
+        if self.device is not None:
             value = value.to(self.device, non_blocking=True)
 
         if (


### PR DESCRIPTION
We call `to(..., non_blocking=True)` in TD creation to make things faster

Before
```python
%%timeit
td = TensorDict({s: torch.zeros(100, 100) for s in string.ascii_lowercase}, [], device="cuda:0")
```
1.16 ms ± 279 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

After
783 µs ± 167 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)


Conversely, before:
```python
%%timeit
td = TensorDict({s: torch.zeros(100, 100, device="cuda:0") for s in string.ascii_lowercase}, [], device="cpu")
```
1.25 ms ± 170 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

after
613 µs ± 27 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

For the record:
I tested pin_memory but it does not help
