### PR TITLE
[Feature] Prevent lock/unlock conflicts for stacked and nested tensordicts

### DIFF
--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -135,6 +135,8 @@ class PersistentTensorDict(TensorDictBase):
         device=None,
         **kwargs,
     ):
+        self._locked_tensordicts = []
+        self._lock_id = set()
         if not _has_h5:
             raise ModuleNotFoundError("Could not load h5py.") from H5_ERR
         super().__init__()

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -373,6 +373,7 @@ def _getattribute_wrapper(getattribute: Callable) -> Callable:
 
     return wrapper
 
+SET_ATTRIBUTES = ("batch_size", "device", "_locked_tensordicts")
 
 def _setattr_wrapper(setattr_: Callable, expected_keys: set[str]) -> Callable:
     @functools.wraps(setattr_)
@@ -387,7 +388,7 @@ def _setattr_wrapper(setattr_: Callable, expected_keys: set[str]) -> Callable:
         if (
             "_tensordict" not in self.__dict__
             or "_non_tensordict" not in self.__dict__
-            or key in ("batch_size", "device")
+            or key in SET_ATTRIBUTES
         ):
             return setattr_(self, key, value)
         if key not in expected_keys:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3289,26 +3289,73 @@ class TensorDictBase(MutableMapping):
         else:
             self.unlock_()
 
-    def lock_(self) -> TensorDictBase:
+    def _lock_propagate(self, lock_ids):
+        """Registers the parent tensordict that handles the lock."""
         self._is_locked = True
+        self._lock_id = self._lock_id.union(lock_ids)
+        lock_ids = lock_ids.union({id(self)})
+        _locked_tensordicts = []
         for key in self.keys():
             if _is_tensor_collection(self.entry_class(key)):
-                self.get(key).lock_()
+                dest = self.get(key)
+                dest_locked, new_lock_ids = dest._lock_propagate(lock_ids)
+                dest._locked_tensordicts += dest_locked
+                _locked_tensordicts.append(dest)
+                # we only keep the next level
+                # _locked_tensordicts += dest_locked
+        return _locked_tensordicts, lock_ids
+
+    def lock_(self) -> TensorDictBase:
+        if self.is_locked:
+            return self
+        self._locked_tensordicts, _ = self._lock_propagate(set())
         return self
 
     lock = _renamed_inplace_method(lock_)
 
-    def unlock_(self) -> TensorDictBase:
+    def _remove_lock(self, lock_id):
+        self._lock_id = self._lock_id - {lock_id}
+        if self._locked_tensordicts:
+            for td in self._locked_tensordicts:
+                td._remove_lock(lock_id)
+
+    def _propagate_unlock(self, lock_ids=None):
+        if lock_ids is not None:
+            self._lock_id.difference_update(lock_ids)
+        else:
+            lock_ids = set()
+
+        unlocked_tds = [self]
+        lock_ids.add(id(self))
+        for key in self.keys():
+            if _is_tensor_collection(self.entry_class(key)):
+                dest = self.get(key)
+                unlocked_tds.extend(dest._propagate_unlock(lock_ids))
+        self._locked_tensordicts = []
+
         self._is_locked = False
         self._is_shared = False
         self._is_memmap = False
         self._sorted_keys = None
-        for key in self.keys():
-            if _is_tensor_collection(self.entry_class(key)):
-                self.get(key).unlock_()
+        return unlocked_tds
+
+    def unlock_(self) -> TensorDictBase:
+        unlock_tds = self._propagate_unlock()
+        for td in unlock_tds:
+            if len(td._lock_id):
+                self.lock_()
+                raise RuntimeError(
+                    "Cannot unlock a tensordict that is part of a locked graph. "
+                    "Unlock the root tensordict first. If the tensordict is part of multiple graphs, "
+                    "group the graphs under a common tensordict an unlock this root. "
+                )
         return self
 
     unlock = _renamed_inplace_method(unlock_)
+
+    def __del__(self):
+        for td in self._locked_tensordicts:
+            td._remove_lock(id(self))
 
     def is_floating_point(self):
         for item in self.values(include_nested=True, leaves_only=True):
@@ -3446,6 +3493,8 @@ class TensorDict(TensorDictBase):
         "_device",
         "_is_locked",
         "_td_dim_names",
+        "_lock_id",
+        "_locked_tensordicts",
     )
 
     def __new__(cls, *args: Any, **kwargs: Any) -> TensorDict:
@@ -3464,6 +3513,9 @@ class TensorDict(TensorDictBase):
         _is_shared: bool | None = False,
         _is_memmap: bool | None = False,
     ) -> None:
+        self._lock_id = set()
+        self._locked_tensordicts = []
+
         self._is_shared = _is_shared
         self._is_memmap = _is_memmap
         if device is not None:
@@ -4912,6 +4964,8 @@ torch.Size([3, 2])
         idx: IndexType,
         batch_size: Sequence[int] | None = None,
     ) -> None:
