### PR TITLE
[BugFix] Fix lazy-stack to call to to_tensordict()

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -6856,7 +6856,12 @@ class LazyStackedTensorDict(TensorDictBase):
             dest = torch.device(dest)
             if self.device is not None and dest == self.device:
                 return self
-            td = self.to_tensordict().to(dest, **kwargs)
+            td = LazyStackedTensorDict(
+                *[td.to(dest, **kwargs) for td in self.tensordicts],
+                stack_dim=self.stack_dim,
+                hook_out=self.hook_out,
+                hook_in=self.hook_in,
+            )
             return td
 
         elif isinstance(dest, torch.Size):


### PR DESCRIPTION
## Description

Closes #511 by making LazyStackedTD.to() return a lazy stack, not a regular td.

Also creates a new test class for tensorclass that assesses that regular ops return an object of the same class (even if they're nested).
