### PR TITLE
[BugFix] fix infinite loop

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2369,7 +2369,7 @@ class TensorDictBase(MutableMapping):
         while mask_expand.ndimension() > self.batch_dims:
             mndim = mask_expand.ndimension()
             mask_expand = mask_expand.squeeze(-1)
-            if mndim == mask_expand.ndimension():   # no more squeeze
+            if mndim == mask_expand.ndimension():  # no more squeeze
                 break
         for key, value in self.items():
             d[key] = value[mask_expand]

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2365,13 +2365,14 @@ class TensorDictBase(MutableMapping):
 
         """
         d = {}
+        mask_expand = mask
+        while mask_expand.ndimension() > self.batch_dims:
+            mndim = mask_expand.ndimension()
+            mask_expand = mask_expand.squeeze(-1)
+            if mndim == mask_expand.ndimension():   # no more squeeze
+                break
         for key, value in self.items():
-            while mask.ndimension() > self.batch_dims:
-                mask_expand = mask.squeeze(-1)
-            else:
-                mask_expand = mask
-            value_select = value[mask_expand]
-            d[key] = value_select
+            d[key] = value[mask_expand]
         dim = int(mask.sum().item())
         other_dim = self.shape[mask.ndim :]
         return TensorDict(


### PR DESCRIPTION
## Description

`TensorDictBase.masked_select()` will stuck in infinite loop if the input argument `mask` has `.ndimension()` > `self.batch_dims`.

It's obvious to know the bug cause from the code piece below inside the `TensorDictBase.masked_select()` without test, where we see the variables are always not updated in the while condition.

```python
        for key, value in self.items():
            while mask.ndimension() > self.batch_dims:
                mask_expand = mask.squeeze(-1)
            else:
                mask_expand = mask
            value_select = value[mask_expand]
            d[key] = value_select
```

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Reproduction and Test

```python
# codes are too heavy for the simple bug
# pip install timeout_decorator
# bug of TensorDict.masked_select()
from torchrl.envs.libs.gym import GymEnv
from torchrl.collectors import SyncDataCollector, RandomPolicy
import torch

coll=SyncDataCollector(GymEnv("Pendulum-v1"), policy=None, total_frames=203, frames_per_batch=7, reset_when_done=True)
for td in coll:
    pass
print(td.batch_size)
print(td["next","done"])
print(td["done"])

del coll

import timeout_decorator
@timeout_decorator.timeout(3)
def masksel():
    # mask=torch.ones(td.batch_size, dtype=torch.bool)
    # mask[3:]=False
    mask=torch.logical_not(td["next","done"])   # with shape [N,1]
    assert mask.ndim == 2
    td1=td.masked_select(mask)
    assert td1 is not td
    print(td1["done"])
masksel()
```