### PR TITLE
[Feature] PyTree compatibility

### DIFF
--- a/tensordict/__init__.py
+++ b/tensordict/__init__.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     __version__ = None
 
+from tensordict._pytree import *
+
 from tensordict._tensordict import unravel_key, unravel_key_list
 
 __all__ = [

--- a/tensordict/_pytree.py
+++ b/tensordict/_pytree.py
@@ -48,13 +48,6 @@ def _str_to_dict(str_spec: str) -> Tuple[List[str], str]:
     return context_strings, ",".join(child_strings)
 
 
-def _maybe_str_to_tensordict(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
-    if not str_spec.startswith("D"):
-        return None
-    context_strings, child_strings = _str_to_dict(str_spec)
-    return TensorDict, context_strings, child_strings
-
-
 def _str_to_tensordictdict(str_spec: str) -> Tuple[List[str], str]:
     context_and_child_strings = str_spec[2:-1]
 
@@ -96,18 +89,9 @@ def _tensordictdict_unflatten(values: List[Any], context: Context) -> Dict[Any, 
     )
 
 
-def _tensordict_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:  # noqa: F821
-    context_child_strings = []
-    for key, child_string in zip(spec.context, child_strings):
-        context_child_strings.append(f"{key}:{child_string}")
-    return f"D({','.join(context_child_strings)})"
-
-
 for cls in PYTREE_REGISTERED_TDS:
     _register_pytree_node(
         cls,
         _tensordict_flatten,
         _tensordictdict_unflatten,
-        # _tensordict_to_str,
-        # _maybe_str_to_tensordict,
     )

--- a/tensordict/_pytree.py
+++ b/tensordict/_pytree.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from tensordict import (
     LazyStackedTensorDict,

--- a/tensordict/_pytree.py
+++ b/tensordict/_pytree.py
@@ -13,6 +13,13 @@ from tensordict import (
 
 from torch.utils._pytree import _register_pytree_node, Context
 
+PYTREE_REGISTERED_TDS = (
+    LazyStackedTensorDict,
+    SubTensorDict,
+    TensorDict,
+    PersistentTensorDict,
+)
+
 
 def _str_to_dict(str_spec: str) -> Tuple[List[str], str]:
     assert str_spec[1] == "("
@@ -96,11 +103,11 @@ def _tensordict_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:  # no
     return f"D({','.join(context_child_strings)})"
 
 
-for cls in (LazyStackedTensorDict, SubTensorDict, TensorDict, PersistentTensorDict):
+for cls in PYTREE_REGISTERED_TDS:
     _register_pytree_node(
         cls,
         _tensordict_flatten,
         _tensordictdict_unflatten,
-        _tensordict_to_str,
-        _maybe_str_to_tensordict,
+        # _tensordict_to_str,
+        # _maybe_str_to_tensordict,
     )

--- a/tensordict/_pytree.py
+++ b/tensordict/_pytree.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Any, Dict, List, Optional, Tuple
+
+from tensordict import (
+    LazyStackedTensorDict,
+    PersistentTensorDict,
+    SubTensorDict,
+    TensorDict,
+)
+
+from torch.utils._pytree import _register_pytree_node, _str_to_dict, Context
+
+
+def _maybe_str_to_tensordict(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+    if not str_spec.startswith("D"):
+        return None
+    context_strings, child_strings = _str_to_dict(str_spec)
+    return TensorDict, context_strings, child_strings
+
+
+def _str_to_tensordictdict(str_spec: str) -> Tuple[List[str], str]:
+    context_and_child_strings = str_spec[2:-1]
+
+    child_strings = []
+    context_strings = []
+    nested_parentheses = 0
+    start_index = 0
+    for i, char in enumerate(context_and_child_strings):
+        if char == ":":
+            if nested_parentheses == 0:
+                context_strings.append(context_and_child_strings[start_index:i])
+                start_index = i + 1
+        elif char == "(":
+            nested_parentheses += 1
+        elif char == ")":
+            nested_parentheses -= 1
+
+        if nested_parentheses == 0 and char == ",":
+            child_strings.append(context_and_child_strings[start_index:i])
+            start_index = i + 1
+
+    child_strings.append(context_and_child_strings[start_index:])
+    return context_strings, ",".join(child_strings)
+
+
+def _tensordict_flatten(d: TensorDict) -> Tuple[List[Any], Context]:
+    return list(d.values()), {
+        "keys": list(d.keys()),
+        "batch_size": d.batch_size,
+        "names": d.names,
+    }
+
+
+def _tensordictdict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]:
+    return TensorDict(
+        dict(zip(context["keys"], values)),
+        context["batch_size"],
+        names=context["names"],
+    )
+
+
+def _tensordict_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:  # noqa: F821
+    context_child_strings = []
+    for key, child_string in zip(spec.context, child_strings):
+        context_child_strings.append(f"{key}:{child_string}")
+    return f"D({','.join(context_child_strings)})"
+
+
+for cls in (LazyStackedTensorDict, SubTensorDict, TensorDict, PersistentTensorDict):
+    _register_pytree_node(
+        cls,
+        _tensordict_flatten,
+        _tensordictdict_unflatten,
+        _tensordict_to_str,
+        _maybe_str_to_tensordict,
+    )

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Iterable
 
 import torch
 
-from tensordict import TensorDict
+from tensordict import PYTREE_REGISTERED_TDS, TensorDict
 from tensordict.tensordict import _is_tensor_collection, TensorDictBase
 
 from tensordict.utils import implement_for
@@ -141,11 +141,16 @@ except ImportError:
 
 
 class _exclude_td_from_pytree:
+    def __init__(self):
+        self.tdnodes = {}
+
     def __enter__(self):
-        self.tdnode = SUPPORTED_NODES.pop(TensorDict)
+        for tdtype in PYTREE_REGISTERED_TDS:
+            self.tdnodes[tdtype] = SUPPORTED_NODES.pop(tdtype)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        SUPPORTED_NODES[TensorDict] = self.tdnode
+        for tdtype in PYTREE_REGISTERED_TDS:
+            SUPPORTED_NODES[tdtype] = self.tdnodes[tdtype]
 
 
 # Monkey-patch functorch, mainly for cases where a "isinstance(obj, Tensor) is invoked

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -14,11 +14,13 @@ from functools import wraps
 from typing import Any, Callable, Iterable
 
 import torch
+
 from tensordict import TensorDict
 from tensordict.tensordict import _is_tensor_collection, TensorDictBase
 
 from tensordict.utils import implement_for
 from torch import nn
+from torch.utils._pytree import SUPPORTED_NODES
 
 try:
     from torch.nn.modules.module import _global_parameter_registration_hooks
@@ -137,6 +139,15 @@ except ImportError:
     except ImportError:
         _has_functorch = False
 
+
+class _exclude_td_from_pytree:
+    def __enter__(self):
+        self.tdnode = SUPPORTED_NODES.pop(TensorDict)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        SUPPORTED_NODES[TensorDict] = self.tdnode
+
+
 # Monkey-patch functorch, mainly for cases where a "isinstance(obj, Tensor) is invoked
 if _has_functorch:
     # Monkey-patches
@@ -157,15 +168,17 @@ inputs, or you are trying to vmap over a function with no inputs.
 The latter is unsupported."""
             )
 
-        flat_args, args_spec = tree_flatten(args)
-        flat_in_dims = _broadcast_to_and_flatten(in_dims, args_spec)
-        if flat_in_dims is None:
-            raise ValueError(
-                f"""vmap({_get_name(func)}, in_dims={in_dims}, ...)(<inputs>):
-in_dims is not compatible with the structure of `inputs`.
-in_dims has structure {tree_flatten(in_dims)[1]} but inputs
-has structure {args_spec}."""
-            )
+        # we want to escape TensorDicts as they take care of adding the batch dimension
+        with _exclude_td_from_pytree():
+            flat_args, args_spec = tree_flatten(args)
+            flat_in_dims = _broadcast_to_and_flatten(in_dims, args_spec)
+            if flat_in_dims is None:
+                raise ValueError(
+                    f"""vmap({_get_name(func)}, in_dims={in_dims}, ...)(<inputs>):
+    in_dims is not compatible with the structure of `inputs`.
+    in_dims has structure {tree_flatten(in_dims)[1]} but inputs
+    has structure {args_spec}."""
+                )
 
         for i, (arg, in_dim) in enumerate(zip(flat_args, flat_in_dims)):
             if not isinstance(in_dim, int) and in_dim is not None:
@@ -226,7 +239,8 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
                 else:
                     batched_input = _add_batch_dim(arg, in_dim, vmap_level)
             batched_inputs.append(batched_input)
-        return tree_unflatten(batched_inputs, args_spec)
+        with _exclude_td_from_pytree():
+            return tree_unflatten(batched_inputs, args_spec)
 
     vmap_src._create_batched_inputs = _create_batched_inputs
 
@@ -237,7 +251,8 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
         batch_size: int,
         func: Callable,
     ) -> Any:
-        flat_batched_outputs, output_spec = tree_flatten(batched_outputs)
+        with _exclude_td_from_pytree():
+            flat_batched_outputs, output_spec = tree_flatten(batched_outputs)
 
         for out in flat_batched_outputs:
             # Change here:
@@ -280,7 +295,8 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
                     vmap_level=vmap_level, batch_size=batch_size, out_dim=out_dim
                 )
             flat_outputs.append(out)
-        return tree_unflatten(flat_outputs, output_spec)
+        with _exclude_td_from_pytree():
+            return tree_unflatten(flat_outputs, output_spec)
 
     vmap_src._unwrap_batched = _unwrap_batched
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -10,7 +10,6 @@ import uuid
 import numpy as np
 import pytest
 import torch
-from torch.utils._pytree import tree_map
 
 try:
     import torchsnapshot
@@ -5538,34 +5537,6 @@ def test_empty():
     td_empty = td.empty(recurse=True)
     assert len(list(td_empty.keys())) == 1
     assert len(list(td_empty.get("b").keys())) == 1
-
-
-class TestPyTree(TestTensorDictsBase):
-    def test_pytree_map(self):
-        td = TensorDict({"a": {"b": {"c": 1}, "d": 1}, "e": 1}, [])
-        td = tree_map(lambda x: x + 1, td)
-        assert (td == 2).all()
-
-    def test_pytree_map_batch(self):
-        td = TensorDict(
-            {
-                "a": TensorDict(
-                    {
-                        "b": TensorDict({"c": torch.ones(2, 3, 4)}, [2, 3]),
-                        "d": torch.ones(2),
-                    },
-                    [2],
-                ),
-                "e": 1,
-            },
-            [],
-        )
-        td = tree_map(lambda x: x + 1, td)
-        assert (td == 2).all()
-        assert td.shape == torch.Size([])
-        assert td["a"].shape == torch.Size([2])
-        assert td["a", "b"].shape == torch.Size([2, 3])
-        assert td["a", "b", "c"].shape == torch.Size([2, 3, 4])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Makes tensordict compatible with pytree.
Solves the conflict with vmap between custom _add_batch_dims and torch version. 
We ignore the tensordict node in pytree within vmap and rely on TensorDict._add_batch_dims instead.

cc @NicolasHug @ezyang @zou3519