+        self._lock_id = set()
+        self._locked_tensordicts = []
         if not isinstance(source, TensorDictBase):
             raise TypeError(
                 f"Expected source to be a subclass of TensorDictBase, "
@@ -5825,8 +5879,10 @@ class LazyStackedTensorDict(TensorDictBase):
         tensors = [td.get(key, default=default) for td in self.tensordicts]
         try:
             out = torch.stack(tensors, self.stack_dim)
-            if _is_tensor_collection(out.__class__) and self._td_dim_names is not None:
-                out.refine_names(*self.names, *out.names[self.ndim :])
+            if _is_tensor_collection(out.__class__):
+                if self._td_dim_names is not None:
+                    out.refine_names(*self.names, *out.names[self.ndim :])
+
             return out
         except RuntimeError as err:
             if "stack expects each tensor to be equal size" in str(err):
@@ -6687,11 +6743,11 @@ class LazyStackedTensorDict(TensorDictBase):
 
     @property
     def is_locked(self) -> bool:
-        is_locked = self._is_locked
         for td in self.tensordicts:
-            is_locked = is_locked or td.is_locked
-        self._is_locked = is_locked
-        return is_locked
+            if td.is_locked:
+                return True
+        else:
+            return False
 
     @is_locked.setter
     def is_locked(self, value: bool) -> None:
@@ -6700,23 +6756,55 @@ class LazyStackedTensorDict(TensorDictBase):
         else:
             self.unlock_()
 
-    def lock_(self) -> LazyStackedTensorDict:
-        self._is_locked = True
+    @property
+    def _lock_id(self):
+        """Ids of all tensordicts that need to be unlocked for this to be unlocked."""
+        _lock_id = set()
+        for tensordict in self.tensordicts:
+            _lock_id = _lock_id.union(tensordict._lock_id)
+        _lock_id = _lock_id - {id(self)}
+        return _lock_id
+
+    def _lock_propagate(self, lock_ids):
+        """Registers the parent tensordict that handles the lock."""
+        print("propagating with lock_ids", lock_ids)
+        _locked_tensordicts = []
+        lock_ids = lock_ids.union({id(self)})
+        for dest in self.tensordicts:
+            dest_locked, new_lock_ids = dest._lock_propagate(lock_ids)
+            dest._locked_tensordicts += dest_locked
+            _locked_tensordicts.append(dest)
+            # we only keep the next level
+            # _locked_tensordicts += dest_locked
+        return _locked_tensordicts, lock_ids
+
+    def _remove_lock(self, lock_id):
         for td in self.tensordicts:
-            td.lock_()
-        return self
+            td._remove_lock(lock_id)
 
-    lock = _renamed_inplace_method(lock_)
+    def _propagate_unlock(self, lock_ids=None):
+        if lock_ids is None:
+            lock_ids = set()
 
-    def unlock_(self) -> LazyStackedTensorDict:
+        unlocked_tds = [self]
+        lock_ids.add(id(self))
+        for dest in self.tensordicts:
+            unlocked_tds.extend(dest._propagate_unlock(lock_ids))
+
         self._is_locked = False
         self._is_shared = False
         self._is_memmap = False
         self._sorted_keys = None
-        for td in self.tensordicts:
-            td.unlock_()
-        return self
+        return unlocked_tds
 
+    def __del__(self):
+        for td in self.tensordicts:
+            td._remove_lock(id(self))
+
+    lock_ = TensorDictBase.lock_
+    lock = _renamed_inplace_method(lock_)
+
+    unlock_ = TensorDictBase.unlock_
     unlock = _renamed_inplace_method(unlock_)
 
 
@@ -6735,6 +6823,8 @@ class _CustomOpTensorDict(TensorDictBase):
         inv_op_kwargs: dict | None = None,
         batch_size: Sequence[int] | None = None,
     ) -> None:
+        self._lock_id = set()
+        self._locked_tensordicts = []
         self._is_shared = source.is_shared()
         self._is_memmap = source.is_memmap()
 


### PR DESCRIPTION
Introduces a lock tracking mechanism across tensordicts in a graph to tie them together such that once a root tensordict is locked, no sub-tensordict (either from a stack or a nested tensordict) can be unlocked and modified.
The use case we want to prevent is this
```python
td = TensorDict({("a", "b", "c", "d"): 1.0}, [])
a = td["a"]
b = td["a", "b"]
c = td["a", "b", "c"]
td.lock_()
a.unlock_()
a["b"] = 1.0
a.lock_()
```
In this case, one should not be allowed to modify "a" as it is locked by "td".

This means that some edge cases now need to be considered:

```python
td = TensorDict({("a", "b", "c", "d"): 1.0}, [])
other_td = TensorDict({"a": td["a"]}, [])
td.lock_()
other_td.lock_()
td.unlock_() # raises an exception
```
This new exception comes from the fact that "a" and the other sub-tesnsordicts are now included in two separated graphs so we can't unlock them.
To unlock this, there are 2 solutions:
```python
del other_td
td.unlock_() # works
```
or
```python
super_td = TensorDict({"td": td, "other_td": other_td}, [])
super_td.unlock_() # works
```

We include some new tests to check that everything works as expected for tensordict and lazy stacks.