### PR TITLE
Functional reset_parameters

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -809,12 +809,10 @@ class TensorDictModuleBase(nn.Module):
             )
             repopulate_module(self, sanitized_parameters)
 
-        for child in list(self.children()):
-            child.apply(
-                lambda m: m.reset_parameters()
-                if hasattr(m, "reset_parameters")
-                else None
-            )
+        def _reset(module):
+            if hasattr(module, 'reset_parameters'):
+                module.reset_parameters()
+        self.apply(reset_parameters)
 
 
 class TensorDictModule(TensorDictModuleBase):

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -800,7 +800,7 @@ class TensorDictModuleBase(nn.Module):
             >>> (old_param == net[0].weight).any()
             tensor(False)
 
-            This method also supports functional parameter sampling:
+        This method also supports functional parameter sampling:
 
             >>> from tensordict import TensorDict
             >>> from tensordict.nn import TensorDictModule
@@ -816,6 +816,10 @@ class TensorDictModuleBase(nn.Module):
         if parameters is None:
             self._reset_parameters(self)
             return
+        elif parameters.ndim:
+            raise NotImplementedError(
+                "reset_parameters_recursive does not support batched TensorDicts, ensure batch_size is []"
+            )
 
         sanitized_parameters = parameters.apply(
             lambda x: x.detach().requires_grad_(), inplace=False

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -773,7 +773,7 @@ class TensorDictModuleBase(nn.Module):
 
     def reset_parameters(self):
         """Recursively reset the parameters of the module and its children.
-
+        
         Examples:
         >>> from tensordict.nn import TensorDictModule
         >>> from torch import nn
@@ -784,16 +784,14 @@ class TensorDictModuleBase(nn.Module):
         >>> (old_param == net[0].weight).all()
         tensor(False)
         """
-        for m in self.children():
-            self._reset_parameters(m)
+        [self._reset_parameters(m) for m in self.children()]
 
     def _reset_parameters(self, module: Union[nn.Module, TensorDictModuleBase]):
-        if isinstance(module, nn.Module):
+        if isinstance(module, Union[TensorDictModuleBase, nn.Module]):
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
             else:
-                for m in module.children():
-                    self._reset_parameters(m)
+                [self._reset_parameters(m) for m in module.children()]
 
 
 class TensorDictModule(TensorDictModuleBase):

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -792,7 +792,8 @@ class TensorDictModuleBase(nn.Module):
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
             else:
-                [self._reset_parameters(m) for m in module.children()]
+                for m in module.children():
+                    self._reset_parameters(m)
 
 
 class TensorDictModule(TensorDictModuleBase):

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -775,7 +775,7 @@ class TensorDictModuleBase(nn.Module):
         """Recursively reset the parameters of the module and its children.
 
         Args:
-            parameters: If set to None, the module will reset using self.parameters().
+            parameters (TensorDict of parameters, optional): If set to None, the module will reset using self.parameters().
                 Otherwise, we will reset the parameters in the tensordict in-place. This is
                 useful for functional modules where the parameters are not stored in the module itself.
 

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -789,16 +789,19 @@ class TensorDictModuleBase(nn.Module):
         >>> (old_param == net[0].weight).any()
         tensor(False)
 
-        >>> from tensordict import TensorDict
-        >>> from tensordict.nn import TensorDictModule
-        >>> from torch import nn
-        >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
-        >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
-        >>> params = TensorDict.from_module(module)
-        >>> old_params = params.clone(recurse=True)
-        >>> module.reset_parameters(params)
-        >>> (old_params == params).any()
-        False
+        This method also supports functional parameter sampling:
+        
+        Examples:
+            >>> from tensordict import TensorDict
+            >>> from tensordict.nn import TensorDictModule
+            >>> from torch import nn
+            >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
+            >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
+            >>> params = TensorDict.from_module(module)
+            >>> old_params = params.clone(recurse=True)
+            >>> module.reset_parameters(params)
+            >>> (old_params == params).any()
+            False
         """
         if parameters is not None:
             sanitized_parameters = parameters.apply(

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -783,18 +783,17 @@ class TensorDictModuleBase(nn.Module):
             A tensordict of the new parameters, only if parameters was not None.
 
         Examples:
-        >>> from tensordict.nn import TensorDictModule
-        >>> from torch import nn
-        >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
-        >>> old_param = net[0].weight.clone()
-        >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
-        >>> module.reset_parameters()
-        >>> (old_param == net[0].weight).any()
-        tensor(False)
+            >>> from tensordict.nn import TensorDictModule
+            >>> from torch import nn
+            >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
+            >>> old_param = net[0].weight.clone()
+            >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
+            >>> module.reset_parameters()
+            >>> (old_param == net[0].weight).any()
+            tensor(False)
 
-        This method also supports functional parameter sampling:
+            This method also supports functional parameter sampling:
         
-        Examples:
             >>> from tensordict import TensorDict
             >>> from tensordict.nn import TensorDictModule
             >>> from torch import nn

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -15,7 +15,13 @@ import torch
 from cloudpickle import dumps as cloudpickle_dumps, loads as cloudpickle_loads
 from tensordict._tensordict import unravel_keys
 
-from tensordict.nn.functional_modules import _swap_state, extract_weights_and_buffers, is_functional, make_functional, repopulate_module
+from tensordict.nn.functional_modules import (
+    _swap_state,
+    extract_weights_and_buffers,
+    is_functional,
+    make_functional,
+    repopulate_module,
+)
 
 from tensordict.nn.utils import set_skip_existing
 from tensordict.tensordict import is_tensor_collection, make_tensordict, TensorDictBase
@@ -771,7 +777,9 @@ class TensorDictModuleBase(nn.Module):
                 del self._forward_hooks[i]
         return self
 
-    def reset_parameters(self, parameters: Optional[TensorDictBase] = None) -> Optional[TensorDictBase]:
+    def reset_parameters(
+        self, parameters: Optional[TensorDictBase] = None
+    ) -> Optional[TensorDictBase]:
         """Recursively reset the parameters of the module and its children.
 
         Args:
@@ -793,7 +801,7 @@ class TensorDictModuleBase(nn.Module):
             tensor(False)
 
             This method also supports functional parameter sampling:
-        
+
             >>> from tensordict import TensorDict
             >>> from tensordict.nn import TensorDictModule
             >>> from torch import nn
@@ -818,12 +826,19 @@ class TensorDictModuleBase(nn.Module):
         if self._is_stateless:
             repopulate_module(self, sanitized_parameters)
         else:
-            old_params = _swap_state(self, sanitized_parameters, is_stateless=False, return_old_tensordict=True)
+            old_params = _swap_state(
+                self,
+                sanitized_parameters,
+                is_stateless=False,
+                return_old_tensordict=True,
+            )
 
         self._reset_parameters()
 
         if not self._is_stateless:
-            new_parameters = _swap_state(self, old_params, is_stateless=False, return_old_tensordict=True)
+            new_parameters = _swap_state(
+                self, old_params, is_stateless=False, return_old_tensordict=True
+            )
         else:
             new_parameters = extract_weights_and_buffers(self)
 

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -818,7 +818,7 @@ class TensorDictModuleBase(nn.Module):
             return
         elif parameters.ndim:
             raise NotImplementedError(
-                "reset_parameters_recursive does not support batched TensorDicts, ensure batch_size is []"
+                "reset_parameters_recursive does not support batched TensorDicts, ensure `batch_size` is empty and the parameters shape match their original shape."
             )
 
         sanitized_parameters = parameters.apply(

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -823,7 +823,8 @@ class TensorDictModuleBase(nn.Module):
 
         if not is_functional(self):
             make_functional(self, keep_params=True)
-        if self._is_stateless:
+        is_stateless = self._is_stateless
+        if is_stateless:
             repopulate_module(self, sanitized_parameters)
         else:
             old_params = _swap_state(
@@ -835,12 +836,12 @@ class TensorDictModuleBase(nn.Module):
 
         self._reset_parameters()
 
-        if not self._is_stateless:
+        if is_stateless:
+            new_parameters = extract_weights_and_buffers(self)
+        else:
             new_parameters = _swap_state(
                 self, old_params, is_stateless=False, return_old_tensordict=True
             )
-        else:
-            new_parameters = extract_weights_and_buffers(self)
 
         return new_parameters
 

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -784,12 +784,11 @@ class TensorDictModuleBase(nn.Module):
 
         Args:
             parameters (TensorDict of parameters, optional): If set to None, the module will reset using self.parameters().
-                Otherwise, we will return a copy tensordict containing reinitialized parameters. This is
+                Otherwise, we will reset the parameters in the tensordict in-place. This is
                 useful for functional modules where the parameters are not stored in the module itself.
 
         Returns:
-            If parameters was not None, then a copy of the tensordict containing new parameters. If
-            parameters was None, then None.
+            A tensordict of the new parameters, only if parameters was not None.
 
         Examples:
             >>> from tensordict.nn import TensorDictModule
@@ -797,7 +796,7 @@ class TensorDictModuleBase(nn.Module):
             >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
             >>> old_param = net[0].weight.clone()
             >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
-            >>> module.reset_parameters_recursive()
+            >>> module.reset_parameters()
             >>> (old_param == net[0].weight).any()
             tensor(False)
 
@@ -809,80 +808,42 @@ class TensorDictModuleBase(nn.Module):
             >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
             >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
             >>> params = TensorDict.from_module(module)
-            >>> new_params = module.reset_parameters_recursive(params)
-            >>> (new_params == params).any()
+            >>> old_params = params.clone(recurse=True)
+            >>> module.reset_parameters(params)
+            >>> (old_params == params).any()
             False
-
-            For ensembles, you may pass in a batched tensordict to reset multiple copies
-            of the same module:
-
-            >>> from tensordict import TensorDict
-            >>> from tensordict.nn import TensorDictModule
-            >>> from torch import nn
-            >>> net = nn.Sequential(nn.Linear(2,3), nn.ReLU())
-            >>> module = TensorDictModule(net, in_keys=['bork'], out_keys=['dork'])
-            >>> params = TensorDict.from_module(module)
-            >>> new_params = module.reset_parameters_recursive(params.expand(5, *params.shape))
-            >>> params.dim()
-            >>> 0
-            >>> new_params.dim()
-            >>> 1
-            >>> old_params.flatten_keys()
-            TensorDict(
-                fields={
-                    module.0.bias: Tensor(shape=torch.Size([3]), device=cpu, dtype=torch.float32, is_shared=False),
-                    module.0.weight: Tensor(shape=torch.Size([3, 2]), device=cpu, dtype=torch.float32, is_shared=False)},
-                batch_size=torch.Size([]),
-                device=None,
-                is_shared=False)
-            >>> new_params.flatten_keys()
-            TensorDict(
-                fields={
-                    module.0.bias: Tensor(shape=torch.Size([5, 3]), device=cpu, dtype=torch.float32, is_shared=False),
-                    module.0.weight: Tensor(shape=torch.Size([5, 3, 2]), device=cpu, dtype=torch.float32, is_shared=False)},
-                batch_size=torch.Size([5]),
-                device=None,
-                is_shared=False)
         """
         if parameters is None:
             self._reset_parameters(self)
             return
-        elif parameters.ndim:
-            # Ensemble case -- we have a batched tensordict and want to reset multiple times
-            batched_params = []
-            for param in parameters.unbind(0):
-                batched_params.append(self.reset_parameters_recursive(param))
-            return torch.stack(batched_params, dim=0)
 
+        sanitized_parameters = parameters.apply(
+            lambda x: x.detach().requires_grad_(), inplace=False
+        )
+
+        if not is_functional(self):
+            make_functional(self, keep_params=True)
+        is_stateless = self._is_stateless
+        if is_stateless:
+            repopulate_module(self, sanitized_parameters)
         else:
-
-            sanitized_parameters = parameters.apply(
-                lambda x: x.detach().clone().requires_grad_(), inplace=False
+            old_params = _swap_state(
+                self,
+                sanitized_parameters,
+                is_stateless=False,
+                return_old_tensordict=True,
             )
 
-            if not is_functional(self):
-                make_functional(self, keep_params=True)
-            is_stateless = self._is_stateless
-            if is_stateless:
-                repopulate_module(self, sanitized_parameters)
-            else:
-                old_params = _swap_state(
-                    self,
-                    sanitized_parameters,
-                    is_stateless=False,
-                    return_old_tensordict=True,
-                )
+        self._reset_parameters(self)
 
-            self._reset_parameters(self)
+        if is_stateless:
+            new_parameters = extract_weights_and_buffers(self)
+        else:
+            new_parameters = _swap_state(
+                self, old_params, is_stateless=False, return_old_tensordict=True
+            )
 
-            if is_stateless:
-                new_parameters = extract_weights_and_buffers(self)
-            else:
-                new_parameters = _swap_state(
-                    self, old_params, is_stateless=False, return_old_tensordict=True
-                )
-
-            return new_parameters
+        return new_parameters
 
     def _reset_parameters(self, module: nn.Module) -> None:
         for child in module.children():

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -788,7 +788,7 @@ class TensorDictModuleBase(nn.Module):
             self._reset_parameters(m)
 
     def _reset_parameters(self, module: Union[nn.Module, TensorDictModuleBase]):
-        if isinstance(module, Union[TensorDictModuleBase, nn.Module]):
+        if isinstance(module, nn.Module):
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
             else:

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -817,7 +817,7 @@ class TensorDictModuleBase(nn.Module):
             self._reset_parameters(self)
             return
         elif parameters.ndim:
-            raise NotImplementedError(
+            raise RuntimeError(
                 "reset_parameters_recursive does not support batched TensorDicts, ensure `batch_size` is empty and the parameters shape match their original shape."
             )
 

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -784,7 +784,8 @@ class TensorDictModuleBase(nn.Module):
         >>> (old_param == net[0].weight).all()
         tensor(False)
         """
-        [self._reset_parameters(m) for m in self.children()]
+        for m in self.children():
+            self._reset_parameters(m)
 
     def _reset_parameters(self, module: Union[nn.Module, TensorDictModuleBase]):
         if isinstance(module, Union[TensorDictModuleBase, nn.Module]):

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -773,7 +773,7 @@ class TensorDictModuleBase(nn.Module):
 
     def reset_parameters(self):
         """Recursively reset the parameters of the module and its children.
-        
+
         Examples:
         >>> from tensordict.nn import TensorDictModule
         >>> from torch import nn

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -120,7 +120,7 @@ class TestTDModule:
 
         params = TensorDict.from_module(seq)
         old_params = params.clone(recurse=True)
-        new_params = params.clone()
+        new_params = params.clone(recurse=True)
         returned_params = seq.reset_parameters(new_params)
 
         weights_changed = new_params != old_params

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -127,7 +127,8 @@ class TestTDModule:
 
         params = TensorDict.from_module(seq)
         old_params = params.clone(recurse=True)
-        new_params = seq.reset_parameters_recursive(params)
+        new_params = params.clone(recurse=True)
+        returned_params = seq.reset_parameters_recursive(new_params)
 
         weights_changed = new_params != old_params
         for w in weights_changed.values(include_nested=True, leaves_only=True):
@@ -139,6 +140,14 @@ class TestTDModule:
             include_nested=True, leaves_only=True
         ):
             assert not p.any(), f"Overwrote stateful weights from the module {p}"
+
+        returned_params_eq_inplace_updated_params = returned_params == new_params
+        for p in returned_params_eq_inplace_updated_params.values(
+            include_nested=True, leaves_only=True
+        ):
+            assert (
+                p.all()
+            ), f"Discrepancy between returned weights and those in-place updated {p}"
 
     def test_reset_functional_called_once(self):
         import unittest.mock
@@ -156,32 +165,6 @@ class TestTDModule:
         params = TensorDict.from_module(tripled_nested)
         tripled_nested.reset_parameters_recursive(params)
         lin.reset_parameters.assert_called_once()
-
-    def test_reset_extra_dims(self):
-        torch.manual_seed(0)
-        net = nn.Sequential(nn.Linear(1, 1), nn.ReLU())
-        module = TensorDictModule(net, in_keys=["in"], out_keys=["mid"])
-        another_module = TensorDictModule(
-            nn.Linear(1, 1), in_keys=["mid"], out_keys=["out"]
-        )
-        seq = TensorDictSequential(module, another_module)
-
-        params = TensorDict.from_module(seq)
-        old_params = params.clone(recurse=True)
-        new_params = seq.reset_parameters_recursive(params.expand(2, 3, *params.shape))
-        for key in new_params.keys(include_nested=True, leaves_only=True):
-            assert (
-                new_params[key].dim()
-                == new_params[key].dim()
-                == old_params[key].dim() + 2
-            )
-
-        weights_changed = new_params != old_params
-        for w in weights_changed.values(include_nested=True, leaves_only=True):
-            assert w.all(), f"Weights should have changed but did not for {w}"
-
-        data = TensorDict({"in": torch.ones(2, 5, 1)}, batch_size=[2, 5])
-        seq(data)
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_stateful(self, lazy):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -109,12 +109,13 @@ class TestTDModule:
         seq.reset_parameters()
         assert torch.all(old_param != net[0][0].weight.data)
 
-    @pytest.mark.parametrize("net", 
+    @pytest.mark.parametrize(
+        "net",
         [
             nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())]),
             nn.Linear(2, 1),
             nn.Sequential(nn.Tanh(), nn.Linear(1, 1), nn.Linear(2, 1)),
-        ]
+        ],
     )
     def test_reset_functional(self, net):
         torch.manual_seed(0)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -106,7 +106,7 @@ class TestTDModule:
         )
         seq = TensorDictSequential(module, another_module)
 
