### PR TITLE
[Refactor] TensorDict.to() signature

### DIFF
--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -700,12 +700,12 @@ MemmapTensor of shape {self.shape}."""
 
     def to(
         self,
-        *args, **kwargs,
+        *args,
+        **kwargs,
     ) -> torch.Tensor | MemmapTensor:
         """Maps a MemmapTensor to a given dtype or device.
 
         Args:
-
             device (torch.device, optional): Destination device when tensors
                 will be used.
             dtype (torch.dtype, optional): the desired floating point or complex dtype of

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -700,34 +700,39 @@ MemmapTensor of shape {self.shape}."""
 
     def to(
         self,
-        dest: DeviceType | torch.dtype,
-        non_blocking: bool = False,
+        *args, **kwargs,
     ) -> torch.Tensor | MemmapTensor:
         """Maps a MemmapTensor to a given dtype or device.
 
         Args:
-            dest (device indicator or torch.dtype): where to cast the
-                MemmapTensor. For devices, this is a lazy operation
-                (as the data is stored on physical memory). For dtypes, the
-                tensor will be retrieved, mapped to the
-                desired dtype and cast to a new MemmapTensor.
-            non_blocking (bool, optional): no-op for MemmapTensors. Default: False.
+
+            device (torch.device, optional): Destination device when tensors
+                will be used.
+            dtype (torch.dtype, optional): the desired floating point or complex dtype of
+                the parameters and buffers in this module
+            tensor (torch.Tensor, optional): Tensor whose dtype and device are the desired
+                dtype and device for all parameters and buffers in this TensorDict
+
+        Keyword Args:
+            non_blocking (bool, optional): whether the operations should be blocking.
+                no-op for MemmapTensors. Default: False.
+            memory_format (torch.memory_format, optional): the desired memory
+                format for 4D parameters and buffers in this module.
 
         Returns: the same memmap-tensor with the changed device.
 
         """
-        if isinstance(dest, (int, str, torch.device)):
-            dest = torch.device(dest)
-            self.device = dest
-            return self
-        elif isinstance(dest, torch.dtype):
-            return MemmapTensor.from_tensor(self._tensor.to(dest))
-        else:
-            raise NotImplementedError(
-                f"argument dest={dest} to MemmapTensor.to(dest) is not "
-                f"handled. "
-                f"Please provide a dtype or a device."
-            )
+        device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(
+            *args, **kwargs
+        )
+        if dtype is not None:
+            out = MemmapTensor.from_tensor(self._tensor.to(dtype))
+            if device is not None:
+                out.device = device
+            return out
+
+        self.device = device
+        return self
 
     def unbind(self, dim: int) -> tuple[torch.Tensor, ...]:
         """Unbinds a MemmapTensor along the desired dimension.

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -27,7 +27,7 @@ from tensordict.tensordict import (
     TD_HANDLED_FUNCTIONS,
     TensorDict,
 )
-from tensordict.utils import DeviceType, erase_cache, IndexType, NestedKey
+from tensordict.utils import erase_cache, IndexType, NestedKey
 from torch import multiprocessing as mp, nn, Tensor
 from torch.utils._pytree import tree_map
 

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -436,8 +436,8 @@ class TensorDictParams(TensorDictBase, nn.Module):
 
     __getitems__ = __getitem__
 
