### PR TITLE
[Refactor] Better key membership check

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -278,47 +278,46 @@ class _TensorDictKeysView:
         return self.tensordict._tensordict.keys()
 
     def __contains__(self, key: NestedKey) -> bool:
+        try:
+            key = unravel_keys(key)
+        except Exception as err:
+            raise TypeError(NON_STR_KEY) from err
+
         if isinstance(key, str):
             if key in self._keys():
                 if self.leaves_only:
                     return not _is_tensor_collection(self.tensordict.entry_class(key))
                 return True
             return False
-
-        elif isinstance(key, tuple):
+        else:
+            # thanks to unravel_keys we know the key is a tuple
             if len(key) == 1:
-                return key[0] in self
-            elif len(key) > 1 and self.include_nested:
+                return key[0] in self._keys()
+            elif self.include_nested:
                 if key[0] in self._keys():
                     entry_type = self.tensordict.entry_class(key[0])
-                    is_tensor = entry_type is Tensor
-                    is_kjt = not is_tensor and entry_type is KeyedJaggedTensor
-                    _is_tensordict = (
-                        not is_tensor
-                        and not is_kjt
-                        and _is_tensor_collection(entry_type)
-                    )
-
-                    # TODO: SavedTensorDict currently doesn't support nested membership checks
-                    _tensordict_nested = _is_tensordict and key[
-                        1:
-                    ] in self.tensordict.get(key[0]).keys(
-                        include_nested=self.include_nested
-                    )
-                    if _tensordict_nested:
-                        return True
-                    _kjt = (
-                        is_kjt
-                        and len(key) == 2
-                        and key[1] in self.tensordict.get(key[0]).keys()
-                    )
-                    return _kjt
-
+                    if entry_type in (Tensor, MemmapTensor):
+                        return False
+                    if entry_type is KeyedJaggedTensor:
+                        if len(key) > 2:
+                            return False
+                        return key[1] in self.tensordict.get(key[0]).keys()
+                    _is_tensordict = _is_tensor_collection(entry_type)
+                    if _is_tensordict:
+                        # # this will call unravel_keys many times
+                        # return key[1:] in self.tensordict._get_str(key[0], NO_DEFAULT).keys(include_nested=self.include_nested)
+                        # this won't call unravel_keys but requires to get the default which can be suboptimal
+                        leaf_td = self.tensordict._get_tuple(key[:-1], None)
+                        if leaf_td is None or (
+                            not _is_tensor_collection(leaf_td.__class__)
+                            and not isinstance(leaf_td, KeyedJaggedTensor)
+                        ):
+                            return False
+                        return key[-1] in leaf_td.keys()
                 return False
+            # this is reached whenever there is more than one key but include_nested is False
             if all(isinstance(subkey, str) for subkey in key):
                 raise TypeError(NON_STR_KEY_TUPLE)
-
-        raise TypeError(NON_STR_KEY)
 
     def __repr__(self):
         include_nested = f"include_nested={self.include_nested}"

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5716,11 +5716,11 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
         return self.tensordict.valid_keys
 
     def __contains__(self, item):
+        item = unravel_keys(item)
         if isinstance(item, str):
             if item in self._keys():
                 return True
-        item = unravel_keys(item)
-        if len(item) == 1:
+        elif len(item) == 1:
                 return item[0] in self
         # otherwise take the long way
         return all(

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5719,9 +5719,16 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
         item = unravel_keys(item)
         if isinstance(item, str):
             if item in self._keys():
+                if self.leaves_only:
+                    return not _is_tensor_collection(self.tensordict.entry_class(item))
                 return True
         elif len(item) == 1:
-            return item[0] in self._keys()
+            if item[0] in self._keys():
+                if self.leaves_only:
+                    return not _is_tensor_collection(
+                        self.tensordict.entry_class(item[0])
+                    )
+                return True
         # otherwise take the long way
         return all(
             item in tensordict.keys(self.include_nested, self.leaves_only)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5715,6 +5715,15 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
     def _keys(self) -> list[str]:
         return self.tensordict.valid_keys
 
+    def __contains__(self, item):
+        if isinstance(item, str) and item in self._keys():
+            return True
+        # otherwise take the long way
+        return all(
+            item in tensordict.keys(self.include_nested, self.leaves_only)
+            for tensordict in self.tensordict.tensordicts
+        )
+
 
 class LazyStackedTensorDict(TensorDictBase):
     """A Lazy stack of TensorDicts.

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5716,8 +5716,11 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
         return self.tensordict.valid_keys
 
     def __contains__(self, item):
-        if isinstance(item, str) and item in self._keys():
-            return True
+        if isinstance(item, str):
+            if item in self._keys():
+                return True
+            if len(item) == 1:
+                return item[0] in self
         # otherwise take the long way
         return all(
             item in tensordict.keys(self.include_nested, self.leaves_only)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5721,7 +5721,7 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
             if item in self._keys():
                 return True
         elif len(item) == 1:
-            return item[0] in self
+            return item[0] in self._keys()
         # otherwise take the long way
         return all(
             item in tensordict.keys(self.include_nested, self.leaves_only)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -5719,7 +5719,8 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
         if isinstance(item, str):
             if item in self._keys():
                 return True
-            if len(item) == 1:
+        item = unravel_keys(item)
+        if len(item) == 1:
                 return item[0] in self
         # otherwise take the long way
         return all(


### PR DESCRIPTION
Duplicate after correction of #461 

This is bc-breaking: see #461 for edge cases where membership of lazy stacks fails to be apparent.
Lazy stacks `pop` method now also truly delete the key from the sub-tds, not only hides it (which would make the key reappear anytime valid_keys is recomputed).