-        seq.reset_parameters()
+        seq.reset_parameters_recursive()
         assert torch.all(old_param != net[0][0].weight.data)
 
     @pytest.mark.parametrize(
@@ -128,7 +128,7 @@ class TestTDModule:
         params = TensorDict.from_module(seq)
         old_params = params.clone(recurse=True)
         new_params = params.clone(recurse=True)
-        returned_params = seq.reset_parameters(new_params)
+        returned_params = seq.reset_parameters_recursive(new_params)
 
         weights_changed = new_params != old_params
         for w in weights_changed.values(include_nested=True, leaves_only=True):
@@ -149,16 +149,13 @@ class TestTDModule:
                 p.all()
             ), f"Discrepancy between returned weights and those in-place updated {p}"
 
-    @pytest.mark.parametrize(
-        "net",
-        [
-            nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())]),
-            nn.Linear(2, 1),
-            nn.Sequential(nn.Tanh(), nn.Linear(1, 1), nn.Linear(2, 1)),
-        ],
-    )
-    def test_reset_functional_triple_nested(self, net):
+    def test_reset_functional_called_once(self):
+        import unittest.mock
+
         torch.manual_seed(0)
+        lin = nn.Linear(1, 1)
+        lin.reset_parameters = unittest.mock.Mock(return_value=None)
+        net = nn.ModuleList([nn.Sequential(lin, nn.ReLU())])
         module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
         nested_module = TensorDictModule(module, in_keys=["in"], out_keys=["out"])
         tripled_nested = TensorDictModule(
@@ -166,28 +163,8 @@ class TestTDModule:
         )
 
         params = TensorDict.from_module(tripled_nested)
