### PR TITLE
[Feature] clone_on_set to clone locked tds

### DIFF
--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -568,7 +568,9 @@ class PersistentTensorDict(TensorDictBase):
 
     def lock_(self, clone_on_set=False) -> TensorDictBase:
         if clone_on_set:
-            raise NotImplementedError("clone_on_set=True is not supported for persistent TensorDicts.")
+            raise NotImplementedError(
+                "clone_on_set=True is not supported for persistent TensorDicts."
+            )
         return super().lock_()
 
     def rename_key_(

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -566,6 +566,11 @@ class PersistentTensorDict(TensorDictBase):
         }
         return out
 
+    def lock_(self, clone_on_set=False) -> TensorDictBase:
+        if clone_on_set:
+            raise NotImplementedError("clone_on_set=True is not supported for persistent TensorDicts.")
+        return super().lock_()
+
     def rename_key_(
         self, old_key: str, new_key: str, safe: bool = False
     ) -> PersistentTensorDict:

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -361,7 +361,7 @@ def _getattribute_wrapper(getattribute: Callable) -> Callable:
                 "_tensordict" in self.__dict__
                 and item in self.__dict__["_tensordict"].keys()
             ):
-                out = self._tensordict[item]
+                out = self._tensordict.get(item)
                 return out
             elif (
                 "_non_tensordict" in self.__dict__
@@ -384,12 +384,19 @@ def _setattr_wrapper(setattr_: Callable, expected_keys: set[str]) -> Callable:
             value (any): the value to set for the attribute
 
         """
+        __dict__ = self.__dict__
         if (
-            "_tensordict" not in self.__dict__
-            or "_non_tensordict" not in self.__dict__
+            "_tensordict" not in __dict__
+            or "_non_tensordict" not in __dict__
             or key in ("batch_size", "device")
         ):
             return setattr_(self, key, value)
+
+        if __dict__["_tensordict"].is_locked:
+            if __dict__["_tensordict"]._clone_on_set:
+                return self.clone(False).set(key, value)
+            raise RuntimeError(TensorDictBase.LOCK_ERROR)
+
         if key not in expected_keys:
             raise AttributeError(
                 f"Cannot set the attribute '{key}', expected attributes are {expected_keys}."
@@ -399,14 +406,13 @@ def _setattr_wrapper(setattr_: Callable, expected_keys: set[str]) -> Callable:
             # Avoiding key clash, honoring the user input to assign tensor type data to the key
             if key in self._non_tensordict.keys():
                 del self._non_tensordict[key]
-            self._tensordict[key] = value
+            self._tensordict.set(key, value)
         else:
             # Avoiding key clash, honoring the user input to assign non-tensor data to the key
             if key in self._tensordict.keys():
-                del self._tensordict[key]
+                self._tensordict.del_(key)
             # Saving all non-tensor attributes
             self._non_tensordict[key] = value
-        return None
 
     return wrapper
 
@@ -600,7 +606,7 @@ def _set(self, key: NestedKey, value: Any):
 
     if key and isinstance(key, tuple):
         if len(key) > 1:
-            return getattr(self, key[0]).set(key[1:], value)
+            return setattr(self, key[0], getattr(self, key[0]).set(key[1:], value))
         return setattr(self, key[0], value)
     raise ValueError(
         f"Supported type for key are str and tuple, got {key} of type {type(key)}"

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5706,7 +5706,8 @@ class LazyStackedTensorDict(TensorDictBase):
         inplace: bool = False,
     ) -> TensorDictBase:
         key = self._validate_key(key)
-        if self.is_locked:
+
+        if self.is_locked and not inplace:
             if self._clone_on_set:
                 return self.clone(False).set(key, tensor, inplace=inplace)
             else:


### PR DESCRIPTION
For #426 we need to lock the tensordict because we cache it and we don't want to modify the keys of a cached tensordict during a call to a vmapped function. For example
```
z = vmap(lambda x, y: y.set(x.get("a")+y.get("a")), (0, None))(x, y)
```
Here, during vmap, the `y.set` is executed on a cached clone of y where some dimensions are batched. If we modify `y` in place, a second call to vmap will see the modified version of `y` which is not what we want (we want this cached version of y to be immutable).
The obvious solution would be to lock the cached tensordict.

However, TensorDictModule modifies things in-place by default. We could patch it to allow it to return cloned versions of the tensordict, but that would be bothersome to the users and would not work across all submodules of TensorDictModuleBase.

This PR proposes a `clone_on_set` kwarg in various methods (mostly set-related) that changes the behaviour of set to return a cloned tensordict when asked for.

**Caveat**: this will fail with the following code which apparently does the same as the previous one:
```
def fun(x, y):
    y.set(x.get("a")+y.get("a"))
    return y
z = vmap(fun, (0, None))(x, y)
```