-    def to(self, dest: DeviceType | type | torch.Size, **kwargs) -> TensorDictBase:
-        params = self._param_td.to(dest)
+    def to(self, *args, **kwargs) -> TensorDictBase:
+        params = self._param_td.to(*args, **kwargs)
         if params is self._param_td:
             return self
         return TensorDictParams(params)

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -38,7 +38,6 @@ from tensordict.tensordict import (
 from tensordict.utils import (
     _split_tensordict,
     cache,
-    DeviceType,
     expand_right,
     IndexType,
     lock_blocked,
@@ -689,9 +688,7 @@ class PersistentTensorDict(TensorDictBase):
             "Create a regular tensordict first using the `to_tensordict` method."
         )
 
-    def to(
-        self, *args, **kwargs: Any
-    ) -> PersistentTensorDict:
+    def to(self, *args, **kwargs: Any) -> PersistentTensorDict:
         batch_size = kwargs.pop("batch_size", None)
         other = kwargs.pop("other", None)
         device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -697,7 +697,7 @@ class PersistentTensorDict(TensorDictBase):
         if device is not None and dtype is None and device == self.device:
             return result
         if dtype is not None:
-            return self.to_tensordict().to(*args, batch_size=batch_size, **kwargs)
+            return self.to_tensordict().to(*args, **kwargs)
         result = self
         if device is not None:
             result = result.clone(False)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2595,31 +2595,38 @@ class TensorDictBase(MutableMapping):
         tensor dtype.
 
         Args:
-            device (torch.device, optional): the desired device of the parameters
-                and buffers in this module
+            device (torch.device, optional): the desired device of the tensordict.
             dtype (torch.dtype, optional): the desired floating point or complex dtype of
-                the parameters and buffers in this module
+                the tensordict.
             tensor (torch.Tensor, optional): Tensor whose dtype and device are the desired
-                dtype and device for all parameters and buffers in this TensorDict
+                dtype and device for all tensors in this TensorDict.
 
         Keyword Args:
             non_blocking (bool, optional): whether the operations should be blocking.
             memory_format (torch.memory_format, optional): the desired memory
-                format for 4D parameters and buffers in this module.
+                format for 4D parameters and buffers in this tensordict.
             batch_size (torch.Size, optional): resulting batch-size of the
                 output tensordict.
             other (TensorDictBase, optional): TensorDict instance whose dtype
-                and device are the desired
-                dtype and device for all parameters and buffers in this TensorDict.
-                .. note:: Since tensordict do not have a dtype, the dtype is gathered
-                    from the leaves. If there are more than one dtype, then no dtype
-                    casting is achieved.
+                and device are the desired dtype and device for all tensors
+                in this TensorDict.
+                .. note:: Since :class:`TensorDictBase` instances do not have
+                    a dtype, the dtype is gathered from the example leaves.
+                    If there are more than one dtype, then no dtype
+                    casting is undertook.
 
         Returns:
             a new tensordict instance if the device differs from the tensordict
             device and/or if the dtype is passed. The same tensordict otherwise.
             ``batch_size`` only modifications are done in-place.
 
+        Examples:
+            >>> data = TensorDict({"a": 1.0}, [], device=None)
+            >>> data_cuda = data.to("cuda:0")  # casts to cuda
+            >>> data_int = data.to(torch.int)  # casts to int
+            >>> data_cuda_int = data.to("cuda:0", torch.int)  # multiple casting
+            >>> data_cuda = data.to(torch.randn(3, device="cuda:0"))  # using an example tensor
+            >>> data_cuda = data.to(other=TensorDict({}, [], device="cuda:0"))  # using a tensordict example
         """
         raise NotImplementedError
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2602,6 +2602,7 @@ class TensorDictBase(MutableMapping):
                 dtype and device for all parameters and buffers in this TensorDict
 
         Keyword Args:
+            non_blocking (bool, optional): whether the operations should be blocking.
             memory_format (torch.memory_format, optional): the desired memory
                 format for 4D parameters and buffers in this module.
             batch_size (torch.Size, optional): resulting batch-size of the
@@ -6928,6 +6929,9 @@ class LazyStackedTensorDict(TensorDictBase):
         return self
 
     def to(self, *args, **kwargs) -> T:
+        batch_size = kwargs.pop("batch_size", None)
+        if batch_size is not None:
+            raise TypeError("Cannot pass batch-size to a LazyStackedTensorDict.")
         return LazyStackedTensorDict(
             *[td.to(*args, **kwargs) for td in self.tensordicts],
             stack_dim=self.stack_dim,
@@ -8125,6 +8129,9 @@ class _CustomOpTensorDict(TensorDictBase):
         return self
 
     def to(self, *args, **kwargs) -> T:
+        batch_size = kwargs.pop("batch_size", None)
+        if batch_size is not None:
+            raise TypeError(f"Cannot pass batch-size to a {type(self)}.")
         td = self._source.to(*args, **kwargs)
         self_copy = copy(self)
         self_copy._source = td

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4530,8 +4530,9 @@ class TensorDict(TensorDictBase):
         return out
 
     def to(self, *args, **kwargs: Any) -> T:
-        batch_size = kwargs.pop("batch_size", None)
-        device, dtype, non_blocking, convert_to_format = _parse_to(*args, **kwargs)
+        device, dtype, non_blocking, convert_to_format, batch_size = _parse_to(
+            *args, **kwargs
+        )
         result = self
 
         if device is not None and dtype is None and device == self.device:
@@ -5708,7 +5709,9 @@ torch.Size([3, 2])
         return self
 
     def to(self, *args, **kwargs: Any) -> T:
-        device, dtype, non_blocking, convert_to_format = _parse_to(*args, **kwargs)
+        device, dtype, non_blocking, convert_to_format, batch_size = _parse_to(
+            *args, **kwargs
+        )
         result = self
 
         if device is not None and dtype is None and device == self.device:
@@ -6926,11 +6929,11 @@ class LazyStackedTensorDict(TensorDictBase):
         return self
 
     def to(self, *args, **kwargs) -> T:
-        batch_size = kwargs.pop("batch_size", None)
+        device, dtype, non_blocking, convert_to_format, batch_size = _parse_to(
+            *args, **kwargs
+        )
         if batch_size is not None:
             raise TypeError("Cannot pass batch-size to a LazyStackedTensorDict.")
-
-        device, dtype, non_blocking, convert_to_format = _parse_to(*args, **kwargs)
         result = self
 
         if device is not None and dtype is None and device == self.device:
@@ -8133,11 +8136,11 @@ class _CustomOpTensorDict(TensorDictBase):
         return self
 
     def to(self, *args, **kwargs) -> T:
-        batch_size = kwargs.pop("batch_size", None)
+        device, dtype, non_blocking, convert_to_format, batch_size = _parse_to(
+            *args, **kwargs
+        )
         if batch_size is not None:
             raise TypeError(f"Cannot pass batch-size to a {type(self)}.")
-
-        device, dtype, non_blocking, convert_to_format = _parse_to(*args, **kwargs)
         result = self
 
         if device is not None and dtype is None and device == self.device:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1261,6 +1261,7 @@ def _split_tensordict(td, chunksize, num_chunks, num_workers, dim):
 
 
 def _parse_to(*args, **kwargs):
+    batch_size = kwargs.pop("batch_size", None)
     other = kwargs.pop("other", None)
     device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(
         *args, **kwargs
@@ -1274,4 +1275,4 @@ def _parse_to(*args, **kwargs):
             dtype = None
         elif len(dtypes) == 1:
             dtype = dtypes[0]
-    return device, dtype, non_blocking, convert_to_format
+    return device, dtype, non_blocking, convert_to_format, batch_size

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1271,8 +1271,8 @@ def _parse_to(*args, **kwargs):
             raise ValueError("other and device cannot be both passed")
         device = other.device
         dtypes = {val.dtype for val in other.values(True, True)}
-        if len(dtypes) > 1 or len(dtype) == 0:
+        if len(dtypes) > 1 or len(dtypes) == 0:
             dtype = None
         elif len(dtypes) == 1:
-            dtype = dtypes[0]
+            dtype = list(dtypes)[0]
     return device, dtype, non_blocking, convert_to_format, batch_size

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1258,3 +1258,20 @@ def _split_tensordict(td, chunksize, num_chunks, num_workers, dim):
     else:
         chunksize = min(td.shape[dim], chunksize)
         return td.split(chunksize, dim=dim)
+
+
+def _parse_to(*args, **kwargs):
+    other = kwargs.pop("other", None)
+    device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(
+        *args, **kwargs
+    )
+    if other is not None:
+        if device is not None and device != other.device:
+            raise ValueError("other and device cannot be both passed")
+        device = other.device
+        dtypes = {val.dtype for val in other.values(True, True)}
+        if len(dtypes) > 1 or len(dtype) == 0:
+            dtype = None
+        elif len(dtypes) == 1:
+            dtype = dtypes[0]
+    return device, dtype, non_blocking, convert_to_format

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -15,7 +15,7 @@ from tensordict.tensordict import (
     is_tensor_collection,
     LazyStackedTensorDict,
 )
-import multiprocessing as mp
+
 
 def prod(sequence):
     if hasattr(math, "prod"):

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -15,7 +15,7 @@ from tensordict.tensordict import (
     is_tensor_collection,
     LazyStackedTensorDict,
 )
-
+import multiprocessing as mp
 
 def prod(sequence):
     if hasattr(math, "prod"):

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -200,6 +200,7 @@ def test_memmap_same_device_as_tensor(device):
     """
     t = torch.tensor([1], device=device)
     m = MemmapTensor.from_tensor(t)
+    assert t.device == torch.device(device)
     assert m.device == torch.device(device)
     for other_device in get_available_devices():
         if other_device != device:

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -12,7 +12,7 @@ import re
 from multiprocessing import Pool
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional, Union, Tuple
+from typing import Any, Optional, Tuple, Union
 
 import pytest
 import torch

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -12,7 +12,7 @@ import re
 from multiprocessing import Pool
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Tuple
 
 import pytest
 import torch
@@ -1676,7 +1676,7 @@ class TestNesting:
     @tensorclass
     class TensorClass:
         tens: torch.Tensor
-        order: tuple[str]
+        order: Tuple[str]
         test: str
 
     def get_nested(self):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1314,7 +1314,7 @@ class TestTensorDicts(TestTensorDictsBase):
         assert td_device.clone().device == device_cast
         if device_cast != td.device:
             assert td_device is not td
-        assert td_device.to(device_cast) == td_device
+        assert td_device.to(device_cast) is td_device
         assert td.to(device) is td
         assert_allclose_td(td, td_device.to(device))
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -688,11 +688,21 @@ class TestTensorDicts(TestTensorDictsBase):
         td_dtype_device = td.to(torch.device("cpu:1"), torch.int)
         assert all(t.dtype == torch.int for t in td_dtype_device.values(True, True))
         assert td_device.device == torch.device("cpu:1")
-        if td_name in ("stacked_td", "unsqueezed_td", "squeezed_td", "permute_td", "nested_stacked_td"):
+        if td_name in (
+            "stacked_td",
+            "unsqueezed_td",
+            "squeezed_td",
+            "permute_td",
+            "nested_stacked_td",
+        ):
             with pytest.raises(TypeError, match="Cannot pass batch-size to a "):
-                td_dtype_device = td.to(torch.device("cpu:1"), torch.int, batch_size=torch.Size([]))
+                td_dtype_device = td.to(
+                    torch.device("cpu:1"), torch.int, batch_size=torch.Size([])
+                )
         else:
-            td_dtype_device = td.to(torch.device("cpu:1"), torch.int, batch_size=torch.Size([]))
+            td_dtype_device = td.to(
+                torch.device("cpu:1"), torch.int, batch_size=torch.Size([])
+            )
             assert all(t.dtype == torch.int for t in td_dtype_device.values(True, True))
             assert td_device.device == torch.device("cpu:1")
             assert td_dtype_device.batch_size == torch.Size([])
@@ -1304,7 +1314,7 @@ class TestTensorDicts(TestTensorDictsBase):
         assert td_device.clone().device == device_cast
         if device_cast != td.device:
             assert td_device is not td
-        assert td_device.to(device_cast) is td_device
+        assert td_device.to(device_cast) == td_device
         assert td.to(device) is td
         assert_allclose_td(td, td_device.to(device))
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -713,9 +713,10 @@ class TestTensorDicts(TestTensorDictsBase):
         # example td, many dtypes
         td_nodtype_device = td.to(
             other=TensorDict(
-                {"a": torch.randn(3, dtype=torch.half, device="cpu:1"),
-                 "b": torch.randint(10, ())
-                 },
+                {
+                    "a": torch.randn(3, dtype=torch.half, device="cpu:1"),
+                    "b": torch.randint(10, ()),
+                },
                 [],
                 device="cpu:1",
             )


### PR DESCRIPTION
## Description

Refactors the `TensorDict.to` to match more closely `torch.Tensor` and `torch.nn.Module`

This is bc-breaking as previously a single `dest` argument was accepted. Keyword arguments can now be used to map `device`, `dtype`, change the `batch_size`. An example `tensor` / tensordict (`other=...`) can be used to retrieve device and dtype.