-        old_params = params.clone(recurse=True)
-        new_params = params.clone(recurse=True)
-        returned_params = tripled_nested.reset_parameters(new_params)
-
-        weights_changed = new_params != old_params
-        for w in weights_changed.values(include_nested=True, leaves_only=True):
-            assert w.all(), f"Weights should have changed but did not for {w}"
-
-        module_params = TensorDict.from_module(tripled_nested)
-        overwrote_stateful_params = module_params != old_params
-        for p in overwrote_stateful_params.values(
-            include_nested=True, leaves_only=True
-        ):
-            assert not p.any(), f"Overwrote stateful weights from the module {p}"
-
-        returned_params_eq_inplace_updated_params = returned_params == new_params
-        for p in returned_params_eq_inplace_updated_params.values(
-            include_nested=True, leaves_only=True
-        ):
-            assert (
-                p.all()
-            ), f"Discrepancy between returned weights and those in-place updated {p}"
+        tripled_nested.reset_parameters_recursive(params)
+        lin.reset_parameters.assert_called_once()
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_stateful(self, lazy):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -178,11 +178,8 @@ class TestTDModule:
         params = TensorDict.from_module(seq)
         new_params = params.expand(2, 3, *params.shape).clone()
         # Does not inherit from test case, no assertRaises :(
