### PR TITLE
[Feature] Add reset_parameters support to TensorDictModuleBase

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -792,7 +792,8 @@ class TensorDictModuleBase(nn.Module):
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
             else:
-                [self._reset_parameters(m) for m in module.children()]
+                for m in module.children():
+                    self._reset_parameters(m)
 
 
 class TensorDictModule(TensorDictModuleBase):

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -788,7 +788,7 @@ class TensorDictModuleBase(nn.Module):
             self._reset_parameters(m)
 
     def _reset_parameters(self, module: Union[nn.Module, TensorDictModuleBase]):
-        if isinstance(module, Union[TensorDictModuleBase, nn.Module]):
+        if isinstance(module, nn.Module):
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
             else:

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -784,7 +784,8 @@ class TensorDictModuleBase(nn.Module):
         >>> (old_param == net[0].weight).all()
         tensor(False)
         """
-        [self._reset_parameters(m) for m in self.children()]
+        for m in self.children():
+            self._reset_parameters(m)
 
     def _reset_parameters(self, module: Union[nn.Module, TensorDictModuleBase]):
         if isinstance(module, Union[TensorDictModuleBase, nn.Module]):

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -773,7 +773,7 @@ class TensorDictModuleBase(nn.Module):
 
     def reset_parameters(self):
         """Recursively reset the parameters of the module and its children.
-        
+
         Examples:
         >>> from tensordict.nn import TensorDictModule
         >>> from torch import nn

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -96,6 +96,17 @@ class TestTDModule:
             td = TensorDict({"1": torch.ones(1)}, [])
         assert (module(td)["a"] == 2).all()
 
+    def test_reset(self):
+        torch.manual_seed(0)
+        net = nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())])
+        old_param = net[0][0].weight.data.clone()
+        module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
+        another_module = TensorDictModule(nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"])
+        seq = TensorDictSequential(module, another_module)
+        
+        seq.reset_parameters()
+        assert torch.all(old_param != net[0][0].weight.data)
+
     @pytest.mark.parametrize("lazy", [True, False])
     def test_stateful(self, lazy):
         torch.manual_seed(0)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -101,9 +101,11 @@ class TestTDModule:
         net = nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())])
         old_param = net[0][0].weight.data.clone()
         module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
-        another_module = TensorDictModule(nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"])
+        another_module = TensorDictModule(
+            nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"]
+        )
         seq = TensorDictSequential(module, another_module)
-        
+
         seq.reset_parameters()
         assert torch.all(old_param != net[0][0].weight.data)
 


### PR DESCRIPTION
## Description

This allows us to call `reset_parameters()` on a `TensorDictModuleBase` like one would with an `nn.Module`. cc @vmoens or @matteobettini

## Motivation and Context

I am trying to implement ensembles in TorchRL (https://github.com/pytorch/rl/issues/1344) and being able to call `reset_parameters` would make things easier. An added bonus is that now you can reinitialize the parameters for any `TensorDictModule` which seems like it could be handy.


- [ oops ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly. (How do I do this?)
