### PR TITLE
[Feature] Module to add state independent normal scale

### DIFF
--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -153,7 +153,7 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         >>> tensor = torch.randn(4, 2, 3)
         >>> loc, scale, others = module_normal(*module(tensor))
         >>> print(loc.shape, scale.shape)
-        torch.Size([4, 2, 2]) torch.Size([4, 2, 2])
+        torch.Size([4, 2, 4]) torch.Size([4, 2, 4])
         >>> assert (scale > 0).all()
     """
 

--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -126,7 +126,7 @@ class NormalParamExtractor(nn.Module):
 
 
 class AddStateIndependentNormalScale(torch.nn.Module):
-    """A nn.Module that adds a trainable state-independent scale parameter.
+    """A nn.Module that adds a trainable state-independent scale parameters.
 
     The scale parameters are mapped onto positive values using the specified ``scale_mapping``.
 

--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from numbers import Number
-from typing import Sequence
+from typing import Sequence, Union
 
 import numpy as np
 
@@ -14,7 +14,7 @@ import torch
 from tensordict.nn.utils import mappings
 from torch import distributions as D, nn
 
-__all__ = ["NormalParamExtractor", "NormalParamWrapper", "Delta"]
+__all__ = ["NormalParamExtractor", "NormalParamWrapper", "AddStateIndependentNormalScale", "Delta"]
 
 # speeds up distribution construction
 D.Distribution.set_default_validate_args(False)
@@ -117,6 +117,74 @@ class NormalParamExtractor(nn.Module):
         tensor, *others = tensors
         loc, scale = tensor.chunk(2, -1)
         scale = mappings(self.scale_mapping)(scale).clamp_min(self.scale_lb)
+        return (loc, scale, *others)
+
+
+class AddStateIndependentNormalScale(torch.nn.Module):
+    """A nn.Module that adds a trainable state-independent scale parameter.
+
+    The scale parameters are mapped onto positive values using the specified ``scale_mapping``.
+
+    Args:
+        scale_mapping (str, optional): positive mapping function to be used with the std.
+            default = "biased_softplus_1.0" (i.e. softplus map with bias such that fn(0.0) = 1.0)
+            choices: "softplus", "exp", "relu", "biased_softplus_1";
+        scale_lb (Number, optional): The minimum value that the variance can take. Default is 1e-4.
+
+    Examples:
+        >>> from torch import nn
+        >>> import torch
+        >>> num_outputs = 4
+        >>> module = nn.Linear(3, num_outputs)
+        >>> module_normal = AddStateIndependentNormalScale(num_outputs)
+        >>> tensor = torch.randn(3)
+        >>> loc, scale = module_normal(module(tensor))
+        >>> print(loc.shape, scale.shape)
+        torch.Size([4]) torch.Size([4])
+        >>> assert (scale > 0).all()
+        >>> # with modules that return more than one tensor
+        >>> module = nn.LSTM(3, num_outputs)
+        >>> module_normal = AddStateIndependentNormalScale(num_outputs)
+        >>> tensor = torch.randn(4, 2, 3)
+        >>> loc, scale, others = module_normal(*module(tensor))
+        >>> print(loc.shape, scale.shape)
+        torch.Size([4, 2, 2]) torch.Size([4, 2, 2])
+        >>> assert (scale > 0).all()
+    """
+    def __init__(
+            self,
+            scale_shape: Union[torch.Size, int, tuple],
+            scale_mapping: str = "exp",
+            scale_lb: Number = 1e-4,
+    ) -> None:
+
+        super().__init__()
+        self.scale_lb = scale_lb
+        if isinstance(scale_shape, int):
+            scale_shape = (scale_shape,)
+        self.scale_shape = scale_shape
+        self.scale_mapping = scale_mapping
+        self.state_independent_scale = torch.nn.Parameter(torch.zeros(scale_shape))
+
+    def forward(self, *tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        loc, *others = tensors
+
+        # check that last dimensions of loc matches the number of dimensions in scale
+        if self.scale_shape != loc.shape[-len(self.scale_shape):]:
+            raise RuntimeError(
+                f"Last dimensions of loc ({loc.shape[-len(self.scale_shape):]}) do not match the number of dimensions "
+                f"in scale ({self.state_independent_scale.shape})"
+            )
+
+        # Reshape scale to match the number of dimensions in loc
+        input_dims = loc.dim()
+        scale_dims = self.state_independent_scale.dim()
+        scale_shape = self.state_independent_scale.shape
+        scale = self.state_independent_scale.view((1,) * (input_dims - scale_dims) + scale_shape)
+
+        scale = torch.zeros(loc.size()).to(loc.device) + scale
+        scale = mappings(self.scale_mapping)(scale).clamp_min(self.scale_lb)
+
         return (loc, scale, *others)
 
 

--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -126,7 +126,7 @@ class NormalParamExtractor(nn.Module):
 
 
 class AddStateIndependentNormalScale(torch.nn.Module):
-    """A nn.Module that adds a trainable state-independent scale parameters.
+    """A nn.Module that adds trainable state-independent scale parameters.
 
     The scale parameters are mapped onto positive values using the specified ``scale_mapping``.
 

--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -14,7 +14,12 @@ import torch
 from tensordict.nn.utils import mappings
 from torch import distributions as D, nn
 
-__all__ = ["NormalParamExtractor", "NormalParamWrapper", "AddStateIndependentNormalScale", "Delta"]
+__all__ = [
+    "NormalParamExtractor",
+    "NormalParamWrapper",
+    "AddStateIndependentNormalScale",
+    "Delta",
+]
 
 # speeds up distribution construction
 D.Distribution.set_default_validate_args(False)
@@ -151,11 +156,12 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         torch.Size([4, 2, 2]) torch.Size([4, 2, 2])
         >>> assert (scale > 0).all()
     """
+
     def __init__(
-            self,
-            scale_shape: Union[torch.Size, int, tuple],
-            scale_mapping: str = "exp",
-            scale_lb: Number = 1e-4,
+        self,
+        scale_shape: Union[torch.Size, int, tuple],
+        scale_mapping: str = "exp",
+        scale_lb: Number = 1e-4,
     ) -> None:
 
         super().__init__()
@@ -170,7 +176,7 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         loc, *others = tensors
 
         # check that last dimensions of loc matches the number of dimensions in scale
-        if self.scale_shape != loc.shape[-len(self.scale_shape):]:
+        if self.scale_shape != loc.shape[-len(self.scale_shape) :]:
             raise RuntimeError(
                 f"Last dimensions of loc ({loc.shape[-len(self.scale_shape):]}) do not match the number of dimensions "
                 f"in scale ({self.state_independent_scale.shape})"
@@ -180,7 +186,9 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         input_dims = loc.dim()
         scale_dims = self.state_independent_scale.dim()
         scale_shape = self.state_independent_scale.shape
-        scale = self.state_independent_scale.view((1,) * (input_dims - scale_dims) + scale_shape)
+        scale = self.state_independent_scale.view(
+            (1,) * (input_dims - scale_dims) + scale_shape
+        )
 
         scale = torch.zeros(loc.size()).to(loc.device) + scale
         scale = mappings(self.scale_mapping)(scale).clamp_min(self.scale_lb)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -23,11 +23,13 @@ from tensordict.nn import (
     TensorDictParams,
     TensorDictSequential,
 )
-from tensordict.nn.common import (
-    TensorDictModule,
-    TensorDictModuleWrapper,
+from tensordict.nn.common import TensorDictModule, TensorDictModuleWrapper
+from tensordict.nn.distributions import (
+    AddStateIndependentNormalScale,
+    Delta,
+    NormalParamExtractor,
+    NormalParamWrapper,
 )
-from tensordict.nn.distributions import Delta, NormalParamExtractor, NormalParamWrapper, AddStateIndependentNormalScale
 from tensordict.nn.ensemble import EnsembleModule
 from tensordict.nn.functional_modules import is_functional, make_functional
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,7 +27,7 @@ from tensordict.nn.common import (
     TensorDictModule,
     TensorDictModuleWrapper,
 )
-from tensordict.nn.distributions import Delta, NormalParamExtractor, NormalParamWrapper, AddStateIndependentNormalScale,
+from tensordict.nn.distributions import Delta, NormalParamExtractor, NormalParamWrapper, AddStateIndependentNormalScale
 from tensordict.nn.ensemble import EnsembleModule
 from tensordict.nn.functional_modules import is_functional, make_functional
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -24,11 +24,10 @@ from tensordict.nn import (
     TensorDictSequential,
 )
 from tensordict.nn.common import (
-    AddStateIndependentNormalScale,
     TensorDictModule,
     TensorDictModuleWrapper,
 )
-from tensordict.nn.distributions import Delta, NormalParamExtractor, NormalParamWrapper
+from tensordict.nn.distributions import Delta, NormalParamExtractor, NormalParamWrapper, AddStateIndependentNormalScale,
 from tensordict.nn.ensemble import EnsembleModule
 from tensordict.nn.functional_modules import is_functional, make_functional
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type


### PR DESCRIPTION
## Description

For continuous action spaces, it is not uncommon to define normal policies with state independent variance. For example, the original PPO paper does so for the MuJoCo trainings. 

This PR proposes o add a module that handles this situation. 

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