-        try:
+        with pytest.raises(RuntimeError):
             seq.reset_parameters_recursive(new_params)
-            raise RuntimeError("Failed to raise exception during test")
-        except NotImplementedError:
-            pass
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_stateful(self, lazy):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -101,9 +101,11 @@ class TestTDModule:
         net = nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())])
         old_param = net[0][0].weight.data.clone()
         module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
-        another_module = TensorDictModule(nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"])
+        another_module = TensorDictModule(
+            nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"]
+        )
         seq = TensorDictSequential(module, another_module)
-        
+
         seq.reset_parameters()
         assert torch.all(old_param != net[0][0].weight.data)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -129,14 +129,18 @@ class TestTDModule:
 
         module_params = TensorDict.from_module(seq)
         overwrote_stateful_params = module_params != old_params
-        for p in overwrote_stateful_params.values(include_nested=True, leaves_only=True):
+        for p in overwrote_stateful_params.values(
+            include_nested=True, leaves_only=True
+        ):
             assert not p.any(), f"Overwrote stateful weights from the module {p}"
 
         returned_params_eq_inplace_updated_params = returned_params == new_params
-        for p in returned_params_eq_inplace_updated_params.values(include_nested=True, leaves_only=True):
-            assert p.all(), f"Discrepancy between returned weights and those in-place updated {p}"
-
-
+        for p in returned_params_eq_inplace_updated_params.values(
+            include_nested=True, leaves_only=True
+        ):
+            assert (
+                p.all()
+            ), f"Discrepancy between returned weights and those in-place updated {p}"
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_stateful(self, lazy):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -101,11 +101,9 @@ class TestTDModule:
         net = nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())])
         old_param = net[0][0].weight.data.clone()
         module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
-        another_module = TensorDictModule(
-            nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"]
-        )
+        another_module = TensorDictModule(nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"])
         seq = TensorDictSequential(module, another_module)
-
+        
         seq.reset_parameters()
         assert torch.all(old_param != net[0][0].weight.data)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -109,9 +109,15 @@ class TestTDModule:
         seq.reset_parameters()
         assert torch.all(old_param != net[0][0].weight.data)
 
-    def test_reset_functional(self):
+    @pytest.mark.parametrize("net", 
+        [
+            nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())]),
+            nn.Linear(2, 1),
+            nn.Sequential(nn.Tanh(), nn.Linear(1, 1), nn.Linear(2, 1)),
+        ]
+    )
+    def test_reset_functional(self, net):
         torch.manual_seed(0)
-        net = nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())])
         module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
         another_module = TensorDictModule(
             nn.Conv2d(1, 1, 1, 1), in_keys=["in"], out_keys=["out"]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -149,6 +149,46 @@ class TestTDModule:
                 p.all()
             ), f"Discrepancy between returned weights and those in-place updated {p}"
 
+    @pytest.mark.parametrize(
+        "net",
+        [
+            nn.ModuleList([nn.Sequential(nn.Linear(1, 1), nn.ReLU())]),
+            nn.Linear(2, 1),
+            nn.Sequential(nn.Tanh(), nn.Linear(1, 1), nn.Linear(2, 1)),
+        ],
+    )
+    def test_reset_functional_triple_nested(self, net):
+        torch.manual_seed(0)
+        module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
+        nested_module = TensorDictModule(module, in_keys=["in"], out_keys=["out"])
+        tripled_nested = TensorDictModule(
+            nested_module, in_keys=["in"], out_keys=["out"]
+        )
+
+        params = TensorDict.from_module(tripled_nested)
+        old_params = params.clone(recurse=True)
+        new_params = params.clone(recurse=True)
+        returned_params = tripled_nested.reset_parameters(new_params)
+
+        weights_changed = new_params != old_params
+        for w in weights_changed.values(include_nested=True, leaves_only=True):
+            assert w.all(), f"Weights should have changed but did not for {w}"
+
+        module_params = TensorDict.from_module(tripled_nested)
+        overwrote_stateful_params = module_params != old_params
+        for p in overwrote_stateful_params.values(
+            include_nested=True, leaves_only=True
+        ):
+            assert not p.any(), f"Overwrote stateful weights from the module {p}"
+
+        returned_params_eq_inplace_updated_params = returned_params == new_params
+        for p in returned_params_eq_inplace_updated_params.values(
+            include_nested=True, leaves_only=True
+        ):
+            assert (
+                p.all()
+            ), f"Discrepancy between returned weights and those in-place updated {p}"
+
     @pytest.mark.parametrize("lazy", [True, False])
     def test_stateful(self, lazy):
         torch.manual_seed(0)


### PR DESCRIPTION
## Description

This adds support for `TensorDictModuleBase.reset_parameters` when the parameters exist as in a tensordict, rather than being attached to the module. It also simplifies the existing `reset_parameters` implementation. cc @matteobettini @vmoens 

## Motivation and Context

Related to https://github.com/pytorch-labs/tensordict/pull/476 and https://github.com/pytorch/rl/issues/1344

- [ :( ